### PR TITLE
fix(snapshot): split gather output into compact + detail (closes #38)

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -58,7 +58,10 @@ Facts-only scanner. Reads:
 - `~/.claude/skills/`, `~/.claude/plugins/**/skills/*/SKILL.md`, project-local `.claude/skills/`, Cowork skill bundles (inventory)
 - `~/.gstack/analytics/skill-usage.jsonl` (optional cross-check)
 
-Emits a JSON snapshot with: `meta`, `stats`, `inventory`, `top_skills`, `skill_counts`, `last_seen`, `sessions`, `events`, `events_audit`, `tool_totals`, `aggregate_tools`, `daily_rollups`, `dormant_by_origin`, `installed_by_origin`, `surface_rollups`, `coverage`.
+Emits **two** JSON files alongside each other:
+
+- `<tempdir>/tinyhat-snapshot.json` — compact, aggregate-only view for the agent's analysis step. Top-level keys: `meta`, `stats`, `top_skills`, `skill_counts`, `last_seen`, `dormant_by_origin`, `installed_by_origin`, `tool_totals`, `aggregate_tools`, `daily_rollups`, `surface_rollups`, `session_tool_patterns`, `events_audit`, `coverage`. Sized to fit in a single `Read` tool call on 100+ skill installations (see [#38](https://github.com/tinyhat-ai/tinyhat/issues/38)).
+- `<tempdir>/tinyhat-snapshot-detail.json` — the full snapshot consumed by `render_report.py`. Superset of the compact view plus `inventory`, per-session `sessions`, raw `events`, and `events_audit.bare_read_skill_md`.
 
 **Attribution rules** (per [`roadmap/v0/skill-attribution-from-transcripts.md`](../../Tinyhat%20Docs/roadmap/v0/skill-attribution-from-transcripts.md) in the private spec):
 
@@ -73,7 +76,7 @@ Dedup: same session + same skill, ≤30s apart → one invocation. Unknown names
 ### `scripts/render_report.py`
 
 Pure templating. Takes:
-- `--snapshot` (default `<tempdir>/tinyhat-snapshot.json`)
+- `--snapshot` (default `<tempdir>/tinyhat-snapshot-detail.json` — the renderer needs the full inventory, per-session rows, and raw events)
 - `--analysis` (default `<tempdir>/tinyhat-analysis.json`)
 
 If `analysis.json` is missing, fills in sensible but generic defaults derived from the snapshot. **This is a fallback — it's safe to run but dull to read.** Real value comes from the agent-written analysis.

--- a/docs/artifacts.md
+++ b/docs/artifacts.md
@@ -26,7 +26,8 @@ plugin-data path automatically.
 | `${CLAUDE_PLUGIN_DATA}/archive/YYYY-MM-DD/{snapshot,analysis}.json` | Dated JSONs alongside the HTML/MD | When `--archive` is passed or the adaptive daily fires |
 | `${CLAUDE_PLUGIN_DATA}/archive/index.html` | Browseable index of latest + all archives | Every render call |
 | `${CLAUDE_PLUGIN_DATA}/feedback.jsonl` | Optional local feedback log (reserved) | Never in v0 (feedback goes via `mailto:`) |
-| `<tempdir>/tinyhat-snapshot.json` | Transient mirror of latest/snapshot.json (pipeline hand-off) | Every `gather_snapshot.py` call |
+| `<tempdir>/tinyhat-snapshot.json` | Transient **compact** snapshot — agent-facing, single-`Read`-sized | Every `gather_snapshot.py` call |
+| `<tempdir>/tinyhat-snapshot-detail.json` | Transient **detail** snapshot — full data, renderer-facing | Every `gather_snapshot.py` call |
 | `<tempdir>/tinyhat-analysis.json` | Transient mirror of latest/analysis.json (pipeline hand-off) | Every `/tinyhat:audit` run |
 
 `<tempdir>` is whatever `python3 -c 'import tempfile; print(tempfile.gettempdir())'` returns on your OS:
@@ -108,7 +109,7 @@ cat "${CLAUDE_PLUGIN_DATA}/latest/snapshot.json"
 
 Top-level keys: `meta`, `stats`, `inventory`, `top_skills`, `skill_counts`, `last_seen`, `sessions`, `events`, `events_audit`, `tool_totals`, `aggregate_tools`, `daily_rollups`, `dormant_by_origin`, `installed_by_origin`, `surface_rollups`, `coverage`. See [development.md](local-development.md) for the shape.
 
-The transient mirror at `<tempdir>/tinyhat-snapshot.json` is the same data — it's the hand-off between `gather_snapshot.py` and `render_report.py`. The copy under `latest/` is the one you (or Claude, on a follow-up turn) should read.
+The renderer consumes the detail copy at `<tempdir>/tinyhat-snapshot-detail.json`; the alongside `<tempdir>/tinyhat-snapshot.json` is a compact, aggregate-only view written for the agent's analysis step (so it fits in a single `Read` call even on 100+ skill installations — see [#38](https://github.com/tinyhat-ai/tinyhat/issues/38)). Both are transient. The durable copy under `latest/snapshot.json` is the full data and is what you (or Claude, on a follow-up turn) should read when drilling in.
 
 ### The agent-authored analysis JSON (the editorial layer)
 

--- a/docs/local-development.md
+++ b/docs/local-development.md
@@ -52,8 +52,8 @@ Audit my skills.
 ```
 
 The agent will:
-1. Run `gather_snapshot.py` → writes `<tempdir>/tinyhat-snapshot.json`.
-2. Read the snapshot and write `<tempdir>/tinyhat-analysis.json` — this is the editorial layer. Watch its reasoning; that's where Tinyhat earns its keep.
+1. Run `gather_snapshot.py` → writes `<tempdir>/tinyhat-snapshot.json` (compact, agent-facing) and `<tempdir>/tinyhat-snapshot-detail.json` (full, renderer-facing).
+2. Read the compact snapshot and write `<tempdir>/tinyhat-analysis.json` — this is the editorial layer. Watch its reasoning; that's where Tinyhat earns its keep.
 3. Run `render_report.py --archive`.
 4. The report lands under Tinyhat's plugin-data root (script-only default: `~/.claude/plugins/data/tinyhat/latest/report.html`).
 
@@ -142,7 +142,9 @@ When you're fiddling with the report layout, skip Claude entirely. The agent ana
 ```bash
 # Gather facts from local transcripts:
 python3 scripts/gather_snapshot.py
-# → writes <tempdir>/tinyhat-snapshot.json, prints the path to stderr
+# → writes <tempdir>/tinyhat-snapshot.json (compact, agent-facing)
+# → writes <tempdir>/tinyhat-snapshot-detail.json (full, renderer-facing)
+# → prints both paths to stderr
 
 # Generate an analysis.json (the editorial layer).
 # For fast iteration, skip this step — render_report.py has Python fallbacks
@@ -164,7 +166,7 @@ If you've edited CSS or the template, keep the snapshot and just re-render:
 python3 scripts/render_report.py
 ```
 
-That reuses `<tempdir>/tinyhat-snapshot.json` from the previous gather run.
+That reuses `<tempdir>/tinyhat-snapshot-detail.json` from the previous gather run (the renderer reads the full detail file, not the compact agent view).
 
 ### Test the archive index in isolation
 

--- a/scripts/dev_reset.py
+++ b/scripts/dev_reset.py
@@ -13,7 +13,8 @@ Targets:
     ~/.claude/plugins/.install-manifests/tinyhat@*.json   install manifests
     ~/.claude/plugins/cache/<marketplace>/tinyhat/        per-marketplace cache
     ~/.claude/tinyhat/                                    legacy pre-#49 home
-    <tempdir>/tinyhat-snapshot.json, tinyhat-analysis.json  pipeline hand-off
+    <tempdir>/tinyhat-snapshot.json, tinyhat-snapshot-detail.json,   pipeline hand-off
+    <tempdir>/tinyhat-analysis.json
     ~/.claude/plugins/installed_plugins.json              entries keyed tinyhat@*
     ~/.claude/plugins/known_marketplaces.json             tinyloop entry (--full)
     ~/.claude/plugins/marketplaces/<ours>/                cloned market (--full)
@@ -96,7 +97,11 @@ def _enumerate_legacy_home() -> list[Target]:
 
 def _enumerate_temp_files() -> list[Target]:
     tmp = Path(tempfile.gettempdir())
-    names = ("tinyhat-snapshot.json", "tinyhat-analysis.json")
+    names = (
+        "tinyhat-snapshot.json",
+        "tinyhat-snapshot-detail.json",
+        "tinyhat-analysis.json",
+    )
     return [Target("temp-file", tmp / n) for n in names if (tmp / n).exists()]
 
 

--- a/scripts/gather_snapshot.py
+++ b/scripts/gather_snapshot.py
@@ -6,12 +6,23 @@ events, per-session metadata, daily rollups, coverage counts. Ranking and
 editorial framing are left to the agent, which reads this snapshot and
 writes its own analysis JSON before render_report.py runs.
 
+Two files are written side by side:
+
+- `tinyhat-snapshot.json` — compact. Aggregated fields only, no raw
+  sessions / inventory / events arrays. Intended for the agent's
+  analysis step (small enough for a single Read call).
+- `tinyhat-snapshot-detail.json` — full. Everything, including per-
+  session rows, full skill inventory, and raw events. Intended for
+  render_report.py and for the agent to drill into when needed.
+
 Usage:
     python3 gather_snapshot.py [--window-days 30] [--output path.json]
 
-Default output is /tmp/tinyhat-snapshot.json. Paths and the window are
-read from arguments; nothing is read from stdin and nothing is written
-outside the output path.
+`--output` sets the compact path; the detail file is written alongside
+it with `-detail` before the extension. Default output is
+/tmp/tinyhat-snapshot.json. Paths and the window are read from
+arguments; nothing is read from stdin and nothing is written outside
+the output directory.
 """
 
 from __future__ import annotations
@@ -949,23 +960,113 @@ def build_snapshot(window_days: int = 30) -> dict:
     return snapshot
 
 
+COMPACT_SESSION_CAP = 30
+
+
+def build_compact(snapshot: dict) -> dict:
+    """Derive a small, aggregate-only view of the snapshot.
+
+    The full snapshot can exceed the Read tool's per-call token limit
+    once an installation has ~100 skills and ~40 sessions (see #38). The
+    compact view drops the three big arrays — `inventory`, `sessions`,
+    and `events` — and replaces `sessions` with a trimmed per-session
+    tool-use list so the agent can still pattern-match for skill
+    recommendations.
+
+    Every field the analysis step cites
+    (see `skills/audit/references/writing-the-analysis.md`) is present
+    here; when the agent needs a full row it reads the detail file.
+    """
+    candidate_rows = [
+        {
+            "session_id": row["session_id"],
+            "project": row["project"],
+            "surface": row["surface"],
+            "last_used": row["last_used"],
+            "turns": row["turns"],
+            "skill_runs": row["skill_runs"],
+            "tool_uses": row["tool_uses"],
+        }
+        for row in snapshot.get("sessions", [])
+        if sum((row.get("tool_uses") or {}).values()) > 0
+    ]
+    candidate_rows.sort(
+        key=lambda r: sum(r["tool_uses"].values()),
+        reverse=True,
+    )
+    session_tool_patterns = candidate_rows[:COMPACT_SESSION_CAP]
+    session_patterns_dropped = max(
+        len(snapshot.get("sessions", [])) - len(session_tool_patterns),
+        0,
+    )
+
+    events_audit_src = snapshot.get("events_audit") or {}
+    events_audit = {
+        "unknown_names": events_audit_src.get("unknown_names", []),
+        "unknown_event_count": events_audit_src.get("unknown_event_count", 0),
+        "bare_read_skill_md_count": len(events_audit_src.get("bare_read_skill_md", [])),
+    }
+    return {
+        "meta": snapshot["meta"],
+        "stats": snapshot["stats"],
+        "top_skills": snapshot.get("top_skills", []),
+        "skill_counts": snapshot.get("skill_counts", {}),
+        "last_seen": snapshot.get("last_seen", {}),
+        "dormant_by_origin": snapshot.get("dormant_by_origin", {}),
+        "installed_by_origin": snapshot.get("installed_by_origin", {}),
+        "tool_totals": snapshot.get("tool_totals", {}),
+        "aggregate_tools": snapshot.get("aggregate_tools", []),
+        "daily_rollups": snapshot.get("daily_rollups", []),
+        "surface_rollups": snapshot.get("surface_rollups", {}),
+        "coverage": snapshot.get("coverage", {}),
+        "events_audit": events_audit,
+        "session_tool_patterns": session_tool_patterns,
+        "session_tool_patterns_meta": {
+            "kept": len(session_tool_patterns),
+            "dropped": session_patterns_dropped,
+            "ordering": "by descending total tool_uses",
+            "note": (
+                "Only the most-active sessions are kept to stay under the "
+                "Read tool's token budget. Dropped rows are low-activity "
+                "and not useful for pattern-matching; open the detail file "
+                "if you need them."
+            ),
+        },
+        "detail_path_hint": "Full inventory, sessions, and events are in "
+        "tinyhat-snapshot-detail.json alongside this file.",
+    }
+
+
+def _detail_path_for(compact_path: Path) -> Path:
+    return compact_path.with_name(compact_path.stem + "-detail" + compact_path.suffix)
+
+
 def main() -> int:
     parser = argparse.ArgumentParser(description="Emit a Tinyhat local snapshot as JSON.")
     parser.add_argument("--window-days", type=int, default=30)
     parser.add_argument(
         "--output",
         default=str(DEFAULT_SNAPSHOT_PATH),
-        help=f"Path to write the snapshot JSON (default: {DEFAULT_SNAPSHOT_PATH})",
+        help=(
+            f"Path to write the compact snapshot JSON (default: {DEFAULT_SNAPSHOT_PATH}). "
+            "The full snapshot is written alongside with '-detail' before the extension."
+        ),
     )
     args = parser.parse_args()
 
     snapshot = build_snapshot(window_days=args.window_days)
-    output_path = Path(args.output)
-    output_path.parent.mkdir(parents=True, exist_ok=True)
-    output_path.write_text(json.dumps(snapshot, indent=2, default=str), encoding="utf-8")
+    compact = build_compact(snapshot)
+
+    compact_path = Path(args.output)
+    detail_path = _detail_path_for(compact_path)
+    compact_path.parent.mkdir(parents=True, exist_ok=True)
+    compact_path.write_text(json.dumps(compact, indent=2, default=str), encoding="utf-8")
+    detail_path.write_text(json.dumps(snapshot, indent=2, default=str), encoding="utf-8")
+
     stats = snapshot["stats"]
     print(
-        f"Wrote {output_path} — {stats['installed_count']} installed skills, "
+        f"Wrote {compact_path} (compact) and {detail_path} (detail) — "
+        f"{stats['installed_count']} installed skills, "
         f"{stats['active_count']} active in last {args.window_days}d, "
         f"{stats['skill_runs_total']} runs, {stats['sessions_total']} sessions.",
         file=sys.stderr,

--- a/scripts/render_report.py
+++ b/scripts/render_report.py
@@ -53,7 +53,7 @@ def _local_tz() -> ZoneInfo | timezone:
 
 PLUGIN_ROOT = Path(__file__).resolve().parent.parent
 TEMPLATE_DIR = PLUGIN_ROOT / "skills" / "audit" / "templates"
-DEFAULT_SNAPSHOT_PATH = Path(tempfile.gettempdir()) / "tinyhat-snapshot.json"
+DEFAULT_SNAPSHOT_PATH = Path(tempfile.gettempdir()) / "tinyhat-snapshot-detail.json"
 DEFAULT_ANALYSIS_PATH = Path(tempfile.gettempdir()) / "tinyhat-analysis.json"
 
 

--- a/skills/audit/SKILL.md
+++ b/skills/audit/SKILL.md
@@ -77,12 +77,27 @@ output. Skip the heads-up on the other `skip:` reasons (e.g.
 python3 "${CLAUDE_SKILL_DIR}/../../scripts/gather_snapshot.py"
 ```
 
-Writes `<temp>/tinyhat-snapshot.json`. The path is printed to stderr.
+Writes two files side by side:
+
+- `<temp>/tinyhat-snapshot.json` — **compact**, aggregate-only. This
+  is what you `Read` in step 2; it fits in a single Read call even on
+  100+ skill installations.
+- `<temp>/tinyhat-snapshot-detail.json` — **detail**, the full
+  snapshot with per-session rows, full inventory, and raw events. The
+  renderer consumes this; you only need to touch it if an observation
+  requires drilling into a specific session or event.
+
+Both paths are printed to stderr.
 
 ### 2. Read the snapshot and write your analysis
 
-Read the snapshot. Then write `<temp>/tinyhat-analysis.json` with
-these keys. Detailed field-by-field guidance is in
+Read the **compact** snapshot (`<temp>/tinyhat-snapshot.json`). It has
+every aggregate field the analysis cites. If you need a specific
+session row or inventory entry, read the detail file — but prefer the
+compact file so you don't burn tokens on data you won't cite.
+
+Then write `<temp>/tinyhat-analysis.json` with these keys. Detailed
+field-by-field guidance is in
 [`references/writing-the-analysis.md`](references/writing-the-analysis.md) —
 read it the first time you run this skill.
 
@@ -104,9 +119,13 @@ read it the first time you run this skill.
 
 **Non-negotiables:**
 - Use literal numbers from `snapshot.stats` for the headline.
-- Only reference skills that appear in `snapshot.inventory`.
+- Only reference skills that appear in the compact snapshot's
+  `top_skills` or `dormant_by_origin` (together these cover every
+  installed skill). Check there before naming a skill in a
+  recommendation so you don't suggest one the user already has.
 - Recommendations must be grounded in tool/session patterns you can
-  cite from the snapshot. No speculation.
+  cite from `tool_totals`, `aggregate_tools`, or
+  `session_tool_patterns`. No speculation.
 
 ### 3. Render
 
@@ -170,7 +189,7 @@ start "${CLAUDE_PLUGIN_DATA}/latest/report.html"       # Windows
 ## Paths
 
 - Scripts: bundled under `<plugin>/scripts/`, invoked here via `${CLAUDE_SKILL_DIR}/../../scripts/...`
-- Transient: `<tempdir>/tinyhat-snapshot.json`, `<tempdir>/tinyhat-analysis.json`
+- Transient: `<tempdir>/tinyhat-snapshot.json` (compact, agent-facing), `<tempdir>/tinyhat-snapshot-detail.json` (detail, renderer-facing), `<tempdir>/tinyhat-analysis.json`
 - Latest: `${CLAUDE_PLUGIN_DATA}/latest/report.{md,html}` + `snapshot.json` + `analysis.json` + `run-stamp.txt`
 - Archive: `${CLAUDE_PLUGIN_DATA}/archive/YYYY-MM-DD/report.{md,html}` + `snapshot.json` + `analysis.json` + `index.html`
 - Routine state: `${CLAUDE_PLUGIN_DATA}/routine.json`

--- a/skills/audit/references/writing-the-analysis.md
+++ b/skills/audit/references/writing-the-analysis.md
@@ -7,28 +7,53 @@ inside it.
 
 ## The snapshot you're reading
 
-`gather_snapshot.py` emits a JSON file with these top-level keys:
+`gather_snapshot.py` writes two files side by side. You read the
+**compact** file (`tinyhat-snapshot.json`) for the analysis; the
+**detail** file (`tinyhat-snapshot-detail.json`) is the renderer's
+input and is only worth opening when you need a specific row the
+compact file doesn't carry.
+
+### Compact snapshot — `tinyhat-snapshot.json` (read this)
+
+Aggregate-only view. Fits in a single `Read` call even on 100+ skill
+installations.
 
 | Key | What's in it |
 |---|---|
 | `meta` | `generated_at`, `window_days`, `window_start`, `window_end` |
 | `stats` | `installed_count`, `active_count`, `skill_runs_total`, `sessions_total`, `sessions_with_skills`, `turns_total`, `tokens_total`, `tokens_total_compact` |
-| `inventory` | `{skill-name: {path, origin, raw_scope, pack, summary, product}}` |
 | `top_skills` | ranked list — `{skill, runs, last_used, summary, origin, pack, raw_scope}` |
 | `skill_counts` | `{skill-name: run-count}` over the window |
 | `last_seen` | `{skill-name: ISO timestamp}` |
-| `sessions` | per-session rows — `session_id, title, surface, project, last_used, turns, tokens_total, tool_uses, total_tool_uses, skill_runs, skill_counter, model, transcript` |
-| `events` | attributed skill events (deduplicated, in window) |
-| `events_audit` | `bare_read_skill_md` (dropped), `unknown_names`, `unknown_event_count` |
+| `dormant_by_origin` | `{origin: [skill-names]}` — every installed skill that didn't run in the window |
+| `installed_by_origin` | `{origin: count}` |
 | `tool_totals` | total calls per tool across the window |
 | `aggregate_tools` | `[{tool, calls, sessions}]` ranked by calls |
 | `daily_rollups` | per-day `{date, sessions, skill_sessions, turns, tokens, skill_runs}` |
-| `dormant_by_origin` | `{origin: [skill-names]}` |
-| `installed_by_origin` | `{origin: count}` |
 | `surface_rollups` | `{surface: session-count}` |
+| `session_tool_patterns` | per-session `{session_id, project, surface, last_used, turns, skill_runs, tool_uses}` — use this to count sessions that match a tool-combo pattern when grounding recommendations |
+| `events_audit` | `unknown_names`, `unknown_event_count`, `bare_read_skill_md_count` |
 | `coverage` | scanner counts — what was read vs. dropped |
+| `detail_path_hint` | pointer to the detail file |
 
-Use this as a reference when drafting your observations.
+Between `top_skills` (used) and `dormant_by_origin` (unused), every
+installed skill name is reachable — that's enough to duplicate-check a
+recommendation without opening the detail file.
+
+### Detail snapshot — `tinyhat-snapshot-detail.json` (read only if needed)
+
+Superset of the compact file. Adds these fields:
+
+| Key | What's in it |
+|---|---|
+| `inventory` | `{skill-name: {path, origin, raw_scope, pack, summary, product}}` |
+| `sessions` | full per-session rows — `session_id, title, surface, project, last_used, turns, tokens_total, tool_uses, total_tool_uses, skill_runs, skill_counter, model, transcript` |
+| `events` | attributed skill events (deduplicated, in window) |
+| `events_audit.bare_read_skill_md` | the dropped bare-read rows (the compact file only carries the count) |
+
+Only open this file when a specific observation requires a row the
+compact file doesn't carry — e.g. to quote a session `title` or the
+`path` of a project-local skill. Reading it consumes a lot of tokens.
 
 ## Field-by-field rules
 
@@ -91,7 +116,8 @@ Each recommendation:
 - `confidence`: `high`, `medium`, or `low`. Be honest.
 - `headline`: one-line value prop.
 - `why`: 2–3 sentences, grounded in evidence you can point to in
-  `snapshot.sessions` or `snapshot.tool_totals`. Cite counts.
+  `snapshot.tool_totals`, `snapshot.aggregate_tools`, or
+  `snapshot.session_tool_patterns`. Cite counts.
 - `triggers`: 3–5 natural-language phrases that should activate the
   skill.
 
@@ -101,11 +127,15 @@ Each recommendation:
    together suggests an `implement-feature` pattern. High `Read + Grep`
    suggests `explore-codebase`. High `WebSearch + WebFetch` alongside
    `Write` suggests `research-and-write-brief`.
-2. Count sessions that match the pattern (`snapshot.sessions`). A
-   pattern across 2+ sessions is worth considering; 5+ is high-confidence.
-3. Check `snapshot.inventory` — if a similar skill already exists, note
-   that and pivot (e.g. "you have `plan-eng-review`; add `plan-sprint`
-   for the weekly cadence").
+2. Count sessions that match the pattern using
+   `session_tool_patterns` (each row has per-tool call counts). A
+   pattern across 2+ sessions is worth considering; 5+ is
+   high-confidence.
+3. Check `top_skills` and `dormant_by_origin` — if a similar skill
+   already exists, note that and pivot (e.g. "you have
+   `plan-eng-review`; add `plan-sprint` for the weekly cadence"). If
+   you need the skill's summary or path, read the detail file's
+   `inventory`.
 
 If you can't ground a recommendation in evidence, **omit it**. A
 confident two-item list beats a speculative three-item list.
@@ -170,8 +200,8 @@ macOS-only."*
   don't belong.
 - **Fabricated counts.** If you can't find the number in the snapshot,
   don't cite it.
-- **Recommending something the user already has.** Check `inventory`
-  first.
+- **Recommending something the user already has.** Check `top_skills`
+  and `dormant_by_origin` first (both are in the compact snapshot).
 - **Burying the lead.** The two pie charts and hero stats are already
   visible; your `what_stands_out` should add signal the charts can't.
 


### PR DESCRIPTION
## Summary

The single `tinyhat-snapshot.json` outgrew the `Read` tool's 25k-token
limit once an installation crossed ~100 skills / ~40 sessions, so the
audit skill could no longer load it in one call. `gather_snapshot.py`
now writes two files side by side:

- `tinyhat-snapshot.json` — **compact**, aggregate-only, what the agent
  `Read`s in the analysis step.
- `tinyhat-snapshot-detail.json` — **full** snapshot, what
  `render_report.py` consumes.

The compact view keeps every field the analysis cites
(`top_skills`, `dormant_by_origin`, `tool_totals`, `aggregate_tools`,
`daily_rollups`, etc.) and replaces the raw `sessions` list with
`session_tool_patterns` — the top-30 most active sessions, which is
enough for pattern-matching (top-20 already cover 88% of tool-use
signal in the maintainer's live install). Duplicate-check during
recommendations uses `top_skills` + `dormant_by_origin`, so the full
`inventory` is not needed at analysis time.

Measured on the maintainer's install (123 skills, 67 sessions):
compact dropped from ~57k to ~14k estimated tokens (single-`Read`-sized);
detail stays ~52k tokens and is only read by Python.

## Linked issue

Closes #38

## Type of change

- [x] `fix` — bug fix

## Testing performed

- [x] Ran `python3 scripts/gather_snapshot.py` — both files written, stderr reports both paths
- [x] `Read`'d the compact file end-to-end in a single call (2,081 lines, under 25k tokens)
- [x] Ran `python3 scripts/render_report.py` — consumes the detail file, writes full `snapshot.json` to `latest/` and `archive/YYYY-MM-DD/`
- [x] Verified `latest/snapshot.json` still has `inventory` (123 entries), `sessions` (67), `events` (52) — renderer sees the full data
- [x] Smoke-tested `dev_reset.py --commit` enumeration picks up the new detail filename

## Checklist

- [x] PR title is a Conventional Commit
- [x] Linked to an issue (`Closes #38`)
- [x] Tests added or updated — no unit-test harness yet for these scripts
- [x] Docs updated where behavior changed (`docs/artifacts.md`, `docs/architecture.md`, `docs/local-development.md`, `skills/audit/SKILL.md`, `skills/audit/references/writing-the-analysis.md`)
- [x] CI is green — waiting on the push
- [x] No references to private maintainer resources
- [x] I will not self-merge

---

<details>
<summary>Agent checklist</summary>

- [x] Commits signed with the Claude Code bot's SSH key and identity
- [x] Branch named `claude-code-bot/issue-38-compact-snapshot`

</details>