### PR TITLE
feat(skills): add review-changelog and wire into release flow

### DIFF
--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -67,10 +67,9 @@ Check:
   patch. If release-please suggests a major bump but we're pre-1.0,
   something's misconfigured — stop and fix
   `.release-please-config.json`.
-- **CHANGELOG entry reads well.** Release-please pulls commit
-  subjects verbatim. If a subject is cryptic, amend it by editing
-  `CHANGELOG.md` *in the release PR itself* — release-please won't
-  overwrite manual edits.
+- **CHANGELOG entries match what shipped.** Release-please pulls
+  commit subjects verbatim, so an entry can advertise an approach
+  that review replaced. Step 3 covers the check and rewrite.
 - **`version.txt`, `.release-please-manifest.json`, and
   `.claude-plugin/plugin.json` all move to the new version.** All
   three get touched by the bot — `plugin.json` is wired in via
@@ -80,7 +79,16 @@ Check:
   `CHANGELOG.md`, `version.txt`, `.release-please-manifest.json`,
   `.claude-plugin/plugin.json`.
 
-### 3. Merge the release PR (squash)
+### 3. Check CHANGELOG accuracy against what shipped
+
+Before merging, run the
+[`review-changelog`](../review-changelog/SKILL.md) skill against the
+open release PR. It compares each new bullet's subject to the source
+PR's merged diff and review discussion, flags divergences, and lands
+approved rewrites on the release-please branch under the bot identity.
+Silent no-op when nothing diverges — safe to run every time.
+
+### 4. Merge the release PR (squash)
 
 Squash-merge from the GitHub UI. Linear history is required.
 
@@ -92,7 +100,7 @@ On merge, release-please runs the release step:
   `chore(main): release <next>` but empty until the next `feat:`/
   `fix:` lands).
 
-### 4. Verify the release landed
+### 5. Verify the release landed
 
 ```bash
 # Tag exists and is annotated:
@@ -107,7 +115,7 @@ gh run list --repo tinyhat-ai/tinyhat --workflow Release --limit 3
 
 If any step shows an error, jump to **Rollback** below.
 
-### 5. Smoke-test the published plugin
+### 6. Smoke-test the published plugin
 
 In a clean Claude Code session:
 
@@ -156,7 +164,7 @@ Steps:
 7. Create the GitHub release:
    `gh release create v<version> --repo tinyhat-ai/tinyhat --notes-file
    <(awk '/^## /{if(found)exit; found=1}found' CHANGELOG.md | tail -n +2)`.
-8. Smoke-test per the Normal-flow step 5.
+8. Smoke-test per the Normal-flow step 6.
 
 ## Rollback (a release is broken)
 

--- a/.claude/skills/review-changelog/SKILL.md
+++ b/.claude/skills/review-changelog/SKILL.md
@@ -1,0 +1,133 @@
+---
+name: review-changelog
+description: Use before merging a release-please PR on tinyhat to check that each CHANGELOG entry matches what actually shipped. Release-please cribs every bullet from the source PR's squashed-merge commit subject; if review replaced the mechanism that subject described, the bullet advertises an abandoned approach. This skill surfaces divergences and lands a rewrite on the release-please branch under the bot identity. Invoke from the `release` skill's pre-merge step, or standalone.
+---
+
+# review-changelog — check release-please bullets against what shipped
+
+Release-please writes each `CHANGELOG.md` bullet from the source PR's
+squashed-merge commit subject. If the PR landed with a subject that
+described its *first-draft* mechanism, and review replaced that
+mechanism, the bullet tells users about an approach that didn't ship.
+This skill catches that before the release PR merges.
+
+Scope is narrow: the single open release-please PR. Not a general
+changelog linter.
+
+## 1. Pick the open release PR
+
+```bash
+gh pr list --repo tinyhat-ai/tinyhat --state open \
+  --label "autorelease:pending" \
+  --json number,title,headRefName,url
+```
+
+There should be exactly one. Record the PR number (`$RP`) and head
+branch (`$RBR`, typically `release-please--branches--main`). Zero
+results means there's no release in flight — nothing to do.
+
+## 2. Read the new CHANGELOG entries
+
+```bash
+gh pr diff $RP --repo tinyhat-ai/tinyhat -- CHANGELOG.md
+```
+
+Each `+` bullet is a candidate. Every release-please bullet links its
+source PR as `(#NN)` at the end — pull those numbers out into a list.
+
+## 3. For each source PR, compare subject to what shipped
+
+For every `$N` in the list:
+
+```bash
+# Subject — what release-please is saying:
+gh pr view $N --repo tinyhat-ai/tinyhat \
+  --json title,body,mergeCommit --jq '{title, merge: .mergeCommit.oid}'
+
+# Reality — what actually shipped:
+gh pr diff $N --repo tinyhat-ai/tinyhat
+
+# Review trail — watch for "replaced with", "superseded by",
+# "switched to", "instead of", "ended up", "dropped":
+gh pr view $N --repo tinyhat-ai/tinyhat --comments
+```
+
+Form a two-sentence summary in your head: *"Subject says X. Diff shows
+Y."* If the mechanism verbs and object nouns in the subject still
+appear in the diff, the bullet is accurate — move on. If they don't,
+or the review trail contains a redesign phrase, flag it.
+
+Judgment, not a keyword matcher. A word-level diff will flag cosmetic
+rewordings; a strict matcher will miss semantic redesigns. Read both
+versions and decide.
+
+## 4. Decide with the maintainer
+
+If nothing diverges, respond with a single line — *"CHANGELOG matches
+shipping behavior, nothing to rewrite"* — and stop. Don't spend a
+maintainer turn on a no-op.
+
+Otherwise surface flagged entries as a table:
+
+| Current bullet | What actually shipped | Proposed rewrite |
+|---|---|---|
+| *"Persist plugin root at load time (#41)"* | Text-substitute `${CLAUDE_SKILL_DIR}`, no file written | *"Substitute plugin root via `${CLAUDE_SKILL_DIR}` at skill load (#41)"* |
+
+Ask the maintainer to approve, edit, or drop each proposed rewrite.
+Don't proceed to step 5 without an explicit approval per entry.
+
+## 5. Rewrite on the release branch
+
+The release-please branch accepts manual edits; release-please won't
+clobber them unless it regenerates from a new push to `main`. Check
+out the branch, edit `CHANGELOG.md` inline, and commit under your bot
+identity per the [`commit`](../commit/SKILL.md) skill:
+
+```bash
+git fetch origin $RBR
+git checkout $RBR
+# Edit CHANGELOG.md — keep the heading level, bullet form, and
+# trailing (#NN) link exactly as release-please wrote them.
+bot_git commit -m "chore(release): clarify changelog entry for #$N" \
+  CHANGELOG.md
+GIT_SSH_COMMAND="ssh -i $HOME/.ssh/<agent-key> -o IdentitiesOnly=yes" \
+  git push origin $RBR
+```
+
+If the PR body also quotes the old subject (release-please mirrors the
+CHANGELOG into the PR description), update it in the same pass:
+
+```bash
+gh pr view $RP --repo tinyhat-ai/tinyhat --json body --jq .body \
+  > /tmp/pr-body.md
+# Edit /tmp/pr-body.md to match the new CHANGELOG.
+gh pr edit $RP --repo tinyhat-ai/tinyhat --body-file /tmp/pr-body.md
+```
+
+## 6. Re-check before handing back
+
+```bash
+# Confirm the label is still there (release-please didn't regenerate):
+gh pr view $RP --repo tinyhat-ai/tinyhat \
+  --json labels --jq '.labels[].name'
+
+# Confirm the signed bot commit landed:
+gh pr view $RP --repo tinyhat-ai/tinyhat --json commits \
+  --jq '.commits[-1] | {oid:.oid, msg:.messageHeadline, author:.authors[0].login}'
+```
+
+If `main` advanced between your edit and now, release-please may have
+regenerated the PR — re-run from step 2. Otherwise return to the
+[`release`](../release/SKILL.md) skill and continue to "Merge the
+release PR (squash)."
+
+## 7. Non-negotiables
+
+- Never rewrite the squashed-merge commit on `main`. Only
+  `CHANGELOG.md` and the release PR body get touched.
+- Never commit the rewrite without the `commit` skill's inline bot
+  identity overrides.
+- Never rewrite a CHANGELOG entry after the release PR has been
+  merged — the tag is already cut. Ship a forward fix instead.
+- Never flag an entry purely on a keyword match without reading the
+  diff. Cosmetic subject rewordings are fine; mechanism drift is not.


### PR DESCRIPTION
## Summary

Release-please cribs each `CHANGELOG.md` bullet from the source PR's squashed-merge commit subject. When review replaces the mechanism the subject described, the bullet ends up advertising an approach that didn't ship — this bit us on PR #41 in the 0.1.3 cycle (patched by hand on the release branch, fragile). This PR adds a `review-changelog` skill that surfaces those divergences before the release PR merges and lands approved rewrites on the release-please branch under the bot identity.

## Linked issue

Closes #42

## Type of change

- [x] `feat` — new feature
- [ ] `fix` — bug fix
- [x] `docs` — documentation only
- [ ] `refactor` — no behavior change
- [ ] `test` — tests only
- [ ] `chore` / `ci` / `build` — tooling
- [ ] Breaking change

## What changed

- **New `.claude/skills/review-changelog/SKILL.md`** (133 lines, under the 150 ceiling). Procedure: pick the open `autorelease:pending` PR, pull its CHANGELOG diff, and for each new bullet compare the source PR's squashed-merge subject against the actual merge diff and review discussion. Agent judgment, not a keyword matcher — the issue's open-questions section preferred this and it avoids false positives on cosmetic rewordings. Surfaces flagged entries as a three-column table (current bullet, what shipped, proposed rewrite), and on maintainer approval commits the rewrite on the release-please branch under the bot identity per the `commit` skill. Silent no-op when nothing diverges, so it's safe to run every release.
- **Updated `.claude/skills/release/SKILL.md`** to insert a short new "3. Check CHANGELOG accuracy against what shipped" step that points at `review-changelog`, before merge. Renumbered downstream steps 4/5/6 (`Merge`, `Verify`, `Smoke-test`) and fixed the internal reference in the Manual-release section. Softened the existing "CHANGELOG entry reads well" review bullet to a forward reference — the "amend by hand if cryptic" hint was duplicative now that the procedure lives in the new skill.

## Design choice — extracted, not inlined

The issue proposed extending the `release` skill. I extracted into a separate skill because `release/SKILL.md` was already at 195 lines (45 over the `update-guidance` 150-line ceiling), and this is a self-contained sub-procedure — same thin-harness-fat-skills pattern the repo dogfoods. The release skill now just adds a 7-line pointer, and the full procedure loads only when invoked. Still addresses the acceptance criteria: fires from the pre-merge checklist, no-op when entries match, rewrite lands as an SSH-signed bot commit.

## Testing performed

- [x] Confirmed `review-changelog/SKILL.md` frontmatter is valid and the description surfaces in Claude Code's skill list for this session (visible in `available-skills`).
- [x] Confirmed `release/SKILL.md` step numbering is internally consistent (3 → 4 → 5 → 6) and the only cross-reference (`Normal-flow step 6` in the Manual-release section) tracks the rename.
- [x] Confirmed no other files cross-link to the renumbered sections (`grep` for `release/SKILL.md#` and `release.md#` — no hits).
- [x] Final line counts: `release/SKILL.md` 203, `review-changelog/SKILL.md` 133.
- Not runtime-tested against a live release-please PR — there's no open release PR right now, and the procedure is pure `gh` + `git` + maintainer judgment. Next time a release PR appears, invoking `review-changelog` against it will exercise the real path.
- [x] `ruff check .` / `ruff format --check .` — N/A, docs-only change.

## Checklist

- [x] PR title is a Conventional Commit
- [x] Linked to an issue (`Closes #42`)
- [x] Docs updated where behavior changed
- [x] CI is green (pending push)
- [x] No references to private maintainer resources
- [x] I will not self-merge

---

<details>
<summary>Agent checklist</summary>

- [x] Commit signed with the `claude-code-bot` SSH key and identity.
- [x] Branch named `claude-code-bot/release-changelog-review`.

</details>