### PR TITLE
fix(report): archived reports link back to archive index correctly

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,6 +86,15 @@ jobs:
             --archive
           ls "$RUNNER_TEMP/tinyhat-ci/home/archive/"
 
+      - name: All-reports backlink points to the right path per target
+        shell: bash
+        run: |
+          latest_html="$RUNNER_TEMP/tinyhat-ci/home/latest/report.html"
+          dated_html=$(ls "$RUNNER_TEMP/tinyhat-ci/home/archive/"*/report.html | head -n1)
+          grep -q 'href="../archive/index.html"[^>]*>all reports' "$latest_html"
+          grep -q 'href="../index.html"[^>]*>all reports' "$dated_html"
+          ! grep -q 'href="../archive/index.html"[^>]*>all reports' "$dated_html"
+
       - name: Routine CLI smoke test
         run: |
           python3 scripts/routine.py --home-root "$RUNNER_TEMP/tinyhat-ci/home" status

--- a/scripts/render_report.py
+++ b/scripts/render_report.py
@@ -606,7 +606,11 @@ def _html_inline_code(text: str) -> str:
     return "".join(out)
 
 
-def render_html(snapshot: dict, analysis: dict) -> str:
+LATEST_ARCHIVE_INDEX_HREF = "../archive/index.html"
+DATED_ARCHIVE_INDEX_HREF = "../index.html"
+
+
+def render_html(snapshot: dict, analysis: dict, *, archive_index_href: str) -> str:
     tpl = (TEMPLATE_DIR / "report.html.tmpl").read_text(encoding="utf-8")
     # Inline CSS from sibling file so edits don't require touching a
     # quoted string inside the template. Template references {{CSS}}.
@@ -879,6 +883,7 @@ def render_html(snapshot: dict, analysis: dict) -> str:
 
     subs = {
         "CSS": css,
+        "ARCHIVE_INDEX_HREF": archive_index_href,
         "GENERATED_AT": generated_local.strftime(f"%Y-%m-%d %H:%M {tz_abbr}".strip()),
         "GENERATED_AT_UTC": generated_utc.strftime("%Y-%m-%d %H:%M UTC"),
         "WINDOW_LABEL": window_label,
@@ -1078,12 +1083,12 @@ def main() -> int:
     latest_dir.mkdir(parents=True, exist_ok=True)
 
     md = render_markdown(snapshot, analysis)
-    htmlout = render_html(snapshot, analysis)
+    html_latest = render_html(snapshot, analysis, archive_index_href=LATEST_ARCHIVE_INDEX_HREF)
     snapshot_json = json.dumps(snapshot, indent=2, ensure_ascii=False) + "\n"
     analysis_json = json.dumps(analysis, indent=2, ensure_ascii=False) + "\n"
 
     (latest_dir / "report.md").write_text(md, encoding="utf-8")
-    (latest_dir / "report.html").write_text(htmlout, encoding="utf-8")
+    (latest_dir / "report.html").write_text(html_latest, encoding="utf-8")
     (latest_dir / "snapshot.json").write_text(snapshot_json, encoding="utf-8")
     (latest_dir / "analysis.json").write_text(analysis_json, encoding="utf-8")
 
@@ -1093,8 +1098,9 @@ def main() -> int:
     if args.archive:
         archive_dir = home_root / "archive" / today
         archive_dir.mkdir(parents=True, exist_ok=True)
+        html_archive = render_html(snapshot, analysis, archive_index_href=DATED_ARCHIVE_INDEX_HREF)
         (archive_dir / "report.md").write_text(md, encoding="utf-8")
-        (archive_dir / "report.html").write_text(htmlout, encoding="utf-8")
+        (archive_dir / "report.html").write_text(html_archive, encoding="utf-8")
         (archive_dir / "snapshot.json").write_text(snapshot_json, encoding="utf-8")
         (archive_dir / "analysis.json").write_text(analysis_json, encoding="utf-8")
         enforce_retention(home_root / "archive", keep=31)

--- a/skills/audit/templates/report.html.tmpl
+++ b/skills/audit/templates/report.html.tmpl
@@ -17,7 +17,7 @@
         <div class="kicker">Tinyhat · Skill Audit</div>
         <h1 class="report-title">Which skills are actually earning their keep?</h1>
         <p class="report-sub">A local, read-only look at how your Claude skills show up in the work you've actually been doing.</p>
-        <p class="report-meta">Generated {{GENERATED_AT}} · window: {{WINDOW_LABEL}} · <a href="../archive/index.html" class="report-meta-link">all reports →</a></p>
+        <p class="report-meta">Generated {{GENERATED_AT}} · window: {{WINDOW_LABEL}} · <a href="{{ARCHIVE_INDEX_HREF}}" class="report-meta-link">all reports →</a></p>
       </div>
       <div class="mode-switch" role="tablist" aria-label="Report detail mode">
         <button class="mode-btn" data-mode="main" type="button" onclick="setMode('main')"><span>✨</span><span>Keep it simple</span></button>


### PR DESCRIPTION
## Summary

From a dated archive report (`archive/YYYY-MM-DD/report.html`), the **all reports →** backlink in the header was pointing at `archive/YYYY-MM-DD/archive/index.html` and 404ing. The template hardcoded `../archive/index.html`, which only resolves correctly from `latest/report.html`. The renderer now fills a per-target `{{ARCHIVE_INDEX_HREF}}` slot: `../archive/index.html` for `latest/`, `../index.html` for dated archive dirs.

## Linked issue

Closes #14

## Type of change

- [x] `fix` — bug fix

## Testing performed

Locally, with a real snapshot, rendered `--archive` and greped both outputs:

- `latest/report.html` → `href="../archive/index.html"` (unchanged)
- `archive/2026-04-23/report.html` → `href="../index.html"` (fixed)

Added a CI smoke assertion that greps both rendered reports to keep the two paths from drifting.

- [x] Ran `python3 scripts/gather_snapshot.py` successfully
- [x] Ran `python3 scripts/render_report.py --archive` successfully
- [x] Exercised the plugin via `claude --plugin-dir "$(pwd)"` (template/href-only change)
- [x] `ruff check .` and `ruff format --check .` pass on the changed file
- [x] Added / updated tests where applicable (CI smoke assertion)

## Checklist

- [x] PR title is a Conventional Commit
- [x] Linked to an issue (`Closes #14`)
- [x] Tests added or updated (CI smoke assertion)
- [x] Docs updated where behavior changed (N/A — no doc surface for this)
- [x] CI is green (pending)
- [x] No references to private maintainer resources
- [x] I will not self-merge

---

<details>
<summary>Agent checklist</summary>

- [x] Commits signed with the bot's SSH key and identity
- [x] Branch named `claude-code-bot/fix-archive-backlink`

</details>