### PR TITLE
feat(audit): chat summary + persisted JSONs instead of auto-opening HTML

### DIFF
--- a/docs/artifacts.md
+++ b/docs/artifacts.md
@@ -9,12 +9,15 @@ Tinyhat is local-only and read-only against Claude's data. It writes files to **
 | `~/.claude/tinyhat/routine.json` | Adaptive-daily on/off + install timestamp | On first run; overwritten on `/tinyhat:audit routine on|off` |
 | `~/.claude/tinyhat/latest/report.html` | Latest report, self-contained HTML | Every `/tinyhat:audit` run |
 | `~/.claude/tinyhat/latest/report.md` | Latest report, markdown mirror | Every `/tinyhat:audit` run |
+| `~/.claude/tinyhat/latest/snapshot.json` | Durable data snapshot — the facts | Every `/tinyhat:audit` run |
+| `~/.claude/tinyhat/latest/analysis.json` | Durable agent analysis — the editorial layer | Every `/tinyhat:audit` run |
 | `~/.claude/tinyhat/latest/run-stamp.txt` | ISO local-date of last successful run | Every `/tinyhat:audit` run |
 | `~/.claude/tinyhat/archive/YYYY-MM-DD/report.{html,md}` | Dated snapshot | When `--archive` is passed or the adaptive daily fires |
+| `~/.claude/tinyhat/archive/YYYY-MM-DD/{snapshot,analysis}.json` | Dated JSONs alongside the HTML/MD | When `--archive` is passed or the adaptive daily fires |
 | `~/.claude/tinyhat/archive/index.html` | Browseable index of latest + all archives | Every render call |
 | `~/.claude/tinyhat/feedback.jsonl` | Optional local feedback log (reserved) | Never in v0 (feedback goes via `mailto:`) |
-| `<tempdir>/tinyhat-snapshot.json` | Transient data snapshot | Every `gather_snapshot.py` call |
-| `<tempdir>/tinyhat-analysis.json` | Transient agent-authored analysis | Every `/tinyhat:audit` run |
+| `<tempdir>/tinyhat-snapshot.json` | Transient mirror of latest/snapshot.json (pipeline hand-off) | Every `gather_snapshot.py` call |
+| `<tempdir>/tinyhat-analysis.json` | Transient mirror of latest/analysis.json (pipeline hand-off) | Every `/tinyhat:audit` run |
 
 `<tempdir>` is whatever `python3 -c 'import tempfile; print(tempfile.gettempdir())'` returns on your OS:
 - macOS: `/var/folders/.../T/`
@@ -29,12 +32,16 @@ Tinyhat is local-only and read-only against Claude's data. It writes files to **
 ├── latest/
 │   ├── report.html         ← open this to see the most recent report
 │   ├── report.md
+│   ├── snapshot.json       ← the facts the report was built from
+│   ├── analysis.json       ← the agent's editorial layer
 │   └── run-stamp.txt       ← one line: YYYY-MM-DD of the last run
 └── archive/
     ├── index.html          ← open this to browse all reports
     ├── 2026-04-23/
     │   ├── report.html
-    │   └── report.md
+    │   ├── report.md
+    │   ├── snapshot.json
+    │   └── analysis.json
     ├── 2026-04-22/
     │   └── ...
     └── ...                 (up to 31 dated dirs; older pruned automatically)
@@ -83,22 +90,25 @@ cat ~/.claude/tinyhat/latest/run-stamp.txt
 
 Or inside Claude Code: `/tinyhat:audit routine status`.
 
-### The raw snapshot JSON (for debugging attribution)
+### The durable snapshot JSON (the facts)
 
 ```bash
-python3 -c 'import tempfile, pathlib; p = pathlib.Path(tempfile.gettempdir()) / "tinyhat-snapshot.json"; print(p)'
-# copy that path and open it
+cat ~/.claude/tinyhat/latest/snapshot.json
 ```
 
 Top-level keys: `meta`, `stats`, `inventory`, `top_skills`, `skill_counts`, `last_seen`, `sessions`, `events`, `events_audit`, `tool_totals`, `aggregate_tools`, `daily_rollups`, `dormant_by_origin`, `installed_by_origin`, `surface_rollups`, `coverage`. See [development.md](local-development.md) for the shape.
 
-### The agent-authored analysis JSON (for debugging framing)
+The transient mirror at `<tempdir>/tinyhat-snapshot.json` is the same data — it's the hand-off between `gather_snapshot.py` and `render_report.py`. The copy under `latest/` is the one you (or Claude, on a follow-up turn) should read.
+
+### The agent-authored analysis JSON (the editorial layer)
 
 ```bash
-python3 -c 'import tempfile, pathlib; p = pathlib.Path(tempfile.gettempdir()) / "tinyhat-analysis.json"; print(p)'
+cat ~/.claude/tinyhat/latest/analysis.json
 ```
 
 Shape: `headline`, `headline_sub`, `what_stands_out[]`, `dormant_commentary`, `skill_recommendations[]`, `coverage_note`. Schema details in [`skills/audit/references/writing-the-analysis.md`](../skills/audit/references/writing-the-analysis.md).
+
+Same story as snapshot.json — there's a transient mirror under `<tempdir>/tinyhat-analysis.json`, but `latest/analysis.json` is the durable copy a follow-up question will read from.
 
 ## Retention
 

--- a/docs/user-flows.md
+++ b/docs/user-flows.md
@@ -16,8 +16,8 @@ The first command registers the Tinyloop marketplace (this repo). The second ins
 
 | Slash command | What it does | Regenerates? |
 |---|---|:---:|
-| `/tinyhat:audit` | Scan → agent writes analysis → render report → open HTML | ✓ |
-| `/tinyhat:open` | Open the latest existing report in your browser | — |
+| `/tinyhat:audit` | Scan → agent writes analysis → render report → summarise in chat with a link | ✓ |
+| `/tinyhat:open` | Answer a question about the last audit from JSON, or open the HTML | — |
 | `/tinyhat:history` | Open the archive index listing every report on disk | — |
 | `/tinyhat:routine` | Manage the daily auto-run (status/on/off/where/clear) | — |
 
@@ -38,10 +38,16 @@ Any of these work:
 
 1. The agent runs `gather_snapshot.py`, which reads your local Claude transcripts and skill inventory and writes a structured JSON snapshot to the system temp directory.
 2. The agent reads that snapshot and writes its own editorial analysis — headline, what stands out, dormant commentary, recommendations, coverage caveats — into a second temp file.
-3. The agent runs `render_report.py`, which merges snapshot + analysis into `~/.claude/tinyhat/latest/report.html` and `report.md`.
-4. Your browser opens the HTML. The agent replies in chat with one sentence referencing one observation from the report.
+3. The agent runs `render_report.py`, which merges snapshot + analysis into `~/.claude/tinyhat/latest/report.{html,md}` and persists both `snapshot.json` and `analysis.json` next to them.
+4. The agent summarises the run in chat — two or three sentences with the headline numbers, top skills, one standout observation, and a clickable `file://` link to the full HTML. **Your browser does not open by default.** Pass `--open` (see below) if you prefer the HTML-first experience.
 
 **Typical run time:** 10–30 seconds. Most of it is the agent reasoning over your data, not Python.
+
+### Flags
+
+- **`/tinyhat:audit`** — default. Summarise in chat with a link; no browser.
+- **`/tinyhat:audit --open`** — also auto-open `report.html` at the end.
+- **`/tinyhat:audit --archive`** — also write a dated copy under `archive/YYYY-MM-DD/`. Implies no auto-open. The adaptive daily run uses this mode.
 
 ### The report layout
 
@@ -75,20 +81,25 @@ That writes an additional `~/.claude/tinyhat/archive/YYYY-MM-DD/` directory (cap
 
 ---
 
-## Flow 2 — Re-open the last report without regenerating
+## Flow 2 — Re-open the last report, or ask a question about it
 
-You already ran an audit today (or yesterday). You want to look at it again without paying the cost of another run.
+You already ran an audit today (or yesterday). You either want to see it again, or you have a specific question about what it said.
 
 ### How to trigger
 
 - **Slash:** `/tinyhat:open`
-- **Natural language:** *"Open my latest skill audit."* · *"Show me the last Tinyhat report."* · *"What did the skill audit say?"*
+- **Natural language:**
+  - To open the HTML: *"Open my latest skill audit."* · *"Show me the last Tinyhat report."*
+  - To ask a question: *"What did the skill audit say?"* · *"Remind me which skills are dormant."* · *"What did you recommend last time?"*
 
 ### What happens
 
-1. The agent checks `~/.claude/tinyhat/latest/report.html` exists.
-2. Opens it in your default browser — no Python runs, no agent reasoning.
-3. Replies with one sentence: which date the report is from.
+The agent reads your message and decides:
+
+- **Specific question** → reads `~/.claude/tinyhat/latest/analysis.json` and `snapshot.json` and answers in chat, citing real numbers and skill names from the saved audit. No browser, no regeneration.
+- **Vague / "open it"** → opens `~/.claude/tinyhat/latest/report.html` in your default browser and says one line about when it was generated.
+
+Neither path reruns `gather_snapshot.py`. The persisted JSONs are the source of truth until the next `/tinyhat:audit`.
 
 ### If there's no report yet
 

--- a/scripts/render_report.py
+++ b/scripts/render_report.py
@@ -851,9 +851,13 @@ def main() -> int:
 
     md = render_markdown(snapshot, analysis)
     htmlout = render_html(snapshot, analysis)
+    snapshot_json = json.dumps(snapshot, indent=2, ensure_ascii=False) + "\n"
+    analysis_json = json.dumps(analysis, indent=2, ensure_ascii=False) + "\n"
 
     (latest_dir / "report.md").write_text(md, encoding="utf-8")
     (latest_dir / "report.html").write_text(htmlout, encoding="utf-8")
+    (latest_dir / "snapshot.json").write_text(snapshot_json, encoding="utf-8")
+    (latest_dir / "analysis.json").write_text(analysis_json, encoding="utf-8")
 
     today = datetime.now(timezone.utc).date().isoformat()
     (latest_dir / "run-stamp.txt").write_text(today + "\n", encoding="utf-8")
@@ -863,6 +867,8 @@ def main() -> int:
         archive_dir.mkdir(parents=True, exist_ok=True)
         (archive_dir / "report.md").write_text(md, encoding="utf-8")
         (archive_dir / "report.html").write_text(htmlout, encoding="utf-8")
+        (archive_dir / "snapshot.json").write_text(snapshot_json, encoding="utf-8")
+        (archive_dir / "analysis.json").write_text(analysis_json, encoding="utf-8")
         enforce_retention(home_root / "archive", keep=31)
 
     # Always regenerate the index so it reflects latest + archives.

--- a/skills/audit/SKILL.md
+++ b/skills/audit/SKILL.md
@@ -1,6 +1,6 @@
 ---
 description: Audit which Claude Code skills you actually use, which look dormant, and what to create next. Produces an agent-authored local HTML+markdown report on the data already on disk. Triggers on "audit my skills", "run a skill audit", "review my skill usage", "clean up unused skills", "trim my skill set", "which skills should I remove", "how am I using Claude", "which skills am I actually using", "what skills should I create", "refresh my tinyhat report", or explicit /tinyhat:audit invocations.
-argument-hint: [--archive] [--no-open]
+argument-hint: [--archive] [--open]
 allowed-tools: Bash(python3 *) Bash(open *) Bash(xdg-open *) Bash(start *) Read Write
 ---
 
@@ -27,9 +27,9 @@ actually worth mentioning.
 
 | `$ARGUMENTS` | What happens |
 |---|---|
-| _(empty)_ | Run the audit, open the HTML. |
-| `--archive` | Also write today's dated archive snapshot. |
-| `--no-open` | Skip the browser. Used by the adaptive daily run. |
+| _(empty)_ | Run the audit, summarise in chat with a link to the HTML. Do **not** auto-open the browser. |
+| `--open` | Also open the HTML in the default browser at the end. |
+| `--archive` | Also write today's dated archive snapshot. Implies no auto-open — used by the adaptive daily run. |
 
 ## Skill-relative script paths
 
@@ -48,9 +48,9 @@ python3 "${CLAUDE_SKILL_DIR}/../../scripts/routine.py" check
 ```
 
 If exit non-zero, skip — proceed to the user's actual request.
-If exit zero, run the full audit flow with `--archive --no-open`, then
-continue to the user's request. Add one short line so the user knows
-today's snapshot refreshed. Never block the user's request on this.
+If exit zero, run the full audit flow with `--archive`, then continue
+to the user's request. Add one short line so the user knows today's
+snapshot refreshed. Never block the user's request on this.
 
 ## The audit flow
 
@@ -91,17 +91,54 @@ read it the first time you run this skill.
 ### 3. Render
 
 ```bash
-# Manual, opens in browser:
+# Default — writes latest/ and archive index; no browser:
+python3 "${CLAUDE_SKILL_DIR}/../../scripts/render_report.py"
+
+# User passed --open — also open the HTML at the end:
 python3 "${CLAUDE_SKILL_DIR}/../../scripts/render_report.py" --open
 
-# Adaptive daily or explicit --archive:
+# User passed --archive (or the adaptive daily fired) — write the
+# dated archive copy too; do NOT open the browser:
 python3 "${CLAUDE_SKILL_DIR}/../../scripts/render_report.py" --archive
 ```
 
-The renderer also rewrites `~/.claude/tinyhat/archive/index.html` so
-the history page always reflects the latest run.
+Rendering always writes four files into `~/.claude/tinyhat/latest/`:
 
-### 4. Open the HTML (if you didn't use `--open`)
+- `report.html` · `report.md` — the view.
+- `snapshot.json` · `analysis.json` — the data you (or a follow-up
+  turn) can read without re-running `gather_snapshot.py`.
+
+The renderer also rewrites `~/.claude/tinyhat/archive/index.html` so
+the history page always reflects the latest run. When `--archive` is
+passed, the same four files land in `archive/YYYY-MM-DD/`.
+
+### 4. Summarise in chat (always)
+
+Write 2–3 sentences in chat, built directly from the analysis you just
+wrote. The default experience is **terminal-first** — most users won't
+open the HTML unless something in the summary pulls them in.
+
+Lead with the literal headline number, name the top 2–3 skills from
+`snapshot.top_skills`, and surface one observation from
+`what_stands_out`. End with a clickable file-URL to the full report:
+
+> Scanned `<INSTALLED_COUNT>` installed skills, `<ACTIVE_COUNT>` active
+> in the last `<WINDOW_DAYS>` days. Top skills: `<skill-a>`, `<skill-b>`,
+> `<skill-c>`.
+>
+> What stood out: `<one line from what_stands_out>`.
+>
+> Full report: `file:///Users/<you>/.claude/tinyhat/latest/report.html`
+
+See [`references/writing-the-analysis.md`](references/writing-the-analysis.md#chat-summary)
+for the exact shape and examples.
+
+### 5. Open the HTML (only if `--open` was passed)
+
+Default is **no auto-open**. The chat summary above already surfaces
+the headline; users who want the HTML click the link in the summary.
+
+When the user passed `--open`, and only then:
 
 ```bash
 open ~/.claude/tinyhat/latest/report.html        # macOS
@@ -109,17 +146,12 @@ xdg-open ~/.claude/tinyhat/latest/report.html    # Linux
 start ~/.claude/tinyhat/latest/report.html       # Windows
 ```
 
-### 5. Tell the user
-
-One or two sentences max. Reference one specific observation from
-`what_stands_out`. Point them at the report.
-
 ## Paths
 
 - Scripts: bundled under `<plugin>/scripts/`, invoked here via `${CLAUDE_SKILL_DIR}/../../scripts/...`
 - Transient: `<tempdir>/tinyhat-snapshot.json`, `<tempdir>/tinyhat-analysis.json`
-- Latest: `~/.claude/tinyhat/latest/report.{md,html}` + `run-stamp.txt`
-- Archive: `~/.claude/tinyhat/archive/YYYY-MM-DD/report.{md,html}` + `index.html`
+- Latest: `~/.claude/tinyhat/latest/report.{md,html}` + `snapshot.json` + `analysis.json` + `run-stamp.txt`
+- Archive: `~/.claude/tinyhat/archive/YYYY-MM-DD/report.{md,html}` + `snapshot.json` + `analysis.json` + `index.html`
 - Routine state: `~/.claude/tinyhat/routine.json`
 
 ## Gotchas

--- a/skills/audit/references/writing-the-analysis.md
+++ b/skills/audit/references/writing-the-analysis.md
@@ -136,6 +136,48 @@ macOS-only."*
 - **Burying the lead.** The two pie charts and hero stats are already
   visible; your `what_stands_out` should add signal the charts can't.
 
+## Chat summary
+
+After the renderer finishes, you write a short summary in chat. That's
+the **terminal-first** default: most users read the summary and stop
+there, so it has to earn the room it takes up.
+
+### Shape
+
+Three short paragraphs. No headings, no bullet marathons.
+
+1. **Headline + top skills.** Literal installed/active numbers plus
+   the top 2–3 skills from `snapshot.top_skills`, backticked.
+2. **One standout.** Pick the single sharpest line from
+   `what_stands_out` — the one most likely to make the user lean in.
+   Not all of them, just one.
+3. **Full-report link.** A clickable `file://` URL to
+   `~/.claude/tinyhat/latest/report.html`, absolute path expanded.
+
+### Example
+
+> Scanned 121 installed skills, 14 active in the last 30 days. Top
+> skills: `plan-eng-review`, `plan-ceo-review`, `browse`.
+>
+> What stood out: planning-review skills made up 7 of 17 runs this
+> window — review prep is the strongest single pattern.
+>
+> Full report: `file:///Users/you/.claude/tinyhat/latest/report.html`
+
+### Rules
+
+- **Never re-run `gather_snapshot.py` to write this summary.** Read
+  what you already produced — `stats`, `top_skills`, and
+  `what_stands_out` are all in the snapshot and analysis JSON you just
+  wrote.
+- **Expand the `~/` to an absolute path** in the `file://` URL so it's
+  clickable in the terminal. `echo $HOME` if you need to.
+- **Don't add a fourth paragraph.** No "want me to open it?" follow-up
+  — a link is enough. If the user wants to dig in they'll say so.
+- **Skip the chat summary only when `--archive` is set without user
+  interaction** (the adaptive daily run) — it's background work;
+  surfacing it would be noise.
+
 ## How the rendering works
 
 `render_report.py` replaces template slots with snapshot facts and your
@@ -143,3 +185,9 @@ analysis strings. If a key in your analysis JSON is missing, the
 renderer falls back to a Python-derived default. That default is
 safe but generic — which is exactly what this skill is trying to avoid.
 Fill every field.
+
+The renderer also writes `snapshot.json` and `analysis.json` next to
+the HTML in both `latest/` and (when `--archive`) `archive/YYYY-MM-DD/`.
+Those two files are the durable view of everything you produced on
+this run — a follow-up turn (or `/tinyhat:open`) can answer questions
+about this audit by reading them instead of re-scanning.

--- a/skills/open/SKILL.md
+++ b/skills/open/SKILL.md
@@ -1,14 +1,69 @@
 ---
-description: Open the most recent Tinyhat skill-audit report (HTML) in the user's default browser — does NOT regenerate. Triggers on "open my latest skill audit", "show my latest tinyhat report", "open the last skill audit", "what did the skill audit say", "open the skill audit report", "open tinyhat", or explicit /tinyhat:open invocations. If no report exists yet, hand off to /tinyhat:audit to create the first one.
+description: Open the most recent Tinyhat skill-audit report (HTML) in the user's default browser, or answer a specific question about it from the persisted JSON — does NOT regenerate. Triggers on "open my latest skill audit", "show my latest tinyhat report", "open the last skill audit", "what did the skill audit say", "remind me what the audit said about X", "which skills are dormant", "open the skill audit report", "open tinyhat", or explicit /tinyhat:open invocations. If no report exists yet, hand off to /tinyhat:audit to create the first one.
 allowed-tools: Bash(open *) Bash(xdg-open *) Bash(start *) Bash(python3 *) Read
 ---
 
-# tinyhat:open — open the latest skill-audit report as-is
+# tinyhat:open — read from or open the latest audit
 
-Open `~/.claude/tinyhat/latest/report.html` in the user's default
-browser. **Do not regenerate.** That's `/tinyhat:audit`'s job.
+Two jobs, decided by what the user actually asked for:
 
-## Flow
+1. **Answer a specific question about the last audit** — read the
+   persisted JSONs at `~/.claude/tinyhat/latest/{snapshot,analysis}.json`
+   and reply in chat. No browser.
+2. **Open the HTML report as-is** — when the user just wants to see it.
+
+**Never regenerate.** That's `/tinyhat:audit`'s job. The agent analysis
+step is non-trivial and the user may not want to spend the turns.
+
+## Decide which job you're doing
+
+Read the user's message. If it contains a specific question —
+*"what did the audit say about dormant skills?"*, *"which skills did I
+use this week?"*, *"remind me what you recommended"* — it's **job 1**:
+answer from JSON. The phrasing is asking for a fact, not a viewing
+experience.
+
+If the message is vague-open — *"open tinyhat"*, *"show me the
+report"*, *"/tinyhat:open"* — it's **job 2**: open the HTML.
+
+When in doubt, prefer job 1. Reading from JSON and answering inline
+keeps the user's attention in the terminal; opening a browser tab
+moves it away.
+
+## Job 1 — answer from JSON
+
+1. Check `~/.claude/tinyhat/latest/analysis.json` and
+   `~/.claude/tinyhat/latest/snapshot.json` both exist.
+   - If missing, say "I don't have a saved audit to read from — let me
+     run a fresh one" and hand off to `/tinyhat:audit`. Stop.
+2. Read one or both JSONs with the Read tool. Prefer `analysis.json`
+   for editorial questions (*"what stood out?"*, *"what did you
+   recommend?"*) and `snapshot.json` for factual questions (*"which
+   skills did I use?"*, *"how many sessions?"*).
+3. Answer in chat. Cite specific numbers/skills from the JSON. Name
+   the date the audit ran (`run-stamp.txt`). End with one line the
+   user can act on — usually a `file://` link to the full HTML if
+   they want more detail.
+
+### Shape of a good answer
+
+> From your 2026-04-23 audit: 107 of 121 installed skills were dormant
+> — the bulk (82) are plugin-bundled skills that came with
+> marketplaces you installed. Open the full report at
+> `file:///Users/you/.claude/tinyhat/latest/report.html` to see them
+> grouped by origin.
+
+### Rules
+
+- **Never re-run `gather_snapshot.py`.** The JSONs on disk are the
+  source of truth for this skill.
+- **Use literal numbers from the JSON.** Don't paraphrase counts.
+- **Only reference skills that appear in `snapshot.inventory`.**
+- If the question can't be answered from the JSON (e.g. *"what would
+  you recommend next week?"*), say so and suggest running a fresh
+  audit.
+
+## Job 2 — open the HTML
 
 1. Check whether `~/.claude/tinyhat/latest/report.html` exists.
    - If missing, tell the user "No skill-audit report yet — let me
@@ -32,9 +87,3 @@ python3 -c "import webbrowser, pathlib; webbrowser.open(pathlib.Path('~/.claude/
    date from `~/.claude/tinyhat/latest/run-stamp.txt` is enough:
    *"Opened your most recent skill-audit report from 2026-04-23. Use
    `/tinyhat:audit` to refresh."*
-
-## When the user wants a fresh report
-
-Direct them to `/tinyhat:audit`. Don't regenerate silently — the
-agent analysis step is non-trivial and the user may not want to spend
-the turns.


### PR DESCRIPTION
## Summary

Default `/tinyhat:audit` stops auto-opening the browser and instead
summarises the run in chat with a clickable `file://` link. The
renderer persists `snapshot.json` and `analysis.json` next to the
HTML/MD in `latest/` and `archive/YYYY-MM-DD/`, so follow-up
questions are answered from disk rather than re-running the scanner.

## Linked issue

Closes #15

## Type of change

- [x] \`feat\` — new feature (default behaviour + persisted artifacts)
- [x] \`docs\` — user-flows, artifacts, writing-the-analysis, and both SKILL.md files

## Testing performed

- [x] Ran \`python3 scripts/gather_snapshot.py\` against the maintainer's local data (121 installed skills, 14 active).
- [x] Ran \`python3 scripts/render_report.py --home-root /tmp/tinyhat-issue15-verify/home\` (default, no \`--open\`) — confirmed no browser, \`snapshot.json\` + \`analysis.json\` landed in \`latest/\`.
- [x] Ran again with \`--archive\` — confirmed identical JSONs also land in \`archive/YYYY-MM-DD/\` (diffed both copies).
- [x] \`ruff check .\` and \`ruff format --check .\` pass.

Commits are split for atomic review: renderer persistence, audit SKILL flow change, writing-the-analysis chat-summary shape, open SKILL two-job flow, and docs — in that order.

## Follow-up

Unblocks #31 (numbered next-action list), which layers on top of the chat summary introduced here.

## Checklist

- [x] PR title is a Conventional Commit
- [x] Linked to an issue (\`Closes #15\`)
- [x] Tests added or updated (or this PR is docs/chore only) — N/A, behaviour verified manually against the scripts
- [x] Docs updated where behavior changed
- [x] CI is green — pending
- [x] No references to private maintainer resources
- [x] I will not self-merge

<details>
<summary>Agent checklist</summary>

- [x] Commits signed with the bot's SSH key (\`claude.farid@tinyloop.co\`, ED25519 \`SHA256:uQqcha1Re4uX1+KFj+mYZrqPQ+jMmx4YJLoOAhuoBTU\`).
- [x] Branch named \`claude-code-bot/issue-15-chat-summary\`.

</details>