### PR TITLE
fix(release): bump plugin.json version with every release (closes #64)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "tinyhat",
-  "version": "0.1.0",
+  "version": "0.1.7",
   "description": "Telemetry, usage analytics, and cost intelligence for Claude Code skills — ask Claude which skills you use most, what they cost per invocation, and which ones are dead code. Replay any captured invocation against a cheaper model (Haiku, GPT, Gemini, or local Ollama) and see the cost delta before you commit to a routing change. Reads the session transcripts Claude Code already writes to disk; no backend, no proxy, no hooks required.",
   "author": {
     "name": "Tinyloop",

--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -71,10 +71,14 @@ Check:
   subjects verbatim. If a subject is cryptic, amend it by editing
   `CHANGELOG.md` *in the release PR itself* — release-please won't
   overwrite manual edits.
-- **`version.txt` and `.release-please-manifest.json` both move to
-  the new version.** Both get touched by the bot.
+- **`version.txt`, `.release-please-manifest.json`, and
+  `.claude-plugin/plugin.json` all move to the new version.** All
+  three get touched by the bot — `plugin.json` is wired in via
+  `extra-files` in `.release-please-config.json` so the installed
+  plugin label tracks the tag.
 - **No unrelated file changes.** The only touched files should be
-  `CHANGELOG.md`, `version.txt`, `.release-please-manifest.json`.
+  `CHANGELOG.md`, `version.txt`, `.release-please-manifest.json`,
+  `.claude-plugin/plugin.json`.
 
 ### 3. Merge the release PR (squash)
 

--- a/.release-please-config.json
+++ b/.release-please-config.json
@@ -8,7 +8,14 @@
       "draft": false,
       "prerelease": false,
       "include-component-in-tag": false,
-      "changelog-path": "CHANGELOG.md"
+      "changelog-path": "CHANGELOG.md",
+      "extra-files": [
+        {
+          "type": "json",
+          "path": ".claude-plugin/plugin.json",
+          "jsonpath": "$.version"
+        }
+      ]
     }
   },
   "plugins": ["sentence-case"],


### PR DESCRIPTION
## Summary

Wire `.claude-plugin/plugin.json` into release-please's `extra-files` so its `version` field gets bumped alongside the tag + changelog on every release, and sync it now to the current released version (`0.1.7`) so the next release-please PR bumps `0.1.7` → next, not `0.1.0` → next.

Without this, fresh `/plugin install tinyhat@tinyloop` lands in `~/.claude/plugins/cache/tinyloop/tinyhat/0.1.0/` and `installed_plugins.json` labels every user as `"version": "0.1.0"` regardless of which release they actually have — compounding as every future release installs into the same stale cache folder.

## Linked issue

Closes #64

## Type of change

- [x] `fix` — bug fix

## Testing performed

- Validated both JSON files parse (`python3 -c "import json; json.load(...)"`).
- Diff inspection: the only files touched are `.release-please-config.json` (add `extra-files`), `.claude-plugin/plugin.json` (`0.1.0` → `0.1.7` one-off catch-up), and the `release` skill's PR-review checklist (now lists `plugin.json` among files the bot is expected to touch).
- Full end-to-end verification will happen on the next release-please PR: its diff should include `plugin.json` bumping from `0.1.7` → next version.

## Checklist

- [x] PR title is a Conventional Commit
- [x] Linked to an issue (`Closes #64`)
- [x] Docs updated where behavior changed (`release` SKILL.md)
- [x] No references to private maintainer resources
- [x] I will not self-merge

---

<details>
<summary>Agent checklist</summary>

- [x] Commits signed with the bot's SSH key and identity
- [x] Branch named `claude-code-bot/fix-64-plugin-json-bump`

</details>