### PR TITLE
fix: add marketplace manifest so the plugin can be installed

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,33 @@
+{
+  "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
+  "name": "tinyloop",
+  "owner": {
+    "name": "Tinyloop",
+    "email": "tinyhat@tinyloop.co"
+  },
+  "metadata": {
+    "description": "Tinyloop's Claude Code plugin marketplace. Currently hosts Tinyhat; future Tinyloop-branded plugins will land here too."
+  },
+  "plugins": [
+    {
+      "name": "tinyhat",
+      "source": "./",
+      "description": "Local, read-only skill-lifecycle observability for Claude Code. Produces an agent-authored report about which skills you actually use, which look dormant, and what to create next.",
+      "homepage": "https://github.com/tinyhat-ai/tinyhat",
+      "repository": "https://github.com/tinyhat-ai/tinyhat",
+      "license": "MIT",
+      "category": "observability",
+      "keywords": [
+        "skills",
+        "observability",
+        "lifecycle",
+        "local",
+        "read-only"
+      ],
+      "author": {
+        "name": "Tinyloop",
+        "email": "tinyhat@tinyloop.co"
+      }
+    }
+  ]
+}

--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -108,14 +108,18 @@ If any step shows an error, jump to **Rollback** below.
 In a clean Claude Code session:
 
 ```text
-/plugin install tinyhat-ai/tinyhat
+/plugin marketplace update tinyloop
+/plugin install tinyhat@tinyloop
 /reload-plugins
 /tinyhat:audit
 ```
 
+If the marketplace isn't already added (first smoke test on a new
+machine), add it first: `/plugin marketplace add tinyhat-ai/tinyhat`.
+
 Watch for:
 
-- The three skills (`audit`, `open`, `history`) plus `routine`
+- The four skills (`audit`, `open`, `history`, `routine`)
   register under the `tinyhat:` namespace.
 - `gather_snapshot.py` and `render_report.py` run without import
   errors.

--- a/README.md
+++ b/README.md
@@ -17,12 +17,15 @@ I keep coming back to the way humans swap roles: *"put on your marketing hat."* 
 
 ## Install
 
-Inside Claude Code:
+Inside Claude Code, add the Tinyloop marketplace and install the plugin from it:
 
 ```text
-/plugin install tinyhat-ai/tinyhat
+/plugin marketplace add tinyhat-ai/tinyhat
+/plugin install tinyhat@tinyloop
 /reload-plugins
 ```
+
+The first line registers Tinyloop's marketplace (this repo doubles as its own marketplace). The second installs the `tinyhat` plugin from it. After this, `/plugin marketplace update tinyloop` pulls newer versions.
 
 Requires Python 3.9+ on your `PATH` (pre-installed on macOS and most Linux).
 

--- a/docs/user-flows.md
+++ b/docs/user-flows.md
@@ -7,19 +7,21 @@ Exactly how to use Tinyhat once the plugin is installed. Each flow below covers 
 Inside any Claude Code session:
 
 ```text
-/plugin install tinyhat-ai/tinyhat
+/plugin marketplace add tinyhat-ai/tinyhat
+/plugin install tinyhat@tinyloop
 /reload-plugins
 ```
 
-That's it. Three skills are now available under the `tinyhat:` namespace:
+The first command registers the Tinyloop marketplace (this repo). The second installs the `tinyhat` plugin from it. After install, four skills register under the `tinyhat:` namespace:
 
 | Slash command | What it does | Regenerates? |
 |---|---|:---:|
 | `/tinyhat:audit` | Scan → agent writes analysis → render report → open HTML | ✓ |
 | `/tinyhat:open` | Open the latest existing report in your browser | — |
 | `/tinyhat:history` | Open the archive index listing every report on disk | — |
+| `/tinyhat:routine` | Manage the daily auto-run (status/on/off/where/clear) | — |
 
-After install, the three flows below are what you'll actually do day-to-day.
+After install, the flows below are what you'll actually do day-to-day.
 
 ---
 


### PR DESCRIPTION
## Summary

Closes #11. Adds \`.claude-plugin/marketplace.json\` so the repo doubles as its own single-plugin marketplace, plus updates every doc + skill that used to point at the broken \`/plugin install tinyhat-ai/tinyhat\` form.

Before this PR:

\`\`\`text
> /plugin install tinyhat-ai/tinyhat
  ⎿  Marketplace "tinyhat-ai/tinyhat" not found
\`\`\`

After:

\`\`\`text
> /plugin marketplace add tinyhat-ai/tinyhat
> /plugin install tinyhat@tinyloop
\`\`\`

Per the [official marketplace docs](https://code.claude.com/docs/en/plugin-marketplaces), Claude Code plugins install *from* marketplaces — which are git repos with a \`.claude-plugin/marketplace.json\` listing available plugins. For a single-plugin repo like ours, the canonical pattern is to make the repo its own marketplace with \`"source": "./"\` pointing at the repo root. That's what this PR does.

## Linked issue

Closes #11.

## Type of change

- [x] \`fix\` — plugin was unreachable via the install flow; this makes it reachable

## Changes

- **\`.claude-plugin/marketplace.json\`** (new) — marketplace name \`tinyloop\`, owner Tinyloop, single plugin entry for \`tinyhat\` with \`"source": "./"\`, full metadata (description, homepage, repository, license, keywords, author, category). Room for future Tinyloop-branded plugins to land in the same catalog.
- **README.md** — Install section updated to the two-step flow.
- **docs/user-flows.md** — Install flow updated, and adds the missing \`/tinyhat:routine\` row to the skills table.
- **.claude/skills/release/SKILL.md** — smoke-test step now uses \`/plugin marketplace update tinyloop\` + \`/plugin install tinyhat@tinyloop\`.

## Testing performed

- [x] \`python3 -c "import json; json.load(open('.claude-plugin/marketplace.json'))"\` — valid JSON.
- [x] Field names match the schema in the official docs verbatim: \`name\`, \`owner.{name,email}\`, \`metadata.description\`, \`plugins[].{name,source,description,...}\`.
- [x] \`source: "./"\` starts with \`./\` as required for relative-path plugin sources.
- [x] Marketplace name \`tinyloop\` is not on the [reserved-names list](https://code.claude.com/docs/en/plugin-marketplaces#marketplace-schema).
- [x] \`ruff check .\` passes (no Python changed, belt-and-braces).
- [ ] Live install from a fresh Claude Code session — deferred until this merges and the commit is on \`main\`. That's the real acceptance test; I'll report back.
- [ ] CI matrix will run on this PR.

## Checklist

- [x] PR title is a Conventional Commit
- [x] Linked to the issue (\`Closes #11\`)
- [x] Docs updated where behavior changed
- [x] No references to private maintainer resources
- [x] I will not self-merge

## All commits final

No more pushes to this branch after review. If something needs to change, comment instead and I'll open a follow-up.