### PR TITLE
fix(paths): forward CLAUDE_PLUGIN_DATA from skill body into python3 env

### DIFF
--- a/.github/scripts/check_skill_env_passthrough.sh
+++ b/.github/scripts/check_skill_env_passthrough.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# Every `python3` invocation inside a packaged `skills/**/SKILL.md` must be
+# prefixed with `CLAUDE_PLUGIN_DATA="${CLAUDE_PLUGIN_DATA}"` — Claude Code
+# expands `${CLAUDE_PLUGIN_DATA}` in the rendered skill body but does not
+# export it into the Bash-tool environment, so scripts that rely on the env
+# var see an empty value unless we forward it explicitly. See issue #58.
+#
+# This lint stays a plain shell script so it runs identically on any Ubuntu
+# or macOS GitHub runner without extra setup.
+
+set -euo pipefail
+
+fail() {
+  echo "skill-env-passthrough: $*" >&2
+  exit 1
+}
+
+violations=0
+
+while IFS= read -r -d '' skill_md; do
+  # Match lines that start a `python3` call — either bare or behind a
+  # simple indent (e.g. a nested bullet). Skip comment lines.
+  #
+  # A compliant line looks like:
+  #   CLAUDE_PLUGIN_DATA="${CLAUDE_PLUGIN_DATA}" python3 ...
+  while IFS=: read -r lineno content; do
+    # Strip a single leading run of spaces (markdown indent) for the check.
+    trimmed="${content#"${content%%[![:space:]]*}"}"
+    # Ignore commented examples.
+    case "$trimmed" in
+      \#*) continue ;;
+    esac
+    case "$trimmed" in
+      'CLAUDE_PLUGIN_DATA="${CLAUDE_PLUGIN_DATA}" python3 '*) ;;
+      python3' '*|python3)
+        echo "  $skill_md:$lineno  $trimmed"
+        violations=$((violations + 1))
+        ;;
+    esac
+  done < <(grep -n -E '(^|[[:space:]])python3([[:space:]]|$)' "$skill_md" || true)
+done < <(find skills -name SKILL.md -print0)
+
+if [[ $violations -gt 0 ]]; then
+  fail "$violations python3 invocation(s) missing the CLAUDE_PLUGIN_DATA passthrough prefix (see above)."
+fi
+
+echo "skill-env-passthrough: ok"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,9 @@ jobs:
       - name: Dev-only assets must not be in the packaged plugin
         run: bash .github/scripts/check_packaging.sh
 
+      - name: Skill bodies must forward CLAUDE_PLUGIN_DATA to python3
+        run: bash .github/scripts/check_skill_env_passthrough.sh
+
   lint:
     name: lint
     runs-on: ubuntu-latest

--- a/skills/audit/SKILL.md
+++ b/skills/audit/SKILL.md
@@ -46,7 +46,7 @@ Every time this skill loads, silently check whether today's adaptive
 snapshot should fire. Do not ask the user.
 
 ```!
-python3 "${CLAUDE_SKILL_DIR}/../../scripts/routine.py" check || true
+CLAUDE_PLUGIN_DATA="${CLAUDE_PLUGIN_DATA}" python3 "${CLAUDE_SKILL_DIR}/../../scripts/routine.py" check || true
 ```
 
 If the output starts with `skip:`, do nothing and proceed to the user's
@@ -61,7 +61,7 @@ request on this.
 ### 1. Gather the snapshot
 
 ```bash
-python3 "${CLAUDE_SKILL_DIR}/../../scripts/gather_snapshot.py"
+CLAUDE_PLUGIN_DATA="${CLAUDE_PLUGIN_DATA}" python3 "${CLAUDE_SKILL_DIR}/../../scripts/gather_snapshot.py"
 ```
 
 Writes `<temp>/tinyhat-snapshot.json`. The path is printed to stderr.
@@ -99,11 +99,11 @@ read it the first time you run this skill.
 
 ```bash
 # Default — writes latest/ and archive index; no browser:
-python3 "${CLAUDE_SKILL_DIR}/../../scripts/render_report.py"
+CLAUDE_PLUGIN_DATA="${CLAUDE_PLUGIN_DATA}" python3 "${CLAUDE_SKILL_DIR}/../../scripts/render_report.py"
 
 # User passed --archive (or the adaptive daily fired) — write the
 # dated archive copy too; do NOT open the browser:
-python3 "${CLAUDE_SKILL_DIR}/../../scripts/render_report.py" --archive
+CLAUDE_PLUGIN_DATA="${CLAUDE_PLUGIN_DATA}" python3 "${CLAUDE_SKILL_DIR}/../../scripts/render_report.py" --archive
 ```
 
 Rendering always writes four files into `${CLAUDE_PLUGIN_DATA}/latest/`:

--- a/skills/history/SKILL.md
+++ b/skills/history/SKILL.md
@@ -26,7 +26,7 @@ of Tinyhat that loaded this skill.
    - If the new path is missing but `${CLAUDE_PLUGIN_DATA}/latest/report.html` exists,
      regenerate the index without running a new audit:
      ```bash
-     python3 "${CLAUDE_SKILL_DIR}/../../scripts/render_report.py" --index-only
+     CLAUDE_PLUGIN_DATA="${CLAUDE_PLUGIN_DATA}" python3 "${CLAUDE_SKILL_DIR}/../../scripts/render_report.py" --index-only
      ```
    - If no reports exist at all, tell the user and hand off to
      `/tinyhat:audit` to create the first snapshot.

--- a/skills/open/SKILL.md
+++ b/skills/open/SKILL.md
@@ -92,7 +92,7 @@ start "${CLAUDE_PLUGIN_DATA}/latest/report.html"       # Windows
 If unsure which OS, use Python's `webbrowser` module (cross-platform):
 
 ```bash
-python3 -c "import os, webbrowser, pathlib; webbrowser.open(pathlib.Path(os.environ['CLAUDE_PLUGIN_DATA'], 'latest', 'report.html').as_uri())"
+CLAUDE_PLUGIN_DATA="${CLAUDE_PLUGIN_DATA}" python3 -c "import os, webbrowser, pathlib; webbrowser.open(pathlib.Path(os.environ['CLAUDE_PLUGIN_DATA'], 'latest', 'report.html').as_uri())"
 ```
 
 3. In one short sentence, tell the user what they're looking at — the

--- a/skills/routine/SKILL.md
+++ b/skills/routine/SKILL.md
@@ -30,7 +30,7 @@ matching bundled `routine.py` for this loaded skill.
 ### status (default)
 
 ```bash
-python3 "${CLAUDE_SKILL_DIR}/../../scripts/routine.py" status
+CLAUDE_PLUGIN_DATA="${CLAUDE_PLUGIN_DATA}" python3 "${CLAUDE_SKILL_DIR}/../../scripts/routine.py" status
 ```
 
 Prints three lines: `routine: on|off`, `last run: YYYY-MM-DD | (never)`, `home: <path>`. Repeat the output to the user verbatim — no re-phrasing needed.
@@ -39,10 +39,10 @@ Prints three lines: `routine: on|off`, `last run: YYYY-MM-DD | (never)`, `home: 
 
 ```bash
 # turn on:
-python3 "${CLAUDE_SKILL_DIR}/../../scripts/routine.py" on
+CLAUDE_PLUGIN_DATA="${CLAUDE_PLUGIN_DATA}" python3 "${CLAUDE_SKILL_DIR}/../../scripts/routine.py" on
 
 # turn off:
-python3 "${CLAUDE_SKILL_DIR}/../../scripts/routine.py" off
+CLAUDE_PLUGIN_DATA="${CLAUDE_PLUGIN_DATA}" python3 "${CLAUDE_SKILL_DIR}/../../scripts/routine.py" off
 ```
 
 Both subcommands write `routine.json` atomically and print the new
@@ -52,7 +52,7 @@ the background auto-run is suppressed.
 ### where
 
 ```bash
-python3 "${CLAUDE_SKILL_DIR}/../../scripts/routine.py" where
+CLAUDE_PLUGIN_DATA="${CLAUDE_PLUGIN_DATA}" python3 "${CLAUDE_SKILL_DIR}/../../scripts/routine.py" where
 ```
 
 Prints the list of sources Tinyhat reads (transcripts, inventory,
@@ -63,7 +63,7 @@ or wants to tail a file.
 ### clear
 
 ```bash
-python3 "${CLAUDE_SKILL_DIR}/../../scripts/routine.py" clear-archive
+CLAUDE_PLUGIN_DATA="${CLAUDE_PLUGIN_DATA}" python3 "${CLAUDE_SKILL_DIR}/../../scripts/routine.py" clear-archive
 ```
 
 Removes every dated `archive/YYYY-MM-DD/` directory. Does not touch


### PR DESCRIPTION
## Summary

Follow-up to #54. The reconcile fix only closed the split-brain halfway — Claude Code expands `\${CLAUDE_PLUGIN_DATA}` in the skill body text but doesn't export it into the Bash-tool environment, so every `python3 .../scripts/*.py` invocation saw the env var as unset. On a fresh install the sibling scan returned nothing, the script-side fell through to `plugin.json`'s `"tinyhat"` name, and writes landed in `~/.claude/plugins/data/tinyhat/` while the skill-side kept reading `tinyhat-tinyloop/`.

Fix (option 1 from the issue): explicitly forward the env var — `CLAUDE_PLUGIN_DATA="\${CLAUDE_PLUGIN_DATA}" python3 ...` — on every call site in the four packaged SKILL.md files (11 invocations across `audit`, `open`, `history`, `routine`). Claude Code renders the `\${CLAUDE_PLUGIN_DATA}` token inside that string before handing the block to the Bash tool, so the child process inherits the same path the skill body advertises. Script-side and skill-side converge; `reconcile_homes()` still runs and handles already-split machines.

## Linked issue

Closes #58

## Type of change

- [x] `fix` — bug fix
- [x] `ci` — new `check_skill_env_passthrough.sh` guard

## Testing performed

Reproduced the issue's fresh-install scenario against a sandbox `\$HOME`:

- **Scenario A** (fresh install, env var passed as Claude Code would): report lands in `tinyhat-tinyloop/latest/report.html`; no stray `tinyhat/` sibling.
- **Scenario B** (`/tinyhat:open` flow): skill body path points at the same file the renderer wrote.
- **Scenario C** (env var unset, shell-side dev iteration): script falls back to `tinyhat/` via `_fallback_plugin_id()` — preserved behavior, still works.
- **Scenario D** (pre-existing `tinyhat/` home, skill invocation after fix): `reconcile_homes()` pulls the legacy dir into `tinyhat-tinyloop/`; `routine.json` and `latest/` survive the merge.

Also:

- Full local CI simulation (`ruff check`, `ruff format --check`, `compileall`, `gather_snapshot.py` → `render_report.py` → `routine.py`, both packaging-guard scripts) passes.
- Exercised `check_skill_env_passthrough.sh` in both pass and fail modes — catches a regression when the prefix is dropped from any single line.

- [x] Ran `python3 scripts/gather_snapshot.py` successfully
- [x] Ran `python3 scripts/render_report.py` successfully (via sandbox home-root)
- [ ] Exercised the plugin via `claude --plugin-dir "\$(pwd)"` — deferred to post-merge smoke test with the new release
- [x] `ruff check .` and `ruff format --check .` pass
- [x] Added new CI guard covering the invariant

## Checklist

- [x] PR title is a Conventional Commit
- [x] Linked to an issue (`Closes #58`)
- [x] Tests added (CI guard)
- [x] Docs updated where behavior changed — no user-visible behavior change; the fix is internal and the skill-body content is still what readers see
- [x] CI is green — **still running; I will report back once all checks pass**
- [x] No references to private maintainer resources
- [x] I will not self-merge

<details>
<summary>Agent checklist</summary>

- [x] Commits signed with the bot's SSH key and identity
- [x] Branch named \`claude-code-bot/issue-58-plugin-data-path\`

</details>