### PR TITLE
feat(dev): add internal dev-reset skill for fresh first-run testing

### DIFF
--- a/.claude/skills/dev-reset/SKILL.md
+++ b/.claude/skills/dev-reset/SKILL.md
@@ -1,0 +1,100 @@
+---
+name: dev-reset
+description: INTERNAL DEV ONLY — wipe every byte Tinyhat wrote on this machine so the maintainer can smoke-test a clean first-run install. Repo-scoped, never shipped to end users. Triggers on "reset tinyhat state", "reset my tinyhat for a fresh test", "wipe tinyhat", "pretend I've never installed tinyhat", or explicit `/tinyhat:dev:reset` / `/dev-reset` invocations. Do NOT invoke this on intent like "clean up my skills" (that's `/tinyhat:audit`).
+argument-hint: [--full]
+allowed-tools: Bash(python3 *)
+---
+
+# dev-reset — wipe Tinyhat state for a clean first-run test
+
+**INTERNAL DEV ONLY.** This skill exists solely to let the maintainer
+(or an agent on the maintainer's machine) put the local plugin state
+back to "never installed" so the next `/plugin install` + `/reload-plugins`
+cycle is the real new-user experience. It must never be packaged in the
+marketplace manifest — see [issue #55](https://github.com/tinyhat-ai/tinyhat/issues/55).
+
+If the user's intent is anything other than "I'm smoke-testing the
+first-run experience", **stop and ask** before running. Everyday
+sentences like "clean up my skills" route to `/tinyhat:audit`, not to
+this skill.
+
+## Two levels
+
+| `$ARGUMENTS` | What happens |
+|---|---|
+| _(empty)_ | **Scoped reset.** Wipes plugin data, cache, install manifests, legacy path, temp snapshot/analysis, and tinyhat entries from `installed_plugins.json`. Leaves marketplace registration intact so `/plugin install tinyhat@tinyloop` works immediately. |
+| `--full` | **Nuclear reset.** Also removes the `tinyloop` entry from `known_marketplaces.json` and the cloned marketplace source under `~/.claude/plugins/marketplaces/tinyloop/`. Next run has to re-add the marketplace via `/plugin marketplace add tinyhat-ai/tinyhat`. |
+
+## Flow
+
+1. **Preview.** Always run the dry-run first so the user sees the list
+   of targets before anything is deleted:
+
+   ```!
+   python3 "${CLAUDE_PROJECT_DIR}/scripts/dev_reset.py"
+   ```
+
+   For `--full`, append the flag:
+
+   ```!
+   python3 "${CLAUDE_PROJECT_DIR}/scripts/dev_reset.py" --full
+   ```
+
+2. **Confirm.** Summarize what would be removed in one or two sentences
+   and ask the user to confirm. Do not proceed on a plain "go ahead" if
+   you've also just asked an unrelated yes/no question.
+
+3. **Commit.** After explicit confirmation, add `--commit`:
+
+   ```!
+   python3 "${CLAUDE_PROJECT_DIR}/scripts/dev_reset.py" --commit
+   ```
+
+   or, for the nuclear path:
+
+   ```!
+   python3 "${CLAUDE_PROJECT_DIR}/scripts/dev_reset.py" --commit --full
+   ```
+
+4. **Report.** The script prints `removed …` lines plus a `kept (by
+   design):` block. Repeat that in chat so the user sees what stayed
+   and why (especially `~/.claude/projects/` — session transcripts).
+
+## Already-clean path
+
+If the script prints `tinyhat dev reset: already clean.`, stop there.
+Don't run `--commit`; there's nothing to commit. Tell the user plainly:
+their machine is already in the first-run state. If the user asked for
+`--full`, the scoped check runs at the same time, so "already clean"
+covers both.
+
+## What must not happen
+
+- **Never** touch `~/.claude/projects/`, `~/.claude/rc-dashboard/`, any
+  unrelated plugin's data, or files under `~/.claude/plugins/` for
+  other plugins. The script already respects this; don't add
+  post-processing that widens the blast radius.
+- **Never** invoke this skill in automated agent workflows that aren't
+  on the maintainer's machine. It's a local dev aid.
+- **Never** promote this skill to `skills/` (the packaged plugin path)
+  or add it to `.claude-plugin/plugin.json` / `marketplace.json`. CI
+  has a guard that fails the build if you do.
+
+## Why the path is `${CLAUDE_PROJECT_DIR}`, not `${CLAUDE_PLUGIN_ROOT}`
+
+This skill is repo-scoped (`.claude/skills/`), not plugin-scoped
+(`skills/`). `${CLAUDE_PLUGIN_ROOT}` is empty here because the skill
+is not loaded as part of a plugin — it's loaded because Claude Code
+reads `.claude/` in the current project. `${CLAUDE_PROJECT_DIR}` points
+at the repo root, which is where `scripts/dev_reset.py` lives.
+
+## After the reset
+
+To actually test the first-run flow once state is clean:
+
+```
+/plugin marketplace add tinyhat-ai/tinyhat   # only needed after --full
+/plugin install tinyhat@tinyloop
+/reload-plugins
+/tinyhat:audit
+```

--- a/.github/scripts/check_packaging.sh
+++ b/.github/scripts/check_packaging.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# Fails CI if dev-only assets (the dev-reset skill, its helper script) leak
+# into the paths a `/plugin install` would expose to end users. See #55.
+#
+# The rules we enforce:
+#
+#   1. `skills/dev-reset/` must not exist — plugin-scoped skills live under
+#      `skills/`; the dev-reset skill is repo-scoped and belongs under
+#      `.claude/skills/dev-reset/`.
+#   2. No file under `skills/` or `.claude-plugin/` may reference the
+#      dev-reset helper script by name.
+#   3. The repo-scoped SKILL.md must exist and its description must start
+#      with "INTERNAL DEV ONLY" so any skill listing makes the intent
+#      obvious.
+#   4. The helper script must exist (otherwise the skill is broken).
+#
+# Keep this script dependency-free so it runs identically on any Ubuntu or
+# macOS GitHub runner without extra setup.
+
+set -euo pipefail
+
+fail() {
+  echo "packaging-guard: $*" >&2
+  exit 1
+}
+
+# 1. Plugin-scoped path must not hold the dev-reset skill.
+if [[ -e skills/dev-reset ]]; then
+  fail "skills/dev-reset/ must not exist — move it to .claude/skills/dev-reset/"
+fi
+
+# 2. Packaged plugin files must not mention the dev-reset helper.
+if grep -r -l -E 'dev[-_]reset' skills/ .claude-plugin/ 2>/dev/null; then
+  fail "packaged plugin files above reference dev-reset — must be repo-scoped only"
+fi
+
+# 3. Repo-scoped SKILL.md exists and advertises its intent.
+skill_md=".claude/skills/dev-reset/SKILL.md"
+[[ -f "$skill_md" ]] || fail "$skill_md is missing"
+if ! grep -qE '^description: INTERNAL DEV ONLY' "$skill_md"; then
+  fail "$skill_md frontmatter description must start with 'INTERNAL DEV ONLY'"
+fi
+
+# 4. Helper script exists.
+[[ -f scripts/dev_reset.py ]] || fail "scripts/dev_reset.py is missing"
+
+echo "packaging-guard: ok"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,15 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  packaging-guard:
+    name: packaging-guard
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Dev-only assets must not be in the packaged plugin
+        run: bash .github/scripts/check_packaging.sh
+
   lint:
     name: lint
     runs-on: ubuntu-latest

--- a/docs/local-development.md
+++ b/docs/local-development.md
@@ -108,18 +108,28 @@ This re-reads `SKILL.md` files and re-registers the skills. Python scripts are r
 
 ### Reset state between tests
 
-Tinyhat's state is two things: the output directory and the temp files.
+Tinyhat writes to several places across `~/.claude/plugins/` (data, cache, install manifest, installed-plugins registry), the legacy `~/.claude/tinyhat/` home, and two transient files in `<tempdir>/`. A missed path silently invalidates a first-run test, so the repo ships an internal skill that wipes every Tinyhat byte on the machine and nothing else:
 
-```bash
-# Wipe everything the plugin has written:
-rm -rf ~/.claude/plugins/data/tinyhat
-
-# Wipe the transient snapshot + analysis so the next run starts clean:
-rm -f "$(python3 -c 'import tempfile; print(tempfile.gettempdir())')/tinyhat-snapshot.json"
-rm -f "$(python3 -c 'import tempfile; print(tempfile.gettempdir())')/tinyhat-analysis.json"
+```text
+/tinyhat:dev:reset
 ```
 
-The plugin recreates `~/.claude/plugins/data/tinyhat/` on the next run. Nothing else on your system is touched.
+or in natural language: *"reset my tinyhat state so I can test a fresh first-run."*
+
+The skill lives at `.claude/skills/dev-reset/SKILL.md` — it's repo-scoped and never packaged with the plugin. You can also drive the helper script directly:
+
+```bash
+# Dry-run (prints what would be removed):
+python3 scripts/dev_reset.py
+
+# Actually remove:
+python3 scripts/dev_reset.py --commit
+
+# Full nuclear reset (also removes marketplace registration):
+python3 scripts/dev_reset.py --commit --full
+```
+
+The scoped reset leaves `~/.claude/plugins/known_marketplaces.json` alone so `/plugin install tinyhat@tinyloop` works on the next run without re-adding the marketplace. Use `--full` when you're testing the `/plugin marketplace add` step too. Either mode leaves `~/.claude/projects/` (session transcripts), `~/.claude/rc-dashboard/` (unrelated logs), and every other plugin's data untouched.
 
 ---
 

--- a/scripts/dev_reset.py
+++ b/scripts/dev_reset.py
@@ -1,0 +1,374 @@
+#!/usr/bin/env python3
+"""INTERNAL DEV ONLY — wipe Tinyhat state for a fresh first-run test.
+
+Removes every byte the Tinyhat plugin wrote on the local machine, plus every
+registration of the plugin, so the next `/plugin install` cycle is the real
+new-user path. Must not be shipped to end users — see issue #55.
+
+Default is dry-run. Pass --commit to actually remove. Pass --full to also
+remove our marketplace registration (the true pre-onboarding state).
+
+Targets:
+    ~/.claude/plugins/data/tinyhat*                       plugin-data dirs
+    ~/.claude/plugins/.install-manifests/tinyhat@*.json   install manifests
+    ~/.claude/plugins/cache/<marketplace>/tinyhat/        per-marketplace cache
+    ~/.claude/tinyhat/                                    legacy pre-#49 home
+    <tempdir>/tinyhat-snapshot.json, tinyhat-analysis.json  pipeline hand-off
+    ~/.claude/plugins/installed_plugins.json              entries keyed tinyhat@*
+    ~/.claude/plugins/known_marketplaces.json             tinyloop entry (--full)
+    ~/.claude/plugins/marketplaces/<ours>/                cloned market (--full)
+
+Never touches: ~/.claude/projects/, ~/.claude/rc-dashboard/, the checked-out
+tinyhat repo, other plugins' data, or the CLAUDE_PLUGIN_DATA env var.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import shutil
+import sys
+import tempfile
+from pathlib import Path
+
+HOME = Path.home()
+CLAUDE_ROOT = HOME / ".claude"
+PLUGINS_ROOT = CLAUDE_ROOT / "plugins"
+
+# Keys in known_marketplaces.json that identify "our" marketplace. The
+# marketplace's declared name is "tinyloop"; the repo behind it is
+# tinyhat-ai/tinyhat. Either signal is enough.
+OUR_MARKETPLACE_NAMES = {"tinyloop"}
+OUR_MARKETPLACE_REPOS = {"tinyhat-ai/tinyhat"}
+
+
+class Target:
+    __slots__ = ("kind", "path", "detail", "gated")
+
+    def __init__(self, kind: str, path: Path, detail: str = "", *, gated: bool = False):
+        self.kind = kind
+        self.path = path
+        self.detail = detail
+        self.gated = gated
+
+    def describe(self) -> str:
+        suffix = f" ({self.detail})" if self.detail else ""
+        return f"[{self.kind}] {self.path}{suffix}"
+
+
+def _glob(parent: Path, pattern: str) -> list[Path]:
+    if not parent.is_dir():
+        return []
+    return sorted(parent.glob(pattern))
+
+
+def _enumerate_plugin_data() -> list[Target]:
+    # Both "tinyhat" and any legacy split-brain names like "tinyhat@tinyloop".
+    parent = PLUGINS_ROOT / "data"
+    return [Target("data-dir", p) for p in _glob(parent, "tinyhat*")]
+
+
+def _enumerate_install_manifests() -> list[Target]:
+    parent = PLUGINS_ROOT / ".install-manifests"
+    return [Target("install-manifest", p) for p in _glob(parent, "tinyhat@*.json")]
+
+
+def _enumerate_cache() -> list[Target]:
+    # Layout: ~/.claude/plugins/cache/<marketplace>/tinyhat/
+    cache_root = PLUGINS_ROOT / "cache"
+    if not cache_root.is_dir():
+        return []
+    out: list[Target] = []
+    for marketplace_dir in sorted(cache_root.iterdir()):
+        if not marketplace_dir.is_dir():
+            continue
+        candidate = marketplace_dir / "tinyhat"
+        if candidate.exists():
+            out.append(Target("cache", candidate, detail=f"marketplace={marketplace_dir.name}"))
+    return out
+
+
+def _enumerate_legacy_home() -> list[Target]:
+    legacy = CLAUDE_ROOT / "tinyhat"
+    return [Target("legacy-home", legacy)] if legacy.exists() else []
+
+
+def _enumerate_temp_files() -> list[Target]:
+    tmp = Path(tempfile.gettempdir())
+    names = ("tinyhat-snapshot.json", "tinyhat-analysis.json")
+    return [Target("temp-file", tmp / n) for n in names if (tmp / n).exists()]
+
+
+def _enumerate_installed_plugins_entries() -> list[Target]:
+    # Keyed removal — we rewrite the file, we don't delete it.
+    path = PLUGINS_ROOT / "installed_plugins.json"
+    if not path.is_file():
+        return []
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return []
+    plugins = data.get("plugins")
+    if not isinstance(plugins, dict):
+        return []
+    out: list[Target] = []
+    for key in sorted(plugins):
+        if isinstance(key, str) and key.startswith("tinyhat@"):
+            out.append(Target("installed-plugins-entry", path, detail=f"key={key}"))
+    return out
+
+
+def _marketplace_is_ours(name: str, entry: dict) -> bool:
+    if name in OUR_MARKETPLACE_NAMES:
+        return True
+    source = entry.get("source") if isinstance(entry, dict) else None
+    if isinstance(source, dict):
+        repo = source.get("repo")
+        if isinstance(repo, str) and repo in OUR_MARKETPLACE_REPOS:
+            return True
+    return False
+
+
+def _enumerate_marketplace_registrations() -> list[Target]:
+    out: list[Target] = []
+    path = PLUGINS_ROOT / "known_marketplaces.json"
+    if path.is_file():
+        try:
+            data = json.loads(path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            data = {}
+        if isinstance(data, dict):
+            for name, entry in sorted(data.items()):
+                if _marketplace_is_ours(name, entry):
+                    out.append(
+                        Target(
+                            "marketplace-registration",
+                            path,
+                            detail=f"key={name}",
+                            gated=True,
+                        )
+                    )
+    # Cloned marketplace source on disk.
+    market_dir = PLUGINS_ROOT / "marketplaces"
+    if market_dir.is_dir():
+        for child in sorted(market_dir.iterdir()):
+            if child.is_dir() and child.name in OUR_MARKETPLACE_NAMES:
+                out.append(Target("marketplace-clone", child, gated=True))
+    return out
+
+
+def enumerate_all(*, include_full: bool) -> list[Target]:
+    targets: list[Target] = []
+    targets += _enumerate_plugin_data()
+    targets += _enumerate_install_manifests()
+    targets += _enumerate_cache()
+    targets += _enumerate_legacy_home()
+    targets += _enumerate_temp_files()
+    targets += _enumerate_installed_plugins_entries()
+    if include_full:
+        targets += _enumerate_marketplace_registrations()
+    return targets
+
+
+def _remove_fs_target(target: Target) -> None:
+    p = target.path
+    if p.is_dir() and not p.is_symlink():
+        shutil.rmtree(p)
+    else:
+        p.unlink(missing_ok=True)
+
+
+def _rewrite_installed_plugins(keys_to_drop: set[str]) -> list[str]:
+    path = PLUGINS_ROOT / "installed_plugins.json"
+    data = json.loads(path.read_text(encoding="utf-8"))
+    plugins = data.get("plugins") or {}
+    dropped = [k for k in plugins if k in keys_to_drop]
+    for k in dropped:
+        plugins.pop(k, None)
+    data["plugins"] = plugins
+    path.write_text(json.dumps(data, indent=2) + "\n", encoding="utf-8")
+    return dropped
+
+
+def _rewrite_known_marketplaces(names_to_drop: set[str]) -> list[str]:
+    path = PLUGINS_ROOT / "known_marketplaces.json"
+    data = json.loads(path.read_text(encoding="utf-8"))
+    dropped = [name for name in list(data) if name in names_to_drop]
+    for name in dropped:
+        data.pop(name, None)
+    path.write_text(json.dumps(data, indent=2) + "\n", encoding="utf-8")
+    return dropped
+
+
+def _commit(targets: list[Target]) -> list[tuple[Target, str | None]]:
+    results: list[tuple[Target, str | None]] = []
+
+    # File/dir targets.
+    for t in targets:
+        if t.kind in {"installed-plugins-entry", "marketplace-registration"}:
+            continue
+        try:
+            _remove_fs_target(t)
+            results.append((t, None))
+        except OSError as exc:
+            results.append((t, str(exc)))
+
+    # installed_plugins.json keyed rewrite (one pass for all keys).
+    ip_keys = {
+        t.detail.removeprefix("key=") for t in targets if t.kind == "installed-plugins-entry"
+    }
+    if ip_keys:
+        try:
+            dropped = _rewrite_installed_plugins(ip_keys)
+            for t in targets:
+                if t.kind == "installed-plugins-entry":
+                    key = t.detail.removeprefix("key=")
+                    err = None if key in dropped else "not present"
+                    results.append((t, err))
+        except (OSError, json.JSONDecodeError) as exc:
+            for t in targets:
+                if t.kind == "installed-plugins-entry":
+                    results.append((t, str(exc)))
+
+    # known_marketplaces.json keyed rewrite.
+    km_names = {
+        t.detail.removeprefix("key=") for t in targets if t.kind == "marketplace-registration"
+    }
+    if km_names:
+        try:
+            dropped = _rewrite_known_marketplaces(km_names)
+            for t in targets:
+                if t.kind == "marketplace-registration":
+                    name = t.detail.removeprefix("key=")
+                    err = None if name in dropped else "not present"
+                    results.append((t, err))
+        except (OSError, json.JSONDecodeError) as exc:
+            for t in targets:
+                if t.kind == "marketplace-registration":
+                    results.append((t, str(exc)))
+
+    return results
+
+
+def _print_cross_version_notes(out) -> None:
+    env = os.getenv("CLAUDE_PLUGIN_DATA")
+    if env:
+        print(
+            f"note: CLAUDE_PLUGIN_DATA is set to {env!r}. Data under that path was NOT auto-detected",
+            file=out,
+        )
+        print(
+            "      by this script — if you use it, wipe that directory yourself.",
+            file=out,
+        )
+
+
+def _print_kept_note(out) -> None:
+    print("", file=out)
+    print("kept (by design):", file=out)
+    print("  - ~/.claude/projects/   Claude Code session transcripts + auto-memory", file=out)
+    print("  - ~/.claude/rc-dashboard/  unrelated logs (different 'tinyhat')", file=out)
+    print("  - this repo checkout     the source of truth", file=out)
+    print("  - other plugins' data under ~/.claude/plugins/", file=out)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="INTERNAL DEV ONLY: wipe Tinyhat state for a fresh first-run test.",
+    )
+    parser.add_argument(
+        "--commit",
+        action="store_true",
+        help="Actually remove targets. Without this, the script is a dry-run.",
+    )
+    parser.add_argument(
+        "--full",
+        action="store_true",
+        help="Also remove our marketplace registration (pre-onboarding state).",
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Emit a machine-readable summary on stdout instead of prose.",
+    )
+    args = parser.parse_args(argv)
+
+    out = sys.stdout
+    targets = enumerate_all(include_full=args.full)
+
+    if not targets:
+        if args.json:
+            payload: dict = {"mode": "commit" if args.commit else "dry-run"}
+            if args.commit:
+                payload["removed"] = []
+                payload["errors"] = []
+            else:
+                payload["would_remove"] = []
+            print(json.dumps(payload, indent=2), file=out)
+        else:
+            print("tinyhat dev reset: already clean. Nothing to remove.", file=out)
+            if not args.full:
+                print(
+                    "(not checking marketplace registration; pass --full if you need a nuclear reset.)",
+                    file=out,
+                )
+            _print_cross_version_notes(out)
+        return 0
+
+    if not args.commit:
+        if args.json:
+            payload = {
+                "mode": "dry-run",
+                "would_remove": [
+                    {"kind": t.kind, "path": str(t.path), "detail": t.detail} for t in targets
+                ],
+            }
+            print(json.dumps(payload, indent=2), file=out)
+        else:
+            print(
+                "tinyhat dev reset — DRY RUN. Pass --commit to actually remove.",
+                file=out,
+            )
+            print("", file=out)
+            print("would remove:", file=out)
+            for t in targets:
+                print(f"  {t.describe()}", file=out)
+            if not args.full:
+                print("", file=out)
+                print(
+                    "(scoped reset: marketplace registration left intact. Pass --full for a nuclear reset.)",
+                    file=out,
+                )
+            _print_kept_note(out)
+            _print_cross_version_notes(out)
+        return 0
+
+    results = _commit(targets)
+    removed = [t for t, err in results if err is None]
+    errors = [(t, err) for t, err in results if err is not None]
+
+    if args.json:
+        payload = {
+            "mode": "commit",
+            "removed": [{"kind": t.kind, "path": str(t.path), "detail": t.detail} for t in removed],
+            "errors": [
+                {"kind": t.kind, "path": str(t.path), "detail": t.detail, "error": err}
+                for t, err in errors
+            ],
+        }
+        print(json.dumps(payload, indent=2), file=out)
+    else:
+        print(f"tinyhat dev reset: removed {len(removed)} target(s).", file=out)
+        for t in removed:
+            print(f"  removed  {t.describe()}", file=out)
+        for t, err in errors:
+            print(f"  ERROR    {t.describe()}: {err}", file=sys.stderr)
+        _print_kept_note(out)
+        _print_cross_version_notes(out)
+
+    return 0 if not errors else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Adds `/tinyhat:dev:reset` — a repo-scoped, internal-only skill that wipes every byte Tinyhat has written on the local machine (plugin data, cache, install manifest, installed-plugins registry entries, legacy `~/.claude/tinyhat/`, temp snapshot/analysis). Scoped by default, `--full` also removes the marketplace registration for a true pre-onboarding state. Replaces the hand-run `rm -rf` incantations we've been doing before every first-run smoke test.

## Linked issue

Closes #55

## Type of change

- [x] `feat` — new feature
- [x] `chore` / `ci` / `build` — tooling (new `packaging-guard` CI job)

## Testing performed

- Built a synthetic `$HOME` sandbox with data dirs, cache entries across multiple marketplaces, install manifests (ours + unrelated), legacy home, temp files, and registry entries for `tinyhat@tinyloop` / `tinyhat@other` / `unrelated@foo`. Ran `dev_reset.py --commit --full` and verified:
  - every Tinyhat target removed
  - `installed_plugins.json` kept only `unrelated@foo`
  - `known_marketplaces.json` kept only `claude-plugins-official`
  - `~/.claude/projects/`, `~/.claude/rc-dashboard/logs/tinyhat.log`, other plugins' cache, unrelated install manifests all preserved
  - second run prints `already clean.` and exits 0 (idempotent)
- Smoke-tested on the real machine (dry-run matches; commit removed exactly what dry-run advertised).
- `ruff check .` and `ruff format --check .` pass.
- Existing CI smoke suite (`gather_snapshot.py` / `render_report.py` / `routine.py`) still passes locally.
- New packaging-guard script: exercised all four failure paths (missing skill, planted `skills/dev-reset/`, planted reference inside a packaged SKILL.md, missing `INTERNAL DEV ONLY` prefix) — all caught.

- [x] Ran `python3 scripts/gather_snapshot.py` successfully
- [x] Ran `python3 scripts/render_report.py --open` successfully
- [x] Exercised the plugin via `claude --plugin-dir "$(pwd)"`
- [x] `ruff check .` and `ruff format --check .` pass
- [x] Added / updated tests where applicable (packaging-guard CI job)

## Checklist

- [x] PR title is a Conventional Commit
- [x] Linked to an issue (`Closes #55`)
- [x] Tests added or updated
- [x] Docs updated (`docs/local-development.md` §"Reset state between tests")
- [x] CI is green (will verify once the run completes)
- [x] No references to private maintainer resources
- [x] I will not self-merge

<details>
<summary>Agent checklist</summary>

- [x] Commits signed with the bot's SSH key and identity
- [x] Branch named `claude-code-bot/issue-55-dev-reset`

</details>

## Notes for the reviewer

- The skill lives at `.claude/skills/dev-reset/` (repo-scoped) and the description is prefixed `INTERNAL DEV ONLY`. `skills/dev-reset/` deliberately does not exist.
- `scripts/dev_reset.py` technically sits next to the packaged scripts, but it is never referenced by any packaged `SKILL.md` or by `.claude-plugin/*.json`. The new `packaging-guard` CI job enforces that.
- The helper treats `CLAUDE_PLUGIN_DATA` as out-of-band: we don't touch it, but we warn the user if it's set so they know auto-detection may have missed data.