### PR TITLE
fix(audit): improve first-run report flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,15 @@ Inside Claude Code, add the Tinyloop marketplace and install the plugin from it:
 
 The first line registers Tinyloop's marketplace (this repo doubles as its own marketplace). The second installs the `tinyhat` plugin from it. After this, `/plugin marketplace update tinyloop` pulls newer versions.
 
+If `/plugin update tinyhat@tinyloop` appears to leave Tinyhat on old
+code, reinstall cleanly:
+
+```text
+/plugin remove tinyhat@tinyloop
+/plugin install tinyhat@tinyloop
+/reload-plugins
+```
+
 Requires Python 3.9+ on your `PATH` (pre-installed on macOS and most Linux).
 
 ## Usage
@@ -38,7 +47,14 @@ Ask in plain English or use a slash command:
 - **Browse history:** *"Show my skill-audit history."* · `/tinyhat:history`
 - **Manage the daily routine:** *"Turn off tinyhat's daily run."* · `/tinyhat:routine status|on|off|where|clear`
 
-Output lives at `~/.claude/tinyhat/latest/report.html`. For every flow, trigger, and sub-command, see [`docs/user-flows.md`](docs/user-flows.md).
+Tinyhat writes under Claude Code's per-plugin data directory. For a
+marketplace install of `tinyhat@tinyloop`, the latest HTML typically
+lands at `~/.claude/plugins/data/tinyhat-tinyloop/latest/report.html`.
+If you're upgrading from an older Tinyhat, the next write-capable run
+automatically migrates data from the legacy `~/.claude/tinyhat/`
+directory.
+For every flow, trigger, and sub-command, see
+[`docs/user-flows.md`](docs/user-flows.md).
 
 ## Documentation
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -61,7 +61,7 @@ In scope for this policy:
   example).
 - Attribution logic that could mis-credit skills.
 - Any path-traversal or file-overwrite concern with the artifacts Tinyhat
-  writes under `~/.claude/tinyhat/`.
+  writes under Claude Code's plugin-data directory (`${CLAUDE_PLUGIN_DATA}` when invoked inside Claude Code).
 
 Out of scope:
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -17,7 +17,7 @@ A Claude Code plugin where a Python script gathers facts, the Claude agent write
 └────────────────────────┘   └──────────────────────┘   └─────────────────────────┘
                                                                      │
                                                                      ▼
-                                                         ~/.claude/tinyhat/
+                                                         ${CLAUDE_PLUGIN_DATA}/
                                                          ├── latest/
                                                          └── archive/YYYY-MM-DD/
                                                              └── index.html
@@ -38,16 +38,16 @@ The primary skill (`tinyhat:audit`). Its `SKILL.md` is the agent entry point —
 Templates live at `templates/`:
 
 - `report.html.tmpl` — the HTML layout with `{{SLOT}}` placeholders.
-- `report.md.tmpl` — the same report as markdown.
+- `report.md.tmpl` — the same report as markdown, optimized for terminal reading.
 - `report.css` — extracted stylesheet, inlined at render time.
 
 ### `skills/open/`
 
-Thin skill (`tinyhat:open`) — opens `~/.claude/tinyhat/latest/report.html`. No regeneration, no Python run. The point is to let the user revisit a report cheaply.
+Thin skill (`tinyhat:open`) — opens `${CLAUDE_PLUGIN_DATA}/latest/report.html`. No regeneration, no Python run. The point is to let the user revisit a report cheaply.
 
 ### `skills/history/`
 
-Thin skill (`tinyhat:history`) — opens `~/.claude/tinyhat/archive/index.html`. Also cheap, also no regeneration. Regenerates just the index page if it's stale or missing.
+Thin skill (`tinyhat:history`) — opens `${CLAUDE_PLUGIN_DATA}/archive/index.html`. Also cheap, also no regeneration. Regenerates just the index page if it's stale or missing.
 
 ### `scripts/gather_snapshot.py`
 
@@ -80,9 +80,10 @@ If `analysis.json` is missing, fills in sensible but generic defaults derived fr
 
 Responsibilities:
 - Renders `report.md` + `report.html`.
-- Writes `~/.claude/tinyhat/latest/{report.md, report.html, run-stamp.txt}`.
-- With `--archive`: also writes `~/.claude/tinyhat/archive/YYYY-MM-DD/` and prunes archive to ≤31 dirs.
-- Always regenerates `~/.claude/tinyhat/archive/index.html` so the history page stays consistent.
+- Writes `${CLAUDE_PLUGIN_DATA}/latest/{report.md, report.html, run-stamp.txt}`.
+- With `--archive`: also writes `${CLAUDE_PLUGIN_DATA}/archive/YYYY-MM-DD/` and prunes archive to ≤31 dirs.
+- Always regenerates `${CLAUDE_PLUGIN_DATA}/archive/index.html` so the history page stays consistent.
+- Builds the fallback `next_actions` list and the terminal-safe percentage strip used by `report.md`.
 - With `--open`: uses `webbrowser.open()` (cross-platform).
 - With `--index-only`: regenerates the index without re-rendering the report.
 
@@ -94,7 +95,7 @@ Responsibilities:
 
 State for the adaptive daily refresh:
 
-- `routine status` / `on` / `off` — reads/writes `~/.claude/tinyhat/routine.json`.
+- `routine status` / `on` / `off` — reads/writes `${CLAUDE_PLUGIN_DATA}/routine.json`.
 - `routine check` — exits 0 if a daily run **should** fire (enabled AND no run today). Exits non-zero otherwise. This is the trigger the main skill calls on every load.
 - `where` — prints the full set of paths.
 - `clear-archive` — removes every dated directory, keeps `latest/`.

--- a/docs/artifacts.md
+++ b/docs/artifacts.md
@@ -1,21 +1,31 @@
 # Artifacts — everything Tinyhat writes to your machine
 
-Tinyhat is local-only and read-only against Claude's data. It writes files to **exactly one directory** plus transient temp files. Everything under these paths is safe to delete — the plugin recreates it on next run.
+Tinyhat is local-only and read-only against Claude's data. It writes
+files to **exactly one directory** plus transient temp files.
+Inside Claude Code, that directory is `${CLAUDE_PLUGIN_DATA}`. For a
+marketplace install of `tinyhat@tinyloop`, that usually resolves to
+`~/.claude/plugins/data/tinyhat-tinyloop/`. Everything under these
+paths is safe to delete — the plugin recreates it on next run.
+In plain-shell examples below, replace `${CLAUDE_PLUGIN_DATA}` with the
+resolved path if your shell does not already have that variable set.
+Older Tinyhat builds wrote to `~/.claude/tinyhat/`; the next
+write-capable command now migrates that legacy directory into the
+plugin-data path automatically.
 
 ## Quick reference
 
 | Path | What's there | When it's written |
 |---|---|---|
-| `~/.claude/tinyhat/routine.json` | Adaptive-daily on/off + install timestamp | On first run; overwritten on `/tinyhat:audit routine on|off` |
-| `~/.claude/tinyhat/latest/report.html` | Latest report, self-contained HTML | Every `/tinyhat:audit` run |
-| `~/.claude/tinyhat/latest/report.md` | Latest report, markdown mirror | Every `/tinyhat:audit` run |
-| `~/.claude/tinyhat/latest/snapshot.json` | Durable data snapshot — the facts | Every `/tinyhat:audit` run |
-| `~/.claude/tinyhat/latest/analysis.json` | Durable agent analysis — the editorial layer | Every `/tinyhat:audit` run |
-| `~/.claude/tinyhat/latest/run-stamp.txt` | ISO local-date of last successful run | Every `/tinyhat:audit` run |
-| `~/.claude/tinyhat/archive/YYYY-MM-DD/report.{html,md}` | Dated snapshot | When `--archive` is passed or the adaptive daily fires |
-| `~/.claude/tinyhat/archive/YYYY-MM-DD/{snapshot,analysis}.json` | Dated JSONs alongside the HTML/MD | When `--archive` is passed or the adaptive daily fires |
-| `~/.claude/tinyhat/archive/index.html` | Browseable index of latest + all archives | Every render call |
-| `~/.claude/tinyhat/feedback.jsonl` | Optional local feedback log (reserved) | Never in v0 (feedback goes via `mailto:`) |
+| `${CLAUDE_PLUGIN_DATA}/routine.json` | Adaptive-daily on/off + install timestamp | On first run; overwritten on `/tinyhat:audit routine on|off` |
+| `${CLAUDE_PLUGIN_DATA}/latest/report.html` | Latest report, self-contained HTML | Every `/tinyhat:audit` run |
+| `${CLAUDE_PLUGIN_DATA}/latest/report.md` | Latest report, markdown mirror | Every `/tinyhat:audit` run |
+| `${CLAUDE_PLUGIN_DATA}/latest/snapshot.json` | Durable data snapshot — the facts | Every `/tinyhat:audit` run |
+| `${CLAUDE_PLUGIN_DATA}/latest/analysis.json` | Durable agent analysis — the editorial layer | Every `/tinyhat:audit` run |
+| `${CLAUDE_PLUGIN_DATA}/latest/run-stamp.txt` | ISO local-date of last successful run | Every `/tinyhat:audit` run |
+| `${CLAUDE_PLUGIN_DATA}/archive/YYYY-MM-DD/report.{html,md}` | Dated snapshot | When `--archive` is passed or the adaptive daily fires |
+| `${CLAUDE_PLUGIN_DATA}/archive/YYYY-MM-DD/{snapshot,analysis}.json` | Dated JSONs alongside the HTML/MD | When `--archive` is passed or the adaptive daily fires |
+| `${CLAUDE_PLUGIN_DATA}/archive/index.html` | Browseable index of latest + all archives | Every render call |
+| `${CLAUDE_PLUGIN_DATA}/feedback.jsonl` | Optional local feedback log (reserved) | Never in v0 (feedback goes via `mailto:`) |
 | `<tempdir>/tinyhat-snapshot.json` | Transient mirror of latest/snapshot.json (pipeline hand-off) | Every `gather_snapshot.py` call |
 | `<tempdir>/tinyhat-analysis.json` | Transient mirror of latest/analysis.json (pipeline hand-off) | Every `/tinyhat:audit` run |
 
@@ -27,7 +37,7 @@ Tinyhat is local-only and read-only against Claude's data. It writes files to **
 ## Directory layout
 
 ```
-~/.claude/tinyhat/
+${CLAUDE_PLUGIN_DATA}/            (e.g. ~/.claude/plugins/data/tinyhat-tinyloop/)
 ├── routine.json
 ├── latest/
 │   ├── report.html         ← open this to see the most recent report
@@ -52,9 +62,9 @@ Tinyhat is local-only and read-only against Claude's data. It writes files to **
 ### The latest report
 
 ```bash
-open ~/.claude/tinyhat/latest/report.html        # macOS
-xdg-open ~/.claude/tinyhat/latest/report.html    # Linux
-start ~/.claude/tinyhat/latest/report.html       # Windows
+open "${CLAUDE_PLUGIN_DATA}/latest/report.html"        # macOS
+xdg-open "${CLAUDE_PLUGIN_DATA}/latest/report.html"    # Linux
+start "${CLAUDE_PLUGIN_DATA}/latest/report.html"       # Windows
 ```
 
 Or inside Claude Code: `/tinyhat:open`.
@@ -62,7 +72,7 @@ Or inside Claude Code: `/tinyhat:open`.
 ### The archive index (browse history)
 
 ```bash
-open ~/.claude/tinyhat/archive/index.html
+open "${CLAUDE_PLUGIN_DATA}/archive/index.html"
 ```
 
 Or inside Claude Code: `/tinyhat:history`.
@@ -70,7 +80,7 @@ Or inside Claude Code: `/tinyhat:history`.
 ### A specific dated snapshot
 
 ```bash
-open ~/.claude/tinyhat/archive/2026-04-23/report.html
+open "${CLAUDE_PLUGIN_DATA}/archive/2026-04-23/report.html"
 ```
 
 The index page links to every dated snapshot — easier than typing.
@@ -78,14 +88,14 @@ The index page links to every dated snapshot — easier than typing.
 ### The markdown mirror (if you want to paste into a doc)
 
 ```bash
-cat ~/.claude/tinyhat/latest/report.md
+cat "${CLAUDE_PLUGIN_DATA}/latest/report.md"
 ```
 
 ### The routine state
 
 ```bash
-cat ~/.claude/tinyhat/routine.json
-cat ~/.claude/tinyhat/latest/run-stamp.txt
+cat "${CLAUDE_PLUGIN_DATA}/routine.json"
+cat "${CLAUDE_PLUGIN_DATA}/latest/run-stamp.txt"
 ```
 
 Or inside Claude Code: `/tinyhat:audit routine status`.
@@ -93,7 +103,7 @@ Or inside Claude Code: `/tinyhat:audit routine status`.
 ### The durable snapshot JSON (the facts)
 
 ```bash
-cat ~/.claude/tinyhat/latest/snapshot.json
+cat "${CLAUDE_PLUGIN_DATA}/latest/snapshot.json"
 ```
 
 Top-level keys: `meta`, `stats`, `inventory`, `top_skills`, `skill_counts`, `last_seen`, `sessions`, `events`, `events_audit`, `tool_totals`, `aggregate_tools`, `daily_rollups`, `dormant_by_origin`, `installed_by_origin`, `surface_rollups`, `coverage`. See [development.md](local-development.md) for the shape.
@@ -103,24 +113,24 @@ The transient mirror at `<tempdir>/tinyhat-snapshot.json` is the same data — i
 ### The agent-authored analysis JSON (the editorial layer)
 
 ```bash
-cat ~/.claude/tinyhat/latest/analysis.json
+cat "${CLAUDE_PLUGIN_DATA}/latest/analysis.json"
 ```
 
-Shape: `headline`, `headline_sub`, `what_stands_out[]`, `dormant_commentary`, `skill_recommendations[]`, `coverage_note`. Schema details in [`skills/audit/references/writing-the-analysis.md`](../skills/audit/references/writing-the-analysis.md).
+Shape: `headline`, `headline_sub`, `what_stands_out[]`, `dormant_commentary`, `skill_recommendations[]`, `next_actions[]`, `coverage_note`. Schema details in [`skills/audit/references/writing-the-analysis.md`](../skills/audit/references/writing-the-analysis.md).
 
 Same story as snapshot.json — there's a transient mirror under `<tempdir>/tinyhat-analysis.json`, but `latest/analysis.json` is the durable copy a follow-up question will read from.
 
 ## Retention
 
-- `~/.claude/tinyhat/latest/` — always overwritten by the most recent run.
-- `~/.claude/tinyhat/archive/` — keeps at most **31** dated directories. On every archive write, oldest directories are pruned. The index page always reflects what's currently on disk.
+- `${CLAUDE_PLUGIN_DATA}/latest/` — always overwritten by the most recent run.
+- `${CLAUDE_PLUGIN_DATA}/archive/` — keeps at most **31** dated directories. On every archive write, oldest directories are pruned. The index page always reflects what's currently on disk.
 
 ## Reset everything
 
 If you want a clean slate:
 
 ```bash
-rm -rf ~/.claude/tinyhat
+rm -rf ~/.claude/plugins/data/tinyhat-tinyloop
 rm -f "$(python3 -c 'import tempfile; print(tempfile.gettempdir())')"/tinyhat-*.json
 ```
 
@@ -130,7 +140,7 @@ Or, less destructive — just clear the dated archives:
 
 - `/tinyhat:audit clear-archive`
 
-That removes every dir under `archive/` but keeps `latest/` and `routine.json`.
+That removes every dir under `${CLAUDE_PLUGIN_DATA}/archive/` but keeps `latest/` and `routine.json`.
 
 ## What Tinyhat **reads** (never writes)
 

--- a/docs/local-development.md
+++ b/docs/local-development.md
@@ -54,8 +54,8 @@ Audit my skills.
 The agent will:
 1. Run `gather_snapshot.py` → writes `<tempdir>/tinyhat-snapshot.json`.
 2. Read the snapshot and write `<tempdir>/tinyhat-analysis.json` — this is the editorial layer. Watch its reasoning; that's where Tinyhat earns its keep.
-3. Run `render_report.py --archive --open`.
-4. Your browser should open `~/.claude/tinyhat/latest/report.html`.
+3. Run `render_report.py --archive`.
+4. The report lands under Tinyhat's plugin-data root (script-only default: `~/.claude/plugins/data/tinyhat/latest/report.html`).
 
 **What to judge on the report:**
 - Headline: *"You have N skills installed. You used M of them in the last 30 days."* — are N and M correct to your gut?
@@ -72,7 +72,7 @@ The agent will:
 /tinyhat:open
 ```
 
-Should open the existing `~/.claude/tinyhat/latest/report.html` in your browser — no Python run.
+Should open the existing `~/.claude/plugins/data/tinyhat/latest/report.html` in your browser — no Python run.
 
 **Browse the archive:**
 
@@ -80,7 +80,7 @@ Should open the existing `~/.claude/tinyhat/latest/report.html` in your browser 
 /tinyhat:history
 ```
 
-Should open `~/.claude/tinyhat/archive/index.html`. One entry per day you've run the audit, up to 31. The header inside each report has an `all reports →` link that returns to this index.
+Should open `~/.claude/plugins/data/tinyhat/archive/index.html`. One entry per day you've run the audit, up to 31. The header inside each report has an `all reports →` link that returns to this index.
 
 **Check / toggle the adaptive daily routine:**
 
@@ -112,14 +112,14 @@ Tinyhat's state is two things: the output directory and the temp files.
 
 ```bash
 # Wipe everything the plugin has written:
-rm -rf ~/.claude/tinyhat
+rm -rf ~/.claude/plugins/data/tinyhat
 
 # Wipe the transient snapshot + analysis so the next run starts clean:
 rm -f "$(python3 -c 'import tempfile; print(tempfile.gettempdir())')/tinyhat-snapshot.json"
 rm -f "$(python3 -c 'import tempfile; print(tempfile.gettempdir())')/tinyhat-analysis.json"
 ```
 
-The plugin recreates `~/.claude/tinyhat/` on the next run. Nothing else on your system is touched.
+The plugin recreates `~/.claude/plugins/data/tinyhat/` on the next run. Nothing else on your system is touched.
 
 ---
 
@@ -139,12 +139,11 @@ python3 scripts/gather_snapshot.py
 # that produce a generic-but-useful analysis. Only the agent should write
 # non-generic analysis.
 
-# Render the report and open the HTML:
-python3 scripts/render_report.py --archive --open
-# → writes ~/.claude/tinyhat/latest/report.{md,html}
-# → writes ~/.claude/tinyhat/archive/YYYY-MM-DD/
-# → regenerates ~/.claude/tinyhat/archive/index.html
-# → opens the HTML in your default browser
+# Render the report:
+python3 scripts/render_report.py --archive
+# → writes ~/.claude/plugins/data/tinyhat/latest/report.{md,html}
+# → writes ~/.claude/plugins/data/tinyhat/archive/YYYY-MM-DD/
+# → regenerates ~/.claude/plugins/data/tinyhat/archive/index.html
 ```
 
 ### Just re-render without re-gathering
@@ -152,7 +151,7 @@ python3 scripts/render_report.py --archive --open
 If you've edited CSS or the template, keep the snapshot and just re-render:
 
 ```bash
-python3 scripts/render_report.py --open
+python3 scripts/render_report.py
 ```
 
 That reuses `<tempdir>/tinyhat-snapshot.json` from the previous gather run.
@@ -161,7 +160,7 @@ That reuses `<tempdir>/tinyhat-snapshot.json` from the previous gather run.
 
 ```bash
 python3 scripts/render_report.py --index-only
-open ~/.claude/tinyhat/archive/index.html
+open ~/.claude/plugins/data/tinyhat/archive/index.html
 ```
 
 ### Test a custom analysis JSON
@@ -196,7 +195,7 @@ python3 scripts/routine.py where
 python3 scripts/routine.py clear-archive
 ```
 
-All of these accept `--home-root /some/path` if you want to test against a throwaway location instead of `~/.claude/tinyhat/`:
+All of these accept `--home-root /some/path` if you want to test against a throwaway location instead of `~/.claude/plugins/data/tinyhat/`:
 
 ```bash
 python3 scripts/routine.py --home-root /tmp/tinyhat-test status
@@ -252,7 +251,7 @@ python3 -c 'import tempfile; print(tempfile.gettempdir())'
 
 ## 5. Before opening a PR
 
-1. Run `/tinyhat:audit` and confirm the report opens without template errors.
+1. Run `/tinyhat:audit` and confirm the report renders without template errors and the terminal briefing looks sane.
 2. Run `/tinyhat:open` and confirm no regeneration happens.
 3. Run `/tinyhat:history` and confirm the index lists today's snapshot.
 4. Confirm the report-header `all reports →` link takes you back to the index, and each index entry re-opens its report.

--- a/docs/user-flows.md
+++ b/docs/user-flows.md
@@ -14,6 +14,9 @@ Inside any Claude Code session:
 
 The first command registers the Tinyloop marketplace (this repo). The second installs the `tinyhat` plugin from it. After install, four skills register under the `tinyhat:` namespace:
 
+If a later `/plugin update tinyhat@tinyloop` looks stale, remove and
+reinstall the plugin, then run `/reload-plugins`.
+
 | Slash command | What it does | Regenerates? |
 |---|---|:---:|
 | `/tinyhat:audit` | Scan → agent writes analysis → render report → summarise in chat with a link | ✓ |
@@ -37,9 +40,10 @@ Any of these work:
 ### What happens
 
 1. The agent runs `gather_snapshot.py`, which reads your local Claude transcripts and skill inventory and writes a structured JSON snapshot to the system temp directory.
-2. The agent reads that snapshot and writes its own editorial analysis — headline, what stands out, dormant commentary, recommendations, coverage caveats — into a second temp file.
-3. The agent runs `render_report.py`, which merges snapshot + analysis into `~/.claude/tinyhat/latest/report.{html,md}` and persists both `snapshot.json` and `analysis.json` next to them.
-4. The agent summarises the run in chat — two or three sentences with the headline numbers, top skills, one standout observation, and a clickable `file://` link to the full HTML. **Your browser does not open by default.** Pass `--open` (see below) if you prefer the HTML-first experience.
+2. The agent reads that snapshot and writes its own editorial analysis — headline, what stands out, dormant commentary, recommendations, next-actions, coverage caveats — into a second temp file.
+3. The agent runs `render_report.py`, which merges snapshot + analysis into Tinyhat's plugin-data directory (for example `~/.claude/plugins/data/tinyhat-tinyloop/latest/report.{html,md}`) and persists both `snapshot.json` and `analysis.json` next to them.
+4. The agent replies in chat with a compact two-line percentage strip, one short headline sentence, and a numbered "pick a next step" menu. **Your browser does not open by default.** Pass `--open` (see below) if you prefer the HTML-first experience, or pick the open-report item from the menu.
+5. If you want the richer charts and drill-downs, choose the "open the full HTML report" action or ask for `/tinyhat:open`.
 
 **Typical run time:** 10–30 seconds. Most of it is the agent reasoning over your data, not Python.
 
@@ -54,6 +58,7 @@ Any of these work:
 Above-the-fold (Keep-it-simple mode, default):
 
 - **Two doughnut charts** — skill utilization %, sessions-with-skills %.
+- **Next-step menu** — compact numbered actions grounded in this run.
 - **Headline** — *"You have N skills installed. You used M of them in the last 30 days."*
 - **Stat grid, two groups:**
   - *Skills*: Installed / Active this window / Skill runs detected.
@@ -73,11 +78,11 @@ Data-junkie mode (click the toggle top-right):
 
 ### Storing this run as a dated archive
 
-By default, `/tinyhat:audit` updates `~/.claude/tinyhat/latest/` and overwrites. If you want today's snapshot preserved for comparison later, pass `--archive`:
+By default, `/tinyhat:audit` updates Tinyhat's `latest/` directory under the plugin-data root and overwrites. If you want today's snapshot preserved for comparison later, pass `--archive`:
 
 - `/tinyhat:audit --archive`
 
-That writes an additional `~/.claude/tinyhat/archive/YYYY-MM-DD/` directory (capped at 31 dated dirs — oldest is auto-pruned). The adaptive daily routine always archives.
+That writes an additional `archive/YYYY-MM-DD/` directory under the same plugin-data root (capped at 31 dated dirs — oldest is auto-pruned). The adaptive daily routine always archives.
 
 ---
 
@@ -96,8 +101,8 @@ You already ran an audit today (or yesterday). You either want to see it again, 
 
 The agent reads your message and decides:
 
-- **Specific question** → reads `~/.claude/tinyhat/latest/analysis.json` and `snapshot.json` and answers in chat, citing real numbers and skill names from the saved audit. No browser, no regeneration.
-- **Vague / "open it"** → opens `~/.claude/tinyhat/latest/report.html` in your default browser and says one line about when it was generated.
+- **Specific question** → reads `latest/analysis.json` and `snapshot.json` from Tinyhat's plugin-data directory and answers in chat, citing real numbers and skill names from the saved audit. No browser, no regeneration.
+- **Vague / "open it"** → opens `latest/report.html` in your default browser and says one line about when it was generated.
 
 Neither path reruns `gather_snapshot.py`. The persisted JSONs are the source of truth until the next `/tinyhat:audit`.
 
@@ -118,7 +123,7 @@ You have several daily snapshots archived and want to compare weeks, or just nav
 
 ### What happens
 
-1. The agent opens `~/.claude/tinyhat/archive/index.html` in your browser.
+1. The agent opens Tinyhat's plugin-data `archive/index.html` in your browser.
 2. The index page lists the **latest** report at the top, then every dated archive snapshot in reverse chronological order. Each entry links to its own `report.html`.
 3. Every report has an **all reports →** link in its header that takes you back to this index.
 
@@ -154,7 +159,7 @@ Useful when you're debugging or want to tail a file.
 
 - `/tinyhat:routine clear`
 
-Removes every dated dir under `~/.claude/tinyhat/archive/`. `~/.claude/tinyhat/latest/` and `routine.json` are preserved. Destructive — the agent will confirm first.
+Removes every dated dir under Tinyhat's plugin-data `archive/`. `latest/` and `routine.json` are preserved. Destructive — the agent will confirm first.
 
 ---
 

--- a/scripts/render_report.py
+++ b/scripts/render_report.py
@@ -37,6 +37,8 @@ from pathlib import Path
 from urllib.parse import quote
 from zoneinfo import ZoneInfo
 
+from tinyhat_paths import resolve_home_root
+
 
 def _local_tz() -> ZoneInfo | timezone:
     """Return the user's local timezone; fall back to system UTC offset."""
@@ -51,7 +53,6 @@ def _local_tz() -> ZoneInfo | timezone:
 
 PLUGIN_ROOT = Path(__file__).resolve().parent.parent
 TEMPLATE_DIR = PLUGIN_ROOT / "skills" / "audit" / "templates"
-DEFAULT_HOME_ROOT = Path.home() / ".claude" / "tinyhat"
 DEFAULT_SNAPSHOT_PATH = Path(tempfile.gettempdir()) / "tinyhat-snapshot.json"
 DEFAULT_ANALYSIS_PATH = Path(tempfile.gettempdir()) / "tinyhat-analysis.json"
 
@@ -73,6 +74,71 @@ def _format_compact(value: float) -> str:
     else:
         return f"{v:.0f}"
     return out.replace(".0B", "B").replace(".0M", "M").replace(".0k", "k")
+
+
+def _pct_int(part: int, total: int) -> int:
+    if total <= 0:
+        return 0
+    return int(round((100 * part) / total))
+
+
+def _ascii_bar(part: int, total: int, *, width: int = 28) -> str:
+    filled = 0 if total <= 0 else int(round(part / total * width))
+    filled = max(0, min(width, filled))
+    return "[" + ("#" * filled) + ("-" * (width - filled)) + "]"
+
+
+def _briefing_strip(snapshot: dict) -> str:
+    stats = snapshot["stats"]
+    skill_pct = _pct_int(stats["active_count"], stats["installed_count"])
+    session_pct = _pct_int(stats["sessions_with_skills"], stats["sessions_total"])
+    lines = [
+        "Skill utilization:    "
+        f"{_ascii_bar(stats['active_count'], stats['installed_count'])} "
+        f"{skill_pct:>3}%  {stats['active_count']} / {stats['installed_count']}",
+        "Sessions with skills: "
+        f"{_ascii_bar(stats['sessions_with_skills'], stats['sessions_total'])} "
+        f"{session_pct:>3}%  {stats['sessions_with_skills']} / {stats['sessions_total']}",
+    ]
+    return "\n".join(lines)
+
+
+def _load_routine_state(home_root: Path) -> dict:
+    routine_path = home_root / "routine.json"
+    state = {"enabled": True}
+    if routine_path.is_file():
+        try:
+            data = json.loads(routine_path.read_text(encoding="utf-8"))
+            if isinstance(data, dict):
+                state.update(data)
+        except (OSError, json.JSONDecodeError):
+            pass
+
+    run_stamp = home_root / "latest" / "run-stamp.txt"
+    last_run = ""
+    if run_stamp.is_file():
+        try:
+            last_run = run_stamp.read_text(encoding="utf-8").strip()
+        except OSError:
+            last_run = ""
+    return {"enabled": bool(state.get("enabled", True)), "last_run": last_run}
+
+
+def _confidence_rank(value: str | None) -> int:
+    return {"high": 3, "medium": 2, "low": 1}.get((value or "").lower(), 0)
+
+
+def _first_sentence(text: str, *, limit: int = 140) -> str:
+    clean = " ".join((text or "").split())
+    if not clean:
+        return ""
+    if clean.endswith((".", "!", "?")):
+        return clean
+    match = re.search(r"(?<=[.!?])\s", clean)
+    head = clean if not match else clean[: match.start()].strip()
+    if match or len(head) <= limit:
+        return head
+    return head[: limit - 3].rstrip() + "..."
 
 
 def _fallback_headline(snapshot: dict) -> str:
@@ -171,6 +237,103 @@ def _fallback_recommendations(snapshot: dict) -> list[dict]:
     return recs[:3]
 
 
+def _cleanup_action(snapshot: dict) -> dict | None:
+    dormant_by_origin = snapshot.get("dormant_by_origin", {})
+    if not dormant_by_origin:
+        return None
+
+    origin = (
+        "Plugin"
+        if dormant_by_origin.get("Plugin")
+        else max(dormant_by_origin.items(), key=lambda kv: len(kv[1]))[0]
+    )
+    names = dormant_by_origin.get(origin, [])
+    if not names:
+        return None
+
+    noun = "skill" if len(names) == 1 else "skills"
+    origin_label = origin.lower()
+    return {
+        "verb": "cleanup",
+        "label": f"Review the {len(names)} dormant {origin_label} {noun}",
+        "context": "They are the cleanest cleanup targets in this snapshot.",
+        "impact": "medium",
+    }
+
+
+def _draft_action(analysis: dict) -> dict | None:
+    recs = analysis.get("skill_recommendations") or []
+    if not recs:
+        return None
+
+    top = max(recs, key=lambda rec: _confidence_rank(rec.get("confidence")))
+    label = f"Draft `{top['name']}`"
+    context = _first_sentence(top.get("why") or top.get("headline") or "")
+    return {
+        "verb": "draft-skill",
+        "label": label,
+        "context": context or "It is the strongest candidate from this audit.",
+        "impact": top.get("confidence") or "medium",
+    }
+
+
+def _routine_action(home_root: Path, *, report_date: str) -> dict:
+    routine = _load_routine_state(home_root)
+    last_run = routine["last_run"] or report_date
+    if routine["enabled"]:
+        context = f"Currently on; last run {last_run}."
+    else:
+        context = f"Currently off; last successful run {last_run}. Turn it on if you want a daily snapshot."
+    return {
+        "verb": "routine",
+        "label": "Check the daily routine",
+        "context": context,
+        "impact": "medium",
+    }
+
+
+def _fallback_next_actions(
+    snapshot: dict, analysis: dict, *, home_root: Path, report_date: str
+) -> list[dict]:
+    actions: list[dict] = []
+
+    draft = _draft_action(analysis)
+    if draft:
+        actions.append(draft)
+
+    cleanup = _cleanup_action(snapshot)
+    if cleanup:
+        actions.append(cleanup)
+
+    actions.append(_routine_action(home_root, report_date=report_date))
+    actions.append(
+        {
+            "verb": "open-report",
+            "label": "Open the full HTML report",
+            "context": "The richer charts and session drill-downs live in the sibling `report.html`.",
+            "impact": None,
+        }
+    )
+    actions.append(
+        {
+            "verb": "defer",
+            "label": "Do nothing — check back tomorrow",
+            "context": "Useful if you only wanted the briefing.",
+            "impact": None,
+        }
+    )
+
+    deduped: list[dict] = []
+    seen_verbs: set[str] = set()
+    for action in actions:
+        verb = action.get("verb")
+        if not verb or verb in seen_verbs:
+            continue
+        seen_verbs.add(verb)
+        deduped.append(action)
+    return deduped[:5]
+
+
 def _fallback_dormant_commentary(snapshot: dict) -> str:
     s = snapshot["stats"]
     dormant = s["installed_count"] - s["active_count"]
@@ -210,7 +373,9 @@ def _fallback_coverage_note(snapshot: dict) -> str:
     return " ".join(parts)
 
 
-def analysis_with_fallbacks(snapshot: dict, analysis: dict | None) -> dict:
+def analysis_with_fallbacks(
+    snapshot: dict, analysis: dict | None, *, home_root: Path, report_date: str
+) -> dict:
     analysis = dict(analysis or {})
     analysis.setdefault("headline", _fallback_headline(snapshot))
     analysis.setdefault(
@@ -219,6 +384,15 @@ def analysis_with_fallbacks(snapshot: dict, analysis: dict | None) -> dict:
     analysis.setdefault("what_stands_out", _fallback_standouts(snapshot))
     analysis.setdefault("dormant_commentary", _fallback_dormant_commentary(snapshot))
     analysis.setdefault("skill_recommendations", _fallback_recommendations(snapshot))
+    analysis.setdefault(
+        "next_actions",
+        _fallback_next_actions(
+            snapshot,
+            analysis,
+            home_root=home_root,
+            report_date=report_date,
+        ),
+    )
     analysis.setdefault("coverage_note", _fallback_coverage_note(snapshot))
     return analysis
 
@@ -228,43 +402,60 @@ def analysis_with_fallbacks(snapshot: dict, analysis: dict | None) -> dict:
 # ---------------------------------------------------------------------------
 
 
-def _md_table_rows(rows: list[list[str]]) -> str:
-    return "\n".join("| " + " | ".join(r) + " |" for r in rows)
+def _markdown_action_lines(actions: list[dict]) -> str:
+    lines = []
+    for idx, action in enumerate(actions, 1):
+        context = action.get("context")
+        line = f"{idx}. {action['label']}"
+        if context:
+            line += f": {context}"
+        lines.append(line)
+    return "\n".join(lines)
 
 
 def render_markdown(snapshot: dict, analysis: dict) -> str:
     tpl = (TEMPLATE_DIR / "report.md.tmpl").read_text(encoding="utf-8")
-    s = snapshot["stats"]
+    stats = snapshot["stats"]
     meta = snapshot["meta"]
 
     generated = datetime.fromisoformat(meta["generated_at"].replace("Z", "+00:00"))
     window_label = f"last {meta['window_days']} days"
+    briefing_strip = _briefing_strip(snapshot)
 
     standouts = (
         "\n".join(f"- {line}" for line in analysis["what_stands_out"]) or "- (no observations)"
     )
 
-    top_rows: list[list[str]] = []
-    for s_row in snapshot.get("top_skills", [])[:6]:
-        summary = s_row["summary"] or "No short description found in the local skill file."
-        top_rows.append(
-            [
-                f"`{s_row['skill']}`",
-                summary.replace("|", "\\|"),
-                str(s_row["runs"]),
-                s_row["last_used"] or "—",
-            ]
-        )
-    top_skills_table = _md_table_rows(top_rows) if top_rows else "| (no active skills) |  |  |  |"
+    next_actions_md = _markdown_action_lines(analysis["next_actions"])
 
-    unused_count = s["installed_count"] - s["active_count"]
-    unused_pct = int(100 * unused_count / s["installed_count"]) if s["installed_count"] else 0
-    dormant_rows: list[list[str]] = []
+    snapshot_md = "\n".join(
+        [
+            f"- Installed skills: {stats['installed_count']}",
+            f"- Active skills: {stats['active_count']}",
+            f"- Skill runs detected: {stats['skill_runs_total']}",
+            f"- Recent sessions scanned: {stats['sessions_total']}",
+            f"- Sessions with skills: {stats['sessions_with_skills']}",
+            f"- Turns scanned: {stats['turns_total']:,}",
+            f"- Token activity (incl. cache): {stats['tokens_total_compact']}",
+        ]
+    )
+
+    top_skill_lines = []
+    for idx, row in enumerate(snapshot.get("top_skills", [])[:6], 1):
+        summary = row["summary"] or "No short description found in the local skill file."
+        top_skill_lines.append(
+            f"{idx}. `{row['skill']}` — {row['runs']} runs, last used {row['last_used'] or '—'}. {summary}"
+        )
+    top_skills_md = "\n".join(top_skill_lines) or "- No active skills in this window."
+
+    unused_count = stats["installed_count"] - stats["active_count"]
+    unused_pct = _pct_int(unused_count, stats["installed_count"])
+    dormant_origin_lines = []
     for origin, names in sorted(
         snapshot.get("dormant_by_origin", {}).items(), key=lambda kv: -len(kv[1])
     ):
-        dormant_rows.append([origin, str(len(names))])
-    dormant_table = _md_table_rows(dormant_rows) if dormant_rows else "| (none) | 0 |"
+        dormant_origin_lines.append(f"- {origin}: {len(names)}")
+    dormant_origins_md = "\n".join(dormant_origin_lines) or "- (none)"
 
     rec_lines = []
     for rec in analysis["skill_recommendations"]:
@@ -277,22 +468,20 @@ def render_markdown(snapshot: dict, analysis: dict) -> str:
 
     out = tpl
     substitutions = {
+        "BRIEFING_STRIP": briefing_strip,
         "WINDOW_LABEL": window_label,
         "GENERATED_AT": generated.strftime("%Y-%m-%d %H:%M UTC"),
         "HEADLINE": analysis["headline"],
-        "INSTALLED_COUNT": s["installed_count"],
-        "ACTIVE_COUNT": s["active_count"],
-        "SKILL_RUNS_TOTAL": s["skill_runs_total"],
-        "SESSIONS_TOTAL": s["sessions_total"],
-        "SESSIONS_WITH_SKILLS": s["sessions_with_skills"],
-        "TURNS_TOTAL": f"{s['turns_total']:,}",
-        "TOKENS_TOTAL_COMPACT": s["tokens_total_compact"],
+        "HEADLINE_SUB": analysis.get("headline_sub", ""),
+        "NEXT_ACTIONS_MD": next_actions_md,
+        "SNAPSHOT_MD": snapshot_md,
         "STANDOUTS_MD": standouts,
-        "TOP_SKILLS_TABLE": top_skills_table,
+        "TOP_SKILLS_MD": top_skills_md,
+        "INSTALLED_COUNT": stats["installed_count"],
         "UNUSED_COUNT": unused_count,
         "UNUSED_PCT": unused_pct,
         "DORMANT_COMMENTARY": analysis["dormant_commentary"],
-        "DORMANT_TABLE": dormant_table,
+        "DORMANT_ORIGINS_MD": dormant_origins_md,
         "RECOMMENDATIONS_MD": recommendations_md,
         "COVERAGE_MD": coverage_md,
     }
@@ -394,6 +583,29 @@ def _origin_slug(origin: str) -> str:
     return re.sub(r"[^a-z0-9]+", "-", origin.lower()).strip("-") or "group"
 
 
+def _html_next_action_label(action: dict) -> str:
+    if action.get("verb") == "open-report":
+        return "Switch to data-junkie mode"
+    return action["label"]
+
+
+def _html_next_action_context(action: dict) -> str:
+    if action.get("verb") == "open-report":
+        return "Charts, filters, and session drill-downs are below."
+    return action.get("context") or ""
+
+
+def _html_inline_code(text: str) -> str:
+    parts = re.split(r"`([^`]+)`", text or "")
+    out = []
+    for idx, part in enumerate(parts):
+        if idx % 2 == 1:
+            out.append(f"<code>{html.escape(part)}</code>")
+        else:
+            out.append(html.escape(part))
+    return "".join(out)
+
+
 def render_html(snapshot: dict, analysis: dict) -> str:
     tpl = (TEMPLATE_DIR / "report.html.tmpl").read_text(encoding="utf-8")
     # Inline CSS from sibling file so edits don't require touching a
@@ -418,6 +630,15 @@ def render_html(snapshot: dict, analysis: dict) -> str:
     standouts_html = "\n".join(
         f"<li>{html.escape(item)}</li>" for item in analysis["what_stands_out"]
     )
+
+    next_actions_html = []
+    for action in analysis["next_actions"]:
+        label = _html_next_action_label(action)
+        context = _html_next_action_context(action)
+        body = f'<span class="next-action-label">{_html_inline_code(label)}</span>'
+        if context:
+            body += f'<span class="next-action-context">{_html_inline_code(context)}</span>'
+        next_actions_html.append(f"<li>{body}</li>")
 
     # Recommendation cards
     rec_cards = []
@@ -665,6 +886,7 @@ def render_html(snapshot: dict, analysis: dict) -> str:
         "FEEDBACK_SUBJECT": feedback_subject_base,
         "HEADLINE": analysis["headline"],
         "HEADLINE_SUB": analysis.get("headline_sub", ""),
+        "NEXT_ACTIONS_HTML": "\n".join(next_actions_html),
         "INSTALLED_COUNT": installed,
         "ACTIVE_COUNT": active,
         "SKILL_RUNS_TOTAL": s["skill_runs_total"],
@@ -801,8 +1023,8 @@ def main() -> int:
     parser.add_argument("--analysis", default=str(DEFAULT_ANALYSIS_PATH))
     parser.add_argument(
         "--home-root",
-        default=str(DEFAULT_HOME_ROOT),
-        help="Root directory for Tinyhat output (default: ~/.claude/tinyhat)",
+        default=None,
+        help="Root directory for Tinyhat output (default: Claude plugin data directory)",
     )
     parser.add_argument(
         "--archive",
@@ -817,8 +1039,10 @@ def main() -> int:
     )
     args = parser.parse_args()
 
+    home_root = resolve_home_root(args.home_root)
+    report_date = datetime.now(_local_tz()).date().isoformat()
+
     if args.index_only:
-        home_root = Path(args.home_root).expanduser()
         (home_root / "archive").mkdir(parents=True, exist_ok=True)
         (home_root / "archive" / "index.html").write_text(render_index(home_root), encoding="utf-8")
         print(f"Wrote {home_root / 'archive' / 'index.html'}", file=sys.stderr)
@@ -843,9 +1067,13 @@ def main() -> int:
                 f"warn: analysis JSON at {analysis_path} is invalid ({exc}); using fallbacks.",
                 file=sys.stderr,
             )
-    analysis = analysis_with_fallbacks(snapshot, analysis_raw)
+    analysis = analysis_with_fallbacks(
+        snapshot,
+        analysis_raw,
+        home_root=home_root,
+        report_date=report_date,
+    )
 
-    home_root = Path(args.home_root).expanduser()
     latest_dir = home_root / "latest"
     latest_dir.mkdir(parents=True, exist_ok=True)
 
@@ -859,7 +1087,7 @@ def main() -> int:
     (latest_dir / "snapshot.json").write_text(snapshot_json, encoding="utf-8")
     (latest_dir / "analysis.json").write_text(analysis_json, encoding="utf-8")
 
-    today = datetime.now(timezone.utc).date().isoformat()
+    today = report_date
     (latest_dir / "run-stamp.txt").write_text(today + "\n", encoding="utf-8")
 
     if args.archive:

--- a/scripts/routine.py
+++ b/scripts/routine.py
@@ -11,7 +11,8 @@ Subcommands:
     routine.py clear-archive  Delete everything under archive/, keep latest/.
     routine.py where          Print the paths Tinyhat reads and writes.
 
-Everything lives under ~/.claude/tinyhat/. No network calls, no daemons.
+Everything lives under Claude Code's plugin data directory. No network
+calls, no daemons.
 The adaptive daily trigger is implemented by having the skill invoke this
 script with `check` on every skill load and firing a background review
 when exit status is 0.
@@ -26,7 +27,7 @@ import sys
 from datetime import datetime, timezone
 from pathlib import Path
 
-DEFAULT_HOME_ROOT = Path.home() / ".claude" / "tinyhat"
+from tinyhat_paths import legacy_home_root, resolve_home_root
 
 
 def _load_routine(root: Path) -> dict:
@@ -135,6 +136,9 @@ def cmd_where(root: Path) -> int:
     print(f"  {root}/latest/run-stamp.txt")
     print(f"  {root}/archive/YYYY-MM-DD/report.{{md,html}}  (up to 31 dated dirs)")
     print(f"  {root}/feedback.jsonl                         (local-only feedback)")
+    legacy = legacy_home_root()
+    if root != legacy:
+        print(f"Legacy path (migrated on first write): {legacy}")
     return 0
 
 
@@ -142,15 +146,15 @@ def main() -> int:
     parser = argparse.ArgumentParser(description="Tinyhat routine state.")
     parser.add_argument(
         "--home-root",
-        default=str(DEFAULT_HOME_ROOT),
-        help="Root directory for Tinyhat state (default: ~/.claude/tinyhat)",
+        default=None,
+        help="Root directory for Tinyhat state (default: Claude plugin data directory)",
     )
     sub = parser.add_subparsers(dest="cmd", required=True)
     for name in ("status", "on", "off", "check", "clear-archive", "where"):
         sub.add_parser(name)
     args = parser.parse_args()
 
-    root = Path(args.home_root).expanduser()
+    root = resolve_home_root(args.home_root)
     commands = {
         "status": cmd_status,
         "on": cmd_on,

--- a/scripts/tinyhat_paths.py
+++ b/scripts/tinyhat_paths.py
@@ -1,0 +1,109 @@
+#!/usr/bin/env python3
+"""Resolve Tinyhat's writable home under Claude Code plugin data."""
+
+from __future__ import annotations
+
+import contextlib
+import json
+import os
+import re
+import shutil
+import sys
+from pathlib import Path
+from typing import TextIO
+
+PLUGIN_ROOT = Path(__file__).resolve().parent.parent
+LEGACY_HOME_ROOT = Path.home() / ".claude" / "tinyhat"
+PLUGIN_DATA_ROOT = Path.home() / ".claude" / "plugins" / "data"
+
+
+def _sanitize_plugin_id(value: str) -> str:
+    slug = re.sub(r"[^A-Za-z0-9_-]+", "-", value).strip("-")
+    return slug or "tinyhat"
+
+
+def _fallback_plugin_id() -> str:
+    manifest_path = PLUGIN_ROOT / ".claude-plugin" / "plugin.json"
+    try:
+        data = json.loads(manifest_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return "tinyhat"
+
+    name = data.get("name")
+    if isinstance(name, str) and name.strip():
+        return _sanitize_plugin_id(name)
+    return "tinyhat"
+
+
+def default_home_root() -> Path:
+    raw = os.getenv("CLAUDE_PLUGIN_DATA")
+    if raw:
+        return Path(raw).expanduser()
+    return PLUGIN_DATA_ROOT / _fallback_plugin_id()
+
+
+def legacy_home_root() -> Path:
+    return LEGACY_HOME_ROOT
+
+
+def _conflict_target(target: Path) -> Path:
+    candidate = target.with_name(f"{target.name}.legacy")
+    idx = 2
+    while candidate.exists():
+        candidate = target.with_name(f"{target.name}.legacy-{idx}")
+        idx += 1
+    return candidate
+
+
+def _merge_tree(src: Path, dst: Path) -> None:
+    dst.mkdir(parents=True, exist_ok=True)
+    for entry in src.iterdir():
+        target = dst / entry.name
+        if not target.exists():
+            shutil.move(str(entry), str(target))
+            continue
+        if entry.is_dir() and target.is_dir():
+            _merge_tree(entry, target)
+            with contextlib.suppress(OSError):
+                entry.rmdir()
+            continue
+        if entry.is_file() and target.is_file():
+            try:
+                if entry.read_bytes() == target.read_bytes():
+                    entry.unlink()
+                    continue
+            except OSError:
+                pass
+        shutil.move(str(entry), str(_conflict_target(target)))
+
+
+def migrate_legacy_home(new_root: Path, *, stderr: TextIO = sys.stderr) -> bool:
+    legacy_root = LEGACY_HOME_ROOT
+    if not legacy_root.exists() or legacy_root == new_root:
+        return False
+
+    new_root.parent.mkdir(parents=True, exist_ok=True)
+    if not new_root.exists():
+        shutil.move(str(legacy_root), str(new_root))
+        print(f"migrated: {legacy_root} -> {new_root}", file=stderr)
+        return True
+
+    _merge_tree(legacy_root, new_root)
+    with contextlib.suppress(OSError):
+        legacy_root.rmdir()
+
+    if legacy_root.exists():
+        print(
+            f"warn: legacy Tinyhat data still exists at {legacy_root}; new writes go to {new_root}.",
+            file=stderr,
+        )
+    else:
+        print(f"migrated: {legacy_root} -> {new_root}", file=stderr)
+    return True
+
+
+def resolve_home_root(home_root: str | Path | None, *, migrate_legacy: bool = True) -> Path:
+    root = default_home_root() if home_root is None else Path(home_root).expanduser()
+    if home_root is None and migrate_legacy:
+        migrate_legacy_home(root)
+    return root

--- a/skills/audit/SKILL.md
+++ b/skills/audit/SKILL.md
@@ -27,8 +27,8 @@ actually worth mentioning.
 
 | `$ARGUMENTS` | What happens |
 |---|---|
-| _(empty)_ | Run the audit, summarise in chat with a link to the HTML. Do **not** auto-open the browser. |
-| `--open` | Also open the HTML in the default browser at the end. |
+| _(empty)_ | Run the audit, write the report, and give the user the terminal briefing with a numbered next-action menu. Do **not** auto-open the browser. |
+| `--open` | Also open the HTML in the default browser at the end, in addition to the terminal briefing. |
 | `--archive` | Also write today's dated archive snapshot. Implies no auto-open — used by the adaptive daily run. |
 
 ## Skill-relative script paths
@@ -36,7 +36,9 @@ actually worth mentioning.
 `${CLAUDE_SKILL_DIR}` is rendered into the skill content before Claude
 runs any Bash blocks. It points at this skill's directory, so reach the
 bundled scripts with `"${CLAUDE_SKILL_DIR}/../../scripts/..."` instead
-of caching shared plugin state under `~/.claude/tinyhat/`.
+of caching shared plugin state under a raw home-directory path. Use
+`${CLAUDE_PLUGIN_DATA}` for any persisted Tinyhat output path you need
+to mention to the user.
 
 ## Load-time daily check (before handling the user's request)
 
@@ -44,13 +46,15 @@ Every time this skill loads, silently check whether today's adaptive
 snapshot should fire. Do not ask the user.
 
 ```!
-python3 "${CLAUDE_SKILL_DIR}/../../scripts/routine.py" check
+python3 "${CLAUDE_SKILL_DIR}/../../scripts/routine.py" check || true
 ```
 
-If exit non-zero, skip — proceed to the user's actual request.
-If exit zero, run the full audit flow with `--archive`, then continue
-to the user's request. Add one short line so the user knows today's
-snapshot refreshed. Never block the user's request on this.
+If the output starts with `skip:`, do nothing and proceed to the user's
+actual request. Do not mention the skipped check.
+If the output starts with `fire:`, run the full audit flow with
+`--archive`, then continue to the user's request. Add one short line
+so the user knows today's snapshot refreshed. Never block the user's
+request on this.
 
 ## The audit flow
 
@@ -78,6 +82,9 @@ read it the first time you run this skill.
   "skill_recommendations": [
     {"name": "...", "confidence": "high|medium|low", "headline": "...", "why": "...", "triggers": ["..."]}
   ],
+  "next_actions": [
+    {"verb": "draft-skill", "label": "Draft `implement-feature`", "context": "...", "impact": "high|medium|low|null"}
+  ],
   "coverage_note": "One paragraph; honest about what was scanned and what's uncertain."
 }
 ```
@@ -94,65 +101,66 @@ read it the first time you run this skill.
 # Default — writes latest/ and archive index; no browser:
 python3 "${CLAUDE_SKILL_DIR}/../../scripts/render_report.py"
 
-# User passed --open — also open the HTML at the end:
-python3 "${CLAUDE_SKILL_DIR}/../../scripts/render_report.py" --open
-
 # User passed --archive (or the adaptive daily fired) — write the
 # dated archive copy too; do NOT open the browser:
 python3 "${CLAUDE_SKILL_DIR}/../../scripts/render_report.py" --archive
 ```
 
-Rendering always writes four files into `~/.claude/tinyhat/latest/`:
+Rendering always writes four files into `${CLAUDE_PLUGIN_DATA}/latest/`:
 
 - `report.html` · `report.md` — the view.
 - `snapshot.json` · `analysis.json` — the data you (or a follow-up
   turn) can read without re-running `gather_snapshot.py`.
 
-The renderer also rewrites `~/.claude/tinyhat/archive/index.html` so
+The renderer also rewrites `${CLAUDE_PLUGIN_DATA}/archive/index.html` so
 the history page always reflects the latest run. When `--archive` is
 passed, the same four files land in `archive/YYYY-MM-DD/`.
 
-### 4. Summarise in chat (always)
+### 4. Give the terminal briefing (always)
 
-Write 2–3 sentences in chat, built directly from the analysis you just
-wrote. The default experience is **terminal-first** — most users won't
-open the HTML unless something in the summary pulls them in.
+Keep it compact and terminal-safe:
 
-Lead with the literal headline number, name the top 2–3 skills from
-`snapshot.top_skills`, and surface one observation from
-`what_stands_out`. End with a clickable file-URL to the full report:
+1. Start with a fenced `text` block containing the two-line percentage
+   strip. Use ASCII only: `#`, `-`, brackets, and plain digits. Do not
+   use ANSI color codes, Unicode block characters, tables, or doughnut
+   metaphors in the chat reply.
+2. Follow with one short sentence that names the headline and one
+   specific observation from `what_stands_out`.
+3. Then show a numbered list of 3–5 concrete next steps from
+   `next_actions`.
+   - Exactly one item should be the defer option.
+   - Exactly one item should be the full-report escape hatch.
+   - Order by impact, not by category.
+4. If the user replies with the number for the full-report action, or
+   asks to see the HTML, open `${CLAUDE_PLUGIN_DATA}/latest/report.html`.
+5. Prefer a plain numbered list over `AskUserQuestion` for now. The
+   list must work cleanly in CLI scrollback, the desktop Code tab, and
+   Cowork.
 
-> Scanned `<INSTALLED_COUNT>` installed skills, `<ACTIVE_COUNT>` active
-> in the last `<WINDOW_DAYS>` days. Top skills: `<skill-a>`, `<skill-b>`,
-> `<skill-c>`.
->
-> What stood out: `<one line from what_stands_out>`.
->
-> Full report: `file:///Users/<you>/.claude/tinyhat/latest/report.html`
-
-See [`references/writing-the-analysis.md`](references/writing-the-analysis.md#chat-summary)
-for the exact shape and examples.
+See [`references/writing-the-analysis.md`](references/writing-the-analysis.md#chat-briefing)
+for the exact shape, examples, and the required `next_actions` classes.
 
 ### 5. Open the HTML (only if `--open` was passed)
 
-Default is **no auto-open**. The chat summary above already surfaces
-the headline; users who want the HTML click the link in the summary.
+Default is **no auto-open**. The terminal briefing above already
+surfaces the headline plus a next-action menu; users who want the HTML
+pick the open-report option from that menu.
 
 When the user passed `--open`, and only then:
 
 ```bash
-open ~/.claude/tinyhat/latest/report.html        # macOS
-xdg-open ~/.claude/tinyhat/latest/report.html    # Linux
-start ~/.claude/tinyhat/latest/report.html       # Windows
+open "${CLAUDE_PLUGIN_DATA}/latest/report.html"        # macOS
+xdg-open "${CLAUDE_PLUGIN_DATA}/latest/report.html"    # Linux
+start "${CLAUDE_PLUGIN_DATA}/latest/report.html"       # Windows
 ```
 
 ## Paths
 
 - Scripts: bundled under `<plugin>/scripts/`, invoked here via `${CLAUDE_SKILL_DIR}/../../scripts/...`
 - Transient: `<tempdir>/tinyhat-snapshot.json`, `<tempdir>/tinyhat-analysis.json`
-- Latest: `~/.claude/tinyhat/latest/report.{md,html}` + `snapshot.json` + `analysis.json` + `run-stamp.txt`
-- Archive: `~/.claude/tinyhat/archive/YYYY-MM-DD/report.{md,html}` + `snapshot.json` + `analysis.json` + `index.html`
-- Routine state: `~/.claude/tinyhat/routine.json`
+- Latest: `${CLAUDE_PLUGIN_DATA}/latest/report.{md,html}` + `snapshot.json` + `analysis.json` + `run-stamp.txt`
+- Archive: `${CLAUDE_PLUGIN_DATA}/archive/YYYY-MM-DD/report.{md,html}` + `snapshot.json` + `analysis.json` + `index.html`
+- Routine state: `${CLAUDE_PLUGIN_DATA}/routine.json`
 
 ## Gotchas
 

--- a/skills/audit/references/writing-the-analysis.md
+++ b/skills/audit/references/writing-the-analysis.md
@@ -110,6 +110,45 @@ Each recommendation:
 If you can't ground a recommendation in evidence, **omit it**. A
 confident two-item list beats a speculative three-item list.
 
+### `next_actions` (3–5 items)
+
+These drive the terminal briefing, the top of `report.md`, and the
+simple-mode action list in `report.html`.
+
+Each action has:
+
+- `verb`: stable machine-ish label such as `draft-skill`, `cleanup`,
+  `routine`, `open-report`, or `defer`.
+- `label`: the imperative action the user sees.
+- `context`: one short evidence-backed sentence. Keep it to one line if
+  possible.
+- `impact`: `high`, `medium`, `low`, or `null`.
+
+Rules of thumb:
+
+- Include **exactly one** `open-report` item.
+- Include **exactly one** `defer` item.
+- Order by impact, not by category.
+- Prefer concrete verbs over topic buckets.
+- If the strongest recommendation is a new skill, that usually belongs
+  first.
+- If plugin-bundled skills dominate the dormant surface, a cleanup
+  action belongs near the top.
+- Ground the routine action in the current state on disk (on/off, last
+  run), not in assumptions.
+
+Example:
+
+- `Draft \`implement-feature\`` — 5 recent sessions leaned hard on Edit
+  + Bash, so the build-fix-verify loop is worth capturing.
+- `Review the 22 dormant plugin skills` — they are the cleanest cleanup
+  targets in this snapshot.
+- `Check the daily routine` — currently on; last run 2026-04-23.
+- `Open the full HTML report` — charts and session drill-downs live in
+  the sibling `report.html`.
+- `Do nothing — check back tomorrow` — useful if the user only wanted
+  the briefing.
+
 ### `coverage_note`
 
 One paragraph. Mention:
@@ -136,47 +175,63 @@ macOS-only."*
 - **Burying the lead.** The two pie charts and hero stats are already
   visible; your `what_stands_out` should add signal the charts can't.
 
-## Chat summary
+## Chat briefing
 
-After the renderer finishes, you write a short summary in chat. That's
-the **terminal-first** default: most users read the summary and stop
-there, so it has to earn the room it takes up.
+After the renderer finishes, you write a compact terminal briefing.
+That's the **terminal-first** default: most users read the briefing
+and stop there, so it has to earn the room it takes up.
 
 ### Shape
 
-Three short paragraphs. No headings, no bullet marathons.
-
-1. **Headline + top skills.** Literal installed/active numbers plus
-   the top 2–3 skills from `snapshot.top_skills`, backticked.
-2. **One standout.** Pick the single sharpest line from
-   `what_stands_out` — the one most likely to make the user lean in.
-   Not all of them, just one.
-3. **Full-report link.** A clickable `file://` URL to
-   `~/.claude/tinyhat/latest/report.html`, absolute path expanded.
+1. **Percentage strip** — fenced `text` block, ASCII only, two lines:
+   - `Skill utilization:    [=========---------]  12%   14 / 121`
+   - `Sessions with skills: [==================-]  26%   14 / 54`
+   Use `=` and `-` for bars (roughly 20 characters wide). No ANSI
+   colors, no Unicode blocks, no tables, no doughnuts.
+2. **One-sentence headline + standout.** Name the headline from
+   `analysis.headline` and pull one line from `what_stands_out`.
+3. **Numbered next-action menu** — 3–5 items straight from
+   `next_actions`. Prefix each with a number so the user can reply
+   with that number. Include the action's `context` as the trailing
+   explanation.
 
 ### Example
 
-> Scanned 121 installed skills, 14 active in the last 30 days. Top
-> skills: `plan-eng-review`, `plan-ceo-review`, `browse`.
+> ```text
+> Skill utilization:    [==----------------]  12%   14 / 121
+> Sessions with skills: [=====-------------]  26%   14 / 54
+> ```
 >
-> What stood out: planning-review skills made up 7 of 17 runs this
-> window — review prep is the strongest single pattern.
+> 121 installed, 14 active this window. What stood out: planning-review
+> skills (plan-eng-review, plan-ceo-review, plan-design-review) made
+> up 7 of 17 runs — review prep is the strongest single pattern.
 >
-> Full report: `file:///Users/you/.claude/tinyhat/latest/report.html`
+> Pick a next step:
+>   1. Draft `implement-feature` — 4,443 combined Edit+Bash calls across 54 sessions would have benefited.
+>   2. Review the 29 dormant plugin-bundled skills — cleanest cleanup targets in this snapshot.
+>   3. Check the daily routine — currently on; last run 2026-04-23.
+>   4. Open the full HTML report for charts and session drill-downs.
+>   5. Do nothing — check back tomorrow.
+>
+> Reply with a number or the natural-language form.
 
 ### Rules
 
-- **Never re-run `gather_snapshot.py` to write this summary.** Read
-  what you already produced — `stats`, `top_skills`, and
-  `what_stands_out` are all in the snapshot and analysis JSON you just
-  wrote.
-- **Expand the `~/` to an absolute path** in the `file://` URL so it's
-  clickable in the terminal. `echo $HOME` if you need to.
-- **Don't add a fourth paragraph.** No "want me to open it?" follow-up
-  — a link is enough. If the user wants to dig in they'll say so.
-- **Skip the chat summary only when `--archive` is set without user
-  interaction** (the adaptive daily run) — it's background work;
-  surfacing it would be noise.
+- **Never re-run `gather_snapshot.py` to write this briefing.** Read
+  what you already produced — `stats`, `top_skills`, `what_stands_out`,
+  and `next_actions` are all in the snapshot and analysis JSON.
+- **Use literal numbers from `snapshot.stats`.** Don't paraphrase
+  counts.
+- **Skip the briefing only when `--archive` fires non-interactively**
+  (the adaptive daily run) — it's background work; surfacing it would
+  be noise.
+- **When the user replies with a number**, map it back to the
+  corresponding `next_actions[i].verb` and act:
+  - `open-report` → open `${CLAUDE_PLUGIN_DATA}/latest/report.html`.
+  - `draft-skill` → hand off to the skill-drafting flow.
+  - `cleanup` → list the dormant skills and help the user pick.
+  - `routine` → invoke `/tinyhat:routine` sub-commands.
+  - `defer` → say "ok" and stop.
 
 ## How the rendering works
 
@@ -185,6 +240,11 @@ analysis strings. If a key in your analysis JSON is missing, the
 renderer falls back to a Python-derived default. That default is
 safe but generic — which is exactly what this skill is trying to avoid.
 Fill every field.
+
+The terminal briefing at the end of the skill mirrors the same
+`next_actions` and the same two-percentage strip as the top of
+`report.md`, but the chat-side strip is rendered by the skill (from
+`snapshot.stats`), not by `analysis.json`.
 
 The renderer also writes `snapshot.json` and `analysis.json` next to
 the HTML in both `latest/` and (when `--archive`) `archive/YYYY-MM-DD/`.

--- a/skills/audit/templates/report.css
+++ b/skills/audit/templates/report.css
@@ -66,6 +66,13 @@ body.mode-details .mode-btn[data-mode="details"] { background: linear-gradient(1
 .pie-copy h3 { margin: 0 0 6px; }
 .pie-copy p { margin: 0; color: var(--muted); font-size: 0.9rem; }
 
+.next-actions { padding: 20px 22px; border: 1px solid var(--border); border-radius: 18px; background: rgba(255, 255, 255, 0.72); box-shadow: var(--shadow); }
+.next-actions h2 { margin-bottom: 10px; }
+.next-action-list { margin: 0; padding-left: 1.35rem; display: grid; gap: 10px; }
+.next-action-list li { padding-left: 4px; line-height: 1.5; }
+.next-action-label { display: block; font-weight: 700; }
+.next-action-context { display: block; color: var(--muted); font-size: 0.92rem; }
+
 section { margin-top: 30px; }
 h2 { margin: 0 0 14px; font-size: 1.4rem; font-family: "Iowan Old Style", "Palatino Linotype", Georgia, serif; }
 h3 { margin: 0; font-size: 1.1rem; }

--- a/skills/audit/templates/report.html.tmpl
+++ b/skills/audit/templates/report.html.tmpl
@@ -47,6 +47,12 @@
     </div>
   </section>
 
+  <section class="main-only next-actions">
+    <div class="kicker">Pick a next step</div>
+    <h2>What to do next</h2>
+    <ol class="next-action-list">{{NEXT_ACTIONS_HTML}}</ol>
+  </section>
+
   <section class="details-only hero">
     <h2 class="hero-headline">{{HEADLINE}}</h2>
     <p class="small">{{HEADLINE_SUB}}</p>
@@ -71,22 +77,9 @@
   </section>
 
   <section>
-    <div class="kicker">Action · 2 of 2 · Recommended skills</div>
+    <div class="kicker">Recommended skills</div>
     <h2>What to create next</h2>
     <div class="recommend-grid">{{RECOMMENDATION_CARDS}}</div>
-  </section>
-
-  <!-- OVERVIEW-MODE-ONLY -->
-  <section class="main-only">
-    <div class="kicker">Action · 1 of 2 · Clean up</div>
-    <div class="action-card" onclick="setMode('details'); setTimeout(()=>document.getElementById('dormant-section').scrollIntoView({behavior:'smooth'}), 100);">
-      <div class="action-card-icon">🧹</div>
-      <div class="action-card-body">
-        <h3>{{UNUSED_COUNT}} of {{INSTALLED_COUNT}} installed skills look dormant</h3>
-        <p>Review the ones you installed, never used, and can retire.</p>
-      </div>
-      <div class="action-card-cta">Review dormant skills →</div>
-    </div>
   </section>
 
   <div class="main-only mode-cta">

--- a/skills/audit/templates/report.md.tmpl
+++ b/skills/audit/templates/report.md.tmpl
@@ -1,23 +1,22 @@
 # Skill Value Review
 
+```text
+{{BRIEFING_STRIP}}
+```
+
 **Window:** {{WINDOW_LABEL}}
 **Generated:** {{GENERATED_AT}}
 
 > {{HEADLINE}}
+> {{HEADLINE_SUB}}
 
----
+## What to do next
+
+{{NEXT_ACTIONS_MD}}
 
 ## Snapshot
 
-| Metric | Value |
-|---|---:|
-| Installed skills | {{INSTALLED_COUNT}} |
-| Active skills | {{ACTIVE_COUNT}} |
-| Skill runs detected | {{SKILL_RUNS_TOTAL}} |
-| Recent sessions scanned | {{SESSIONS_TOTAL}} |
-| Sessions with skills | {{SESSIONS_WITH_SKILLS}} |
-| Turns scanned | {{TURNS_TOTAL}} |
-| Token activity (incl. cache) | {{TOKENS_TOTAL_COMPACT}} |
+{{SNAPSHOT_MD}}
 
 ## What stands out
 
@@ -25,19 +24,16 @@
 
 ## Top skills
 
-| Skill | What it does | Runs | Last used |
-|---|---|---:|---|
-{{TOP_SKILLS_TABLE}}
+{{TOP_SKILLS_MD}}
 
 ## Dormant surface
 
-- {{UNUSED_COUNT}} of {{INSTALLED_COUNT}} installed skills showed no detected use in this window ({{UNUSED_PCT}}%).
+- {{UNUSED_COUNT}} of {{INSTALLED_COUNT}} installed skills look dormant ({{UNUSED_PCT}}%).
+- {{DORMANT_COMMENTARY}}
 
-{{DORMANT_COMMENTARY}}
+## Dormant by origin
 
-| Source | Unused skills |
-|---|---:|
-{{DORMANT_TABLE}}
+{{DORMANT_ORIGINS_MD}}
 
 ## Skill recommendations
 
@@ -46,5 +42,3 @@
 ## Coverage
 
 {{COVERAGE_MD}}
-
-> Open the HTML snapshot for the doughnut charts, activity patterns, and expandable session details.

--- a/skills/history/SKILL.md
+++ b/skills/history/SKILL.md
@@ -5,9 +5,13 @@ allowed-tools: Bash(open *) Bash(xdg-open *) Bash(start *) Bash(python3 *) Read
 
 # tinyhat:history — browse all skill-audit reports
 
-Open `~/.claude/tinyhat/archive/index.html`. That page lists the
+Open `${CLAUDE_PLUGIN_DATA}/archive/index.html`. That page lists the
 latest report plus every dated archive snapshot (up to 31) with
 one-click links. Each entry opens its own `report.html`.
+
+If the new plugin-data path is empty but the legacy path
+`~/.claude/tinyhat/archive/index.html` exists, use the legacy path for
+this browse. The next write-capable Tinyhat command will migrate it.
 
 ## Skill-relative script path
 
@@ -17,8 +21,9 @@ of Tinyhat that loaded this skill.
 
 ## Flow
 
-1. Check whether `~/.claude/tinyhat/archive/index.html` exists.
-   - If missing but `~/.claude/tinyhat/latest/report.html` exists,
+1. Check whether `${CLAUDE_PLUGIN_DATA}/archive/index.html` exists.
+   - If it doesn't, check `~/.claude/tinyhat/archive/index.html`.
+   - If the new path is missing but `${CLAUDE_PLUGIN_DATA}/latest/report.html` exists,
      regenerate the index without running a new audit:
      ```bash
      python3 "${CLAUDE_SKILL_DIR}/../../scripts/render_report.py" --index-only
@@ -28,9 +33,9 @@ of Tinyhat that loaded this skill.
 2. Open the index:
 
 ```bash
-open ~/.claude/tinyhat/archive/index.html        # macOS
-xdg-open ~/.claude/tinyhat/archive/index.html    # Linux
-start ~/.claude/tinyhat/archive/index.html       # Windows
+open "${CLAUDE_PLUGIN_DATA}/archive/index.html"        # macOS
+xdg-open "${CLAUDE_PLUGIN_DATA}/archive/index.html"    # Linux
+start "${CLAUDE_PLUGIN_DATA}/archive/index.html"       # Windows
 ```
 
 3. In one sentence, note how many dated snapshots are listed.

--- a/skills/open/SKILL.md
+++ b/skills/open/SKILL.md
@@ -8,12 +8,20 @@ allowed-tools: Bash(open *) Bash(xdg-open *) Bash(start *) Bash(python3 *) Read
 Two jobs, decided by what the user actually asked for:
 
 1. **Answer a specific question about the last audit** — read the
-   persisted JSONs at `~/.claude/tinyhat/latest/{snapshot,analysis}.json`
+   persisted JSONs at `${CLAUDE_PLUGIN_DATA}/latest/{snapshot,analysis}.json`
    and reply in chat. No browser.
 2. **Open the HTML report as-is** — when the user just wants to see it.
 
 **Never regenerate.** That's `/tinyhat:audit`'s job. The agent analysis
 step is non-trivial and the user may not want to spend the turns.
+
+## Where the data lives
+
+Tinyhat writes under `${CLAUDE_PLUGIN_DATA}` (the Claude-Code-sanctioned
+per-plugin data directory). Older installs may still have artefacts
+under the legacy `~/.claude/tinyhat/` — fall back to it only if the new
+path is empty. The next write-capable Tinyhat command will migrate the
+legacy directory forward.
 
 ## Decide which job you're doing
 
@@ -32,15 +40,17 @@ moves it away.
 
 ## Job 1 — answer from JSON
 
-1. Check `~/.claude/tinyhat/latest/analysis.json` and
-   `~/.claude/tinyhat/latest/snapshot.json` both exist.
+1. Find the latest directory: prefer `${CLAUDE_PLUGIN_DATA}/latest/`,
+   fall back to `~/.claude/tinyhat/latest/` only if the first is empty.
+2. Check that `analysis.json` and `snapshot.json` both exist in that
+   directory.
    - If missing, say "I don't have a saved audit to read from — let me
      run a fresh one" and hand off to `/tinyhat:audit`. Stop.
-2. Read one or both JSONs with the Read tool. Prefer `analysis.json`
+3. Read one or both JSONs with the Read tool. Prefer `analysis.json`
    for editorial questions (*"what stood out?"*, *"what did you
    recommend?"*) and `snapshot.json` for factual questions (*"which
    skills did I use?"*, *"how many sessions?"*).
-3. Answer in chat. Cite specific numbers/skills from the JSON. Name
+4. Answer in chat. Cite specific numbers/skills from the JSON. Name
    the date the audit ran (`run-stamp.txt`). End with one line the
    user can act on — usually a `file://` link to the full HTML if
    they want more detail.
@@ -50,7 +60,7 @@ moves it away.
 > From your 2026-04-23 audit: 107 of 121 installed skills were dormant
 > — the bulk (82) are plugin-bundled skills that came with
 > marketplaces you installed. Open the full report at
-> `file:///Users/you/.claude/tinyhat/latest/report.html` to see them
+> `file://${CLAUDE_PLUGIN_DATA}/latest/report.html` to see them
 > grouped by origin.
 
 ### Rules
@@ -65,25 +75,27 @@ moves it away.
 
 ## Job 2 — open the HTML
 
-1. Check whether `~/.claude/tinyhat/latest/report.html` exists.
-   - If missing, tell the user "No skill-audit report yet — let me
+1. Check whether `${CLAUDE_PLUGIN_DATA}/latest/report.html` exists.
+   - If it does, use it.
+   - If it doesn't, check `~/.claude/tinyhat/latest/report.html`.
+   - If neither exists, tell the user "No skill-audit report yet — let me
      create your first one" and hand off to `/tinyhat:audit`.
      Stop here; don't try to open nothing.
 2. Open the file with the platform-appropriate command:
 
 ```bash
-open ~/.claude/tinyhat/latest/report.html        # macOS
-xdg-open ~/.claude/tinyhat/latest/report.html    # Linux
-start ~/.claude/tinyhat/latest/report.html       # Windows
+open "${CLAUDE_PLUGIN_DATA}/latest/report.html"        # macOS
+xdg-open "${CLAUDE_PLUGIN_DATA}/latest/report.html"    # Linux
+start "${CLAUDE_PLUGIN_DATA}/latest/report.html"       # Windows
 ```
 
 If unsure which OS, use Python's `webbrowser` module (cross-platform):
 
 ```bash
-python3 -c "import webbrowser, pathlib; webbrowser.open(pathlib.Path('~/.claude/tinyhat/latest/report.html').expanduser().as_uri())"
+python3 -c "import os, webbrowser, pathlib; webbrowser.open(pathlib.Path(os.environ['CLAUDE_PLUGIN_DATA'], 'latest', 'report.html').as_uri())"
 ```
 
 3. In one short sentence, tell the user what they're looking at — the
-   date from `~/.claude/tinyhat/latest/run-stamp.txt` is enough:
+   date from `${CLAUDE_PLUGIN_DATA}/latest/run-stamp.txt` is enough:
    *"Opened your most recent skill-audit report from 2026-04-23. Use
    `/tinyhat:audit` to refresh."*

--- a/skills/routine/SKILL.md
+++ b/skills/routine/SKILL.md
@@ -9,7 +9,7 @@ allowed-tools: Bash(python3 *) Read
 All routine-related admin: check whether the adaptive daily auto-run
 is on, toggle it, print the paths Tinyhat reads and writes, or wipe
 the dated-archive directory. State lives in
-`~/.claude/tinyhat/routine.json`.
+`${CLAUDE_PLUGIN_DATA}/routine.json`.
 
 ## Sub-commands (dispatch on `$ARGUMENTS`)
 
@@ -57,7 +57,7 @@ python3 "${CLAUDE_SKILL_DIR}/../../scripts/routine.py" where
 
 Prints the list of sources Tinyhat reads (transcripts, inventory,
 optional telemetry) and the paths it writes (under
-`~/.claude/tinyhat/`). Use this when a user asks where their data is
+`${CLAUDE_PLUGIN_DATA}/`). Use this when a user asks where their data is
 or wants to tail a file.
 
 ### clear


### PR DESCRIPTION
## Summary
Fixes the first-run Tinyhat audit experience by moving persisted output into Claude Code's plugin data directory, migrating legacy `~/.claude/tinyhat/` data forward, and reshaping the generated report around a terminal-safe briefing plus explicit next actions. It also updates the Tinyhat skills and docs to match the new storage path and worktree-safe guidance.

## Linked issue
Closes #47
Refs #48

## Type of change
- [x] `fix` — bug fix
- [ ] `docs` — documentation only
- [ ] `refactor` — no behavior change
- [ ] `test` — tests only
- [ ] `chore` / `ci` / `build` — tooling
- [ ] Breaking change (requires `!` in the type or a `BREAKING CHANGE:` footer)

## Testing performed
- [x] Ran `python3 scripts/gather_snapshot.py --output /tmp/tinyhat-snapshot-47.json` successfully
- [x] Ran `python3 scripts/render_report.py --snapshot /tmp/tinyhat-snapshot-47.json --analysis /tmp/does-not-exist.json --home-root /tmp/tinyhat-report-47b --archive` successfully
- [x] Exercised the plugin via `claude --plugin-dir "$(pwd)"`
- [x] `ruff check .` and `ruff format --check .` pass
- [x] Added / updated tests where applicable
- [x] Ran `python3 -m py_compile scripts/render_report.py scripts/routine.py scripts/tinyhat_paths.py` successfully
- [x] Ran `git diff --check` successfully
- [x] Verified legacy-home migration with a temporary `$HOME` smoke test

## Screenshots (if UI)
Not included.

## Checklist
- [x] PR title is a Conventional Commit (e.g. `feat(skills): …`, `fix: …`)
- [x] Linked to an issue (`Closes #…`) or this PR is the canonical spec
- [x] Tests added or updated (or this PR is docs/chore only)
- [x] Docs updated where behavior changed
- [x] CI is green
- [x] No references to private maintainer resources (see [AGENTS.md](../AGENTS.md#local-override-files))
- [x] I will not self-merge

---

<details>
<summary>Agent checklist (only if a bot opened this PR)</summary>

- [x] Commits signed with the bot's SSH key and identity — see [`commit` skill](../.claude/skills/commit/SKILL.md).
- [x] Branch named `<agent>/<short-topic>`.

</details>
