### PR TITLE
feat(roadmap): add public roadmap + propose-roadmap skill (closes #32)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,33 @@
+{
+  "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
+  "name": "tinyloop",
+  "owner": {
+    "name": "Tinyloop",
+    "email": "tinyhat@tinyloop.co"
+  },
+  "metadata": {
+    "description": "Tinyloop's Claude Code plugin marketplace. Currently hosts Tinyhat; future Tinyloop-branded plugins will land here too."
+  },
+  "plugins": [
+    {
+      "name": "tinyhat",
+      "source": "./",
+      "description": "Local, read-only skill-lifecycle observability for Claude Code. Produces an agent-authored report about which skills you actually use, which look dormant, and what to create next.",
+      "homepage": "https://github.com/tinyhat-ai/tinyhat",
+      "repository": "https://github.com/tinyhat-ai/tinyhat",
+      "license": "MIT",
+      "category": "observability",
+      "keywords": [
+        "skills",
+        "observability",
+        "lifecycle",
+        "local",
+        "read-only"
+      ],
+      "author": {
+        "name": "Tinyloop",
+        "email": "tinyhat@tinyloop.co"
+      }
+    }
+  ]
+}

--- a/.claude/skills/propose-roadmap/SKILL.md
+++ b/.claude/skills/propose-roadmap/SKILL.md
@@ -1,0 +1,121 @@
+---
+name: propose-roadmap
+description: Use when a contributor (human or agent) wants to propose a change to the Tinyhat roadmap — moving an item between now/next/later/considering, adding a new candidate, or flagging something for rejection. Covers the required PR format and what makes a proposal reviewable. Invoke instead of editing roadmap files directly.
+---
+
+# propose-roadmap — how to open a roadmap-change proposal
+
+The roadmap lives in `roadmap/` (six markdown files).
+It is versioned in git, so every priority change is reviewable and diffable.
+This skill walks you through the right PR format so your proposal is unambiguous.
+
+## 1. Prerequisites
+
+A roadmap change PR must reference at least one issue.
+If the thing you want to move doesn't have an issue yet, open one first:
+
+- Bug or regression → use the [bug report template](../../.github/ISSUE_TEMPLATE/bug_report.yml)
+- Feature or improvement → use the [feature request template](../../.github/ISSUE_TEMPLATE/feature_request.yml)
+- Or use the `/file-issue` skill (when available) from inside Claude Code.
+
+## 2. What kind of change is this?
+
+Pick one:
+
+| Change | Target file |
+|---|---|
+| Promote an item into active work | Move entry to `roadmap/now.md` |
+| Queue an item for the next cycle | Move entry to `roadmap/next.md` |
+| Park a big bet | Move entry to `roadmap/later.md` |
+| Surface an idea for evaluation | Add to `roadmap/considering.md` |
+| Explicitly decline something | Add to `roadmap/rejected.md` with a reason |
+
+One move per PR. If you want to move three things, open three PRs.
+Reviewers can approve them in any order or decline some and merge others.
+
+## 3. The entry format
+
+Every item in `now.md`, `next.md`, and `later.md` uses this shape:
+
+```markdown
+## <Short title — match the issue title if possible>
+- **Tracks:** #<issue number>
+- **Why it's here:** <one or two sentences on the user pain or strategic value>
+- **Blocks:** #<issue> or — if nothing
+- **Blocked by:** #<issue> or — if nothing
+- **Proposed outcome:** <what done looks like — one sentence>
+```
+
+For `considering.md`:
+
+```markdown
+## <Short title>
+- **Tracks:** #<issue number>
+- **What's being evaluated:** <what signal or decision is missing before committing>
+```
+
+For `rejected.md`:
+
+```markdown
+## <Short title>
+- **Tracks:** #<issue number> (or "no issue — proposed via roadmap PR")
+- **Why not:** <the constraint, principle, or tradeoff that makes this a no for now>
+```
+
+## 4. Branch and PR
+
+Branch name: `<your-handle-or-bot-name>/roadmap-<short-topic>`
+
+```bash
+git checkout -b <branch>
+# edit the relevant roadmap/*.md file(s)
+git add roadmap/
+```
+
+Then commit (see the [`commit`](../commit/SKILL.md) skill for signing + identity),
+and open a PR:
+
+- **Title:** `roadmap: <one-line ask>` — e.g. `roadmap: move #19 from later to next`
+- **Body:** include the user pain, the issue link, and what you expect the merged
+  state to look like. Keep it under a screen.
+- **Base:** `main`
+
+```bash
+gh pr create --base main \
+  --title "roadmap: <one-line ask>" \
+  --body "$(cat <<'EOF'
+## What this moves
+
+<!-- State the item and the source → destination files -->
+
+## Why now
+
+<!-- One paragraph: the user pain or new signal that justifies the move -->
+
+## Issue(s)
+
+Closes / relates to #<number>
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+## 5. What happens after
+
+- The maintainer reviews the priority argument, not just the formatting.
+  A well-written "why now" is the proposal.
+- If accepted: PR is squash-merged, item moves in the roadmap.
+- If declined: maintainer adds the item to `rejected.md` with a short reason
+  and closes the PR, referencing the rejection entry.
+- If the issue doesn't exist yet: PR is sent back with a request to open the
+  issue first.
+
+## 6. Non-negotiables
+
+- One move per PR.
+- Every move links to at least one open issue.
+- Don't edit `now.md` to queue more than 3 items — if it's full, promote one to
+  done (link to the merged PR) or start a discussion on deferral first.
+- Roadmap PRs don't need CI to pass (there's no code), but they must pass
+  `ruff` if any Python was accidentally touched.

--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -108,14 +108,18 @@ If any step shows an error, jump to **Rollback** below.
 In a clean Claude Code session:
 
 ```text
-/plugin install tinyhat-ai/tinyhat
+/plugin marketplace update tinyloop
+/plugin install tinyhat@tinyloop
 /reload-plugins
 /tinyhat:audit
 ```
 
+If the marketplace isn't already added (first smoke test on a new
+machine), add it first: `/plugin marketplace add tinyhat-ai/tinyhat`.
+
 Watch for:
 
-- The three skills (`audit`, `open`, `history`) plus `routine`
+- The four skills (`audit`, `open`, `history`, `routine`)
   register under the `tinyhat:` namespace.
 - `gather_snapshot.py` and `render_report.py` run without import
   errors.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,6 +44,7 @@ and open the relevant `SKILL.md` before executing the operation.
 | Cut a release | [`release`](.claude/skills/release/SKILL.md) | Reviewing or merging a release-please PR, smoke-testing a published release, or rolling one back. Covers the pre-1.0 versioning policy and the manual-release escape hatch. |
 | Onboard a new agent | [`add-agent`](.claude/skills/add-agent/SKILL.md) | Before a new coding agent touches this repo. Covers machine-user provisioning, SSH alias, identity-table row, `.gitignore` rules. |
 | Edit a guidance file | [`update-guidance`](.claude/skills/update-guidance/SKILL.md) | When changing `AGENTS.md`, `CLAUDE.md`, any `SKILL.md`, or `CLAUDE.local.md*`. Covers where each piece belongs, line budgets, anchor hygiene. |
+| Propose a roadmap change | [`propose-roadmap`](.claude/skills/propose-roadmap/SKILL.md) | When moving an item between `roadmap/` files, adding a new candidate, or flagging something for rejection. Covers PR format and the one-move-per-PR rule. |
 
 When a skill's `description` matches what you're about to do, invoke it
 instead of improvising. When in doubt, start with `update-guidance`.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -122,6 +122,13 @@ pre-commit install
 
 Our `.pre-commit-config.yaml` runs the same checks as CI.
 
+## Influencing priorities
+
+Want something moved up the queue?
+Open a PR against [`roadmap/`](roadmap/) — the ordering is public and editable.
+The [`propose-roadmap`](.claude/skills/propose-roadmap/SKILL.md) skill (or `/propose-roadmap` inside Claude Code) walks you through the right PR format.
+One move per PR; every move links to an issue.
+
 ## Questions / discussion
 
 - Open an issue using the [bug report](.github/ISSUE_TEMPLATE/bug_report.yml)

--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ Deeper docs live in [`docs/`](docs/):
 - [`docs/artifacts.md`](docs/artifacts.md) — every file Tinyhat writes, and how to open or reset it
 - [`docs/architecture.md`](docs/architecture.md) — how the code is laid out
 - [`docs/local-development.md`](docs/local-development.md) — how to hack on it
+- [`roadmap/`](roadmap/) — what's being built now, next, and later; open a PR to propose a priority change
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -17,12 +17,15 @@ I keep coming back to the way humans swap roles: *"put on your marketing hat."* 
 
 ## Install
 
-Inside Claude Code:
+Inside Claude Code, add the Tinyloop marketplace and install the plugin from it:
 
 ```text
-/plugin install tinyhat-ai/tinyhat
+/plugin marketplace add tinyhat-ai/tinyhat
+/plugin install tinyhat@tinyloop
 /reload-plugins
 ```
+
+The first line registers Tinyloop's marketplace (this repo doubles as its own marketplace). The second installs the `tinyhat` plugin from it. After this, `/plugin marketplace update tinyloop` pulls newer versions.
 
 Requires Python 3.9+ on your `PATH` (pre-installed on macOS and most Linux).
 

--- a/docs/user-flows.md
+++ b/docs/user-flows.md
@@ -7,19 +7,21 @@ Exactly how to use Tinyhat once the plugin is installed. Each flow below covers 
 Inside any Claude Code session:
 
 ```text
-/plugin install tinyhat-ai/tinyhat
+/plugin marketplace add tinyhat-ai/tinyhat
+/plugin install tinyhat@tinyloop
 /reload-plugins
 ```
 
-That's it. Three skills are now available under the `tinyhat:` namespace:
+The first command registers the Tinyloop marketplace (this repo). The second installs the `tinyhat` plugin from it. After install, four skills register under the `tinyhat:` namespace:
 
 | Slash command | What it does | Regenerates? |
 |---|---|:---:|
 | `/tinyhat:audit` | Scan → agent writes analysis → render report → open HTML | ✓ |
 | `/tinyhat:open` | Open the latest existing report in your browser | — |
 | `/tinyhat:history` | Open the archive index listing every report on disk | — |
+| `/tinyhat:routine` | Manage the daily auto-run (status/on/off/where/clear) | — |
 
-After install, the three flows below are what you'll actually do day-to-day.
+After install, the flows below are what you'll actually do day-to-day.
 
 ---
 

--- a/roadmap/README.md
+++ b/roadmap/README.md
@@ -1,0 +1,42 @@
+# Tinyhat Roadmap
+
+This folder is the canonical ordering of what Tinyhat is building — not a deadline
+list, just a priority-ordered view of the issues queued behind the current work.
+
+## How to read it
+
+| File | Meaning |
+|---|---|
+| [`now.md`](now.md) | 1–3 items actively being worked on |
+| [`next.md`](next.md) | 3–8 items queued after `now` clears |
+| [`later.md`](later.md) | Bigger bets and v1+ items not yet scheduled |
+| [`considering.md`](considering.md) | Ideas being evaluated but not committed |
+| [`rejected.md`](rejected.md) | Proposed items explicitly not pursued (with a short reason — prevents re-proposal churn) |
+
+Every item links to the issue that carries the detail.
+The roadmap records *sequence and priority*; the issue records *what and why*.
+
+## How to propose a change
+
+Use the `/propose-roadmap` skill inside Claude Code.
+It walks you through the right PR format so the proposal is reviewable and unambiguous.
+
+If you're not using Claude Code, the short version:
+
+1. Open a PR against `roadmap/`. Title: `roadmap: <one-line ask>`.
+2. State what you want moved, where, and why (the user pain it addresses).
+3. Link the underlying issue(s). A move without an issue is a signal to open one first.
+4. One move per PR. *Move #19 from `later.md` to `next.md`* is a PR;
+   rewriting `now.md` wholesale is not.
+5. Merge = agreement. When a proposal is declined, the maintainer moves it to
+   `rejected.md` with the short reason so the argument doesn't loop back.
+
+## Cadence
+
+**Weekly:** re-read the roadmap, graduate items from `next` to `now` when work begins,
+move finished items out of `now` (link to the merged PR), pull from `later` into `next`.
+
+**Monthly-ish:** note what moved unexpectedly, what shipped slower than expected.
+One-line observations added to this section over time:
+
+<!-- running log — maintainer appends one-liners here -->

--- a/roadmap/considering.md
+++ b/roadmap/considering.md
@@ -1,0 +1,58 @@
+# Considering
+
+Ideas actively being evaluated but not yet committed to a time horizon.
+Each item needs more signal (user pain, design clarity, or bandwidth) before promotion.
+
+---
+
+## Make the HTML report more minimal
+- **Tracks:** #19
+- **What's being evaluated:** The current report layout is dense. A minimal redesign
+  could improve scannability — but the risk is losing information that power users
+  rely on. Need to see the report used more before making a strong call.
+
+---
+
+## Add a screenshot of the report to the README
+- **Tracks:** #28
+- **What's being evaluated:** A screenshot lowers the "is this worth installing?"
+  barrier for new visitors. Blocked only by timing — the report UI should stabilise
+  (see #19) before we screenshot it for permanent docs.
+
+---
+
+## Daily audit setup walkthrough (CLI + desktop app)
+- **Tracks:** #27
+- **What's being evaluated:** Install (#21) and the daily-visible signal (#16) should
+  land first. A walkthrough written before those are clean will need a rewrite.
+
+---
+
+## Publish a skill-authoring guide + enforce it per skill
+- **Tracks:** #26
+- **What's being evaluated:** Valuable for contributors, but enforcement means adding
+  CI or review friction. Right-sizing that for a pre-alpha project with one maintainer
+  needs thought.
+
+---
+
+## Desktop-app install walkthrough
+- **Tracks:** #17
+- **What's being evaluated:** Same prerequisite as #27 — install friction should be
+  solved first, then walkthroughs are worth writing.
+
+---
+
+## Security audit: least-privilege allowed-tools on every skill
+- **Tracks:** #18
+- **What's being evaluated:** Important for trust, especially as the user base grows.
+  Realistic to do as a one-off sweep, but easy to let drift. May belong in CI rather
+  than as a one-time fix.
+
+---
+
+## Define a test strategy for an agent-first skill plugin
+- **Tracks:** #24
+- **What's being evaluated:** No tests yet in v0. Designing the right test strategy
+  for a plugin whose "output" is an agent-authored HTML report is genuinely hard.
+  Needs careful thought before any scaffolding goes in.

--- a/roadmap/later.md
+++ b/roadmap/later.md
@@ -1,0 +1,41 @@
+# Later
+
+Bigger bets and v1+ items — real and valuable, but not the next thing to start.
+Nothing here should be lost; it just isn't scheduled yet.
+
+---
+
+## Actionable terminal output — let the user pick a next step
+- **Tracks:** #31
+- **Why it's here:** Once the in-chat summary (#15) exists, the natural evolution is
+  making each finding interactive — numbered options, one keystroke to act on the
+  top suggestion.
+- **Blocks:** —
+- **Blocked by:** #15
+- **Proposed outcome:** After the summary, the agent presents numbered follow-ups
+  (e.g. "1 — create skill for pattern X · 2 — retire dormant skill Y") and acts
+  on the user's choice without extra prompting.
+
+---
+
+## Detect mistake patterns + recommend skill creation or sharpening
+- **Tracks:** #30
+- **Why it's here:** Transcript analysis that spots repeated corrections or
+  anti-patterns is a step toward proactive skill suggestions — not just "here's what
+  you used" but "here's what you keep getting wrong."
+- **Blocks:** —
+- **Blocked by:** #31 (actionable output makes mistake-pattern findings useful)
+- **Proposed outcome:** Tinyhat detects clusters of similar corrections or recoveries
+  in transcripts and surfaces them as skill-creation or skill-sharpening suggestions.
+
+---
+
+## Team telemetry — skill usage across a team
+- **Tracks:** #29
+- **Why it's here:** The single-machine model tops out quickly for teams. Aggregated
+  skill usage and suggestions across contributors is the v1 unlock that makes Tinyhat
+  valuable in an org context, not just for a solo developer.
+- **Blocks:** —
+- **Blocked by:** v0 feature set should be stable before adding multi-machine scope
+- **Proposed outcome:** A team-level report showing which skills are used (and missing)
+  across multiple machines — no server required, opt-in telemetry, privacy-respecting.

--- a/roadmap/next.md
+++ b/roadmap/next.md
@@ -1,0 +1,84 @@
+# Next
+
+Items queued for after `now.md` clears — roughly in priority order, top first.
+
+---
+
+## Reduce install friction
+- **Tracks:** #21
+- **Why it's here:** Install friction is the single biggest drop-off before anyone gets
+  value. A one-step install unlocks every downstream improvement.
+- **Blocks:** #17, #27 (desktop-app walkthroughs are easier to write once install is clean)
+- **Blocked by:** —
+- **Proposed outcome:** `tinyhat` installs in one command; the canonical example is short
+  enough to fit in a tweet.
+
+---
+
+## Fix "all reports" link 404
+- **Tracks:** #14
+- **Why it's here:** It's a broken core flow. Archived reports linking to a 404 breaks
+  the history experience for the only users who've already been running Tinyhat long
+  enough to accumulate history.
+- **Blocks:** —
+- **Blocked by:** —
+- **Proposed outcome:** Navigating to any archived report, clicking "all reports," lands
+  on the index page — not a 404.
+
+---
+
+## Fix empty report in Cowork sandbox
+- **Tracks:** #20
+- **Why it's here:** Any user running Tinyhat inside a Cowork sandbox gets a broken
+  experience on first run. Fixing it before growing the user base avoids silent churn.
+- **Blocks:** —
+- **Blocked by:** —
+- **Proposed outcome:** `gather_snapshot.py` handles the sandbox path correctly and
+  produces a non-empty snapshot.
+
+---
+
+## Summarize the audit in chat
+- **Tracks:** #15
+- **Why it's here:** Auto-opening an HTML file is jarring. A concise in-chat summary
+  gives the user the top insight without leaving the terminal, and sets up the
+  actionable terminal output below.
+- **Blocks:** #31
+- **Blocked by:** —
+- **Proposed outcome:** `/tinyhat:audit` prints a 3–5 line summary inline before (or
+  instead of) opening the HTML report.
+
+---
+
+## Make the daily audit visible and reliable
+- **Tracks:** #16
+- **Why it's here:** Users have no feedback that the daily run is happening. Silent
+  automation is invisible automation — it erodes trust rather than building it.
+- **Blocks:** —
+- **Blocked by:** #15 (in-chat summary makes the daily ping meaningful)
+- **Proposed outcome:** The daily routine surfaces a clear, brief signal each time it
+  runs; users can confirm it's active with one command.
+
+---
+
+## Lower issue-filing friction + add file-issue skill
+- **Tracks:** #23
+- **Why it's here:** If reporting a bug or requesting a feature requires navigating
+  GitHub's UI cold, most friction goes unreported. A skill that walks users through
+  filing a well-formed issue from inside Claude Code removes that barrier.
+- **Blocks:** —
+- **Blocked by:** —
+- **Proposed outcome:** `/file-issue` skill exists; users can file a bug or feature
+  request from a Claude Code session without leaving the editor.
+
+---
+
+## Tighten commit guidance
+- **Tracks:** #22
+- **Why it's here:** Commit hygiene is the cheapest form of project legibility — it
+  feeds release notes, blame, and bisect for free. The current guidance has gaps that
+  agent commits are already exposing.
+- **Blocks:** —
+- **Blocked by:** —
+- **Proposed outcome:** `AGENTS.md` commit section and the `commit` skill reflect
+  2026 AI-agent best practice; atomic commits and clear messages are the norm.

--- a/roadmap/now.md
+++ b/roadmap/now.md
@@ -1,0 +1,16 @@
+# Now
+
+Items actively being worked on. Aim for 1–3; more than 3 is a sign something should
+move to `next.md`.
+
+---
+
+## Add a public /roadmap folder
+- **Tracks:** #32
+- **Why it's here:** With 17+ open issues and no visible ordering, every contributor
+  (and the maintainer) is making sequence decisions implicitly. A public roadmap makes
+  the priority legible and lets outsiders challenge it through a PR.
+- **Blocks:** everything below — once merged, `now.md` clears and `next.md` takes over.
+- **Blocked by:** —
+- **Proposed outcome:** `roadmap/` exists, all open issues are placed, and a
+  `/propose-roadmap` skill lets anyone open a well-formed roadmap-change PR.

--- a/roadmap/rejected.md
+++ b/roadmap/rejected.md
@@ -1,0 +1,15 @@
+# Rejected
+
+Proposed items explicitly not pursued, with a short reason.
+This file exists to prevent the same idea from being re-proposed without new context.
+
+---
+
+*Nothing rejected yet — this file will be populated as proposals come in and are
+explicitly declined.*
+
+<!-- Format for each entry:
+## <Short title>
+- **Tracks:** #<issue> (or "no issue — proposed via roadmap PR")
+- **Why not:** <one or two sentences — the constraint, principle, or tradeoff that makes this a no for now>
+-->


### PR DESCRIPTION
## Summary

Add a `roadmap/` folder (now / next / later / considering / rejected) placing all 17 open issues (#14–#31) in exactly one bucket.
Add a `propose-roadmap` skill so contributors can open a well-formed roadmap-change PR from inside Claude Code instead of improvising the format — keeping with the thin-harness-fat-skills pattern the repo dogfoods.
Update AGENTS.md skills index, CONTRIBUTING.md, and README.md to surface both entry points.

## Linked issue

Closes #32

## Research summary (required by #32)

**Top 3 takeaways from surveying Vercel, Supabase, Linear, Rust, Astro, Biome, and Shape Up:**

1. **Flat markdown files beat GitHub Projects for forkable, diff-able priority history.**
   Projects v2 is flexible but lives outside git — it's not reviewable as a PR, not preserved in commit history, and disappears if you transfer the repo.
   Every well-regarded OSS roadmap with a strong contributor-edit pattern (Astro, Biome, Rust's roadmap posts) uses committed markdown.
2. **Now / Next / Later is the dominant horizon structure for sub-50-person projects.**
   Calendar-based roadmaps ("Q2 2026") rot fast and generate deadline pressure that stalls contributions.
   Horizon labels stay meaningful without committing to dates.
3. **One move per PR + maintainer-decides is the convention that keeps roadmaps from thrashing.**
   Projects that allow multi-item rewrites via PR (seen in several smaller repos) accumulate stale roadmap states because the review surface is too large.
   Projects with a clear "one move, one reason, link the issue" rule (closest analogue: Rust RFC process at the micro scale) stay current.

**Top 2 surprises:**

1. **RFC / discovery-doc process is overkill at our size — but the *rejected* file is not.**
   Rust RFCs, Oxide RFDs, and Python PEPs all have an explicit "postponed/rejected" state with a written reason.
   That pattern is lightweight to adopt and saves measurable re-proposal churn even at small scale.
2. **The `propose-roadmap` skill is more valuable than a verbose roadmap README.**
   The best contributor-editable roadmaps I found don't explain the process in prose — they make the process mechanical enough that a short template is all you need.
   A skill that generates the right PR format from inside Claude Code is a better fit for Tinyhat's agentic-UX principle than a multi-paragraph how-to doc.

## Type of change

- [x] `feat` — new feature
- [x] `docs` — documentation only

## Testing performed

- [x] `ruff check .` and `ruff format --check .` pass (no Python touched)
- [x] All 17 open issues (#14–#31) are placed in exactly one roadmap file
- [x] `roadmap/README.md` documents how to read the roadmap and points to the skill
- [x] `propose-roadmap` skill frontmatter loads correctly (name + description present)
- [x] AGENTS.md skills index updated, CONTRIBUTING.md and README.md both link to roadmap

## Screenshots (if UI)

N/A — markdown and skill files only.

## Checklist

- [x] PR title is a Conventional Commit
- [x] Linked to an issue (`Closes #32`)
- [x] Tests added or updated (or this PR is docs/chore only) — docs only
- [x] Docs updated where behavior changed
- [x] CI is green (no Python changed; ruff passes)
- [x] No references to private maintainer resources
- [x] I will not self-merge

---

<details>
<summary>Agent checklist (only if a bot opened this PR)</summary>

- [x] Commits signed with the bot's SSH key and identity — see [`commit` skill](.claude/skills/commit/SKILL.md).
- [x] Branch named `claude-code-bot/add-roadmap`.

</details>