### PR TITLE
fix(audit): direct agent to Bash heredoc for analysis JSON (closes #39)

### DIFF
--- a/skills/audit/SKILL.md
+++ b/skills/audit/SKILL.md
@@ -96,26 +96,37 @@ every aggregate field the analysis cites. If you need a specific
 session row or inventory entry, read the detail file — but prefer the
 compact file so you don't burn tokens on data you won't cite.
 
-Then write `<temp>/tinyhat-analysis.json` with these keys. Detailed
-field-by-field guidance is in
+Then write `<temp>/tinyhat-analysis.json` via the Bash heredoc below —
+**do not use the `Write` tool**, it requires a prior `Read` on the
+path and will fail for a brand-new temp file. Detailed field-by-field
+guidance is in
 [`references/writing-the-analysis.md`](references/writing-the-analysis.md) —
 read it the first time you run this skill.
 
-```json
-{
-  "headline": "You have N skills installed. You used M of them in the last 30 days.",
-  "headline_sub": "One short supporting sentence.",
-  "what_stands_out": ["3–5 specific observations citing real names, counts, dates"],
-  "dormant_commentary": "One or two sentences about the dormant surface.",
-  "skill_recommendations": [
-    {"name": "...", "confidence": "high|medium|low", "headline": "...", "why": "...", "triggers": ["..."]}
-  ],
-  "next_actions": [
-    {"verb": "draft-skill", "label": "Draft `implement-feature`", "context": "...", "impact": "high|medium|low|null"}
-  ],
-  "coverage_note": "One paragraph; honest about what was scanned and what's uncertain."
-}
+```bash
+python3 <<'PY'
+import json, tempfile, pathlib
+out = pathlib.Path(tempfile.gettempdir()) / "tinyhat-analysis.json"
+out.write_text(json.dumps({
+    "headline": "You have N skills installed. You used M of them in the last 30 days.",
+    "headline_sub": "One short supporting sentence.",
+    "what_stands_out": ["3–5 specific observations citing real names, counts, dates"],
+    "dormant_commentary": "One or two sentences about the dormant surface.",
+    "skill_recommendations": [
+        {"name": "...", "confidence": "high", "headline": "...", "why": "...", "triggers": ["..."]}
+    ],
+    "next_actions": [
+        {"verb": "draft-skill", "label": "Draft `implement-feature`", "context": "...", "impact": "high"}
+    ],
+    "coverage_note": "One paragraph; honest about what was scanned and what's uncertain.",
+}, indent=2))
+print(f"Wrote {out}")
+PY
 ```
+
+Fill the dict with your real analysis before running. Python resolves
+the correct temp directory on every OS and surfaces any JSON-shaped
+mistakes as a clean error.
 
 **Non-negotiables:**
 - Use literal numbers from `snapshot.stats` for the headline.

--- a/skills/audit/references/writing-the-analysis.md
+++ b/skills/audit/references/writing-the-analysis.md
@@ -55,6 +55,15 @@ Only open this file when a specific observation requires a row the
 compact file doesn't carry — e.g. to quote a session `title` or the
 `path` of a project-local skill. Reading it consumes a lot of tokens.
 
+## Tool note: how to write `tinyhat-analysis.json`
+
+Use Bash (a `python3` heredoc, or `cat > … <<'EOF'`) to write the
+analysis JSON. **Do not use the `Write` tool.** Claude Code blocks
+`Write` on a path that hasn't been `Read` in the current session, and a
+brand-new temp file can never satisfy that check — you'll hit "File has
+not been read yet" every time. `SKILL.md` step 2 shows the exact
+heredoc to copy.
+
 ## Field-by-field rules
 
 ### `headline`


### PR DESCRIPTION
## Summary

Step 2 of the `tinyhat:audit` flow told the agent to "write `<temp>/tinyhat-analysis.json`", so the agent reached for the `Write` tool and hit "File has not been read yet" — `Write` is blocked on any path not previously `Read` in the same session, and a brand-new temp file can never satisfy that. The skill now shows an explicit `python3` heredoc to copy and calls out the `Write`-tool gotcha in the reference file.

## Linked issue

Closes #39

## Type of change

- [x] `fix` — bug fix
- [x] `docs` — documentation only

## Testing performed

- [x] Smoke-tested the `python3` heredoc pattern locally — resolves the correct temp dir on macOS (`/var/folders/…`) and writes valid JSON the renderer can consume
- [x] Ran `python3 scripts/gather_snapshot.py` successfully
- [x] Ran `python3 scripts/render_report.py --open` successfully
- [x] Exercised the plugin via `claude --plugin-dir "$(pwd)"`
- [x] `ruff check .` and `ruff format --check .` pass
- [x] Added / updated tests where applicable

The full gather→analyze→render loop will be exercised on the next real audit run. This PR is doc-only; no code paths changed.

## Checklist

- [x] PR title is a Conventional Commit
- [x] Linked to an issue (`Closes #39`)
- [x] Tests added or updated (or this PR is docs/chore only) — docs only
- [x] Docs updated where behavior changed
- [x] No references to private maintainer resources
- [x] I will not self-merge

<details>
<summary>Agent checklist (bot opened this PR)</summary>

- [x] Commits signed with the Claude Code bot's SSH key and identity
- [x] Branch named after the agent

</details>