### PR TITLE
fix(report): hero doughnut arcs match their integer labels

### DIFF
--- a/scripts/render_report.py
+++ b/scripts/render_report.py
@@ -627,9 +627,9 @@ def render_html(snapshot: dict, analysis: dict, *, archive_index_href: str) -> s
 
     installed = s["installed_count"]
     active = s["active_count"]
-    util_pct = (100 * active / installed) if installed else 0
+    util_pct = _pct_int(active, installed)
     sess_total = s["sessions_total"]
-    sess_skill_pct = (100 * s["sessions_with_skills"] / sess_total) if sess_total else 0
+    sess_skill_pct = _pct_int(s["sessions_with_skills"], sess_total)
 
     standouts_html = "\n".join(
         f"<li>{html.escape(item)}</li>" for item in analysis["what_stands_out"]
@@ -899,10 +899,8 @@ def render_html(snapshot: dict, analysis: dict, *, archive_index_href: str) -> s
         "SESSIONS_WITH_SKILLS": s["sessions_with_skills"],
         "TURNS_TOTAL_COMPACT": _format_compact(s["turns_total"]),
         "TOKENS_TOTAL_COMPACT": s["tokens_total_compact"],
-        "UTILIZATION_PCT": f"{util_pct:.1f}",
-        "UTILIZATION_PCT_INT": f"{util_pct:.0f}",
-        "SESSION_SKILL_PCT": f"{sess_skill_pct:.1f}",
-        "SESSION_SKILL_PCT_INT": f"{sess_skill_pct:.0f}",
+        "UTILIZATION_PCT": util_pct,
+        "SESSION_SKILL_PCT": sess_skill_pct,
         "UNUSED_COUNT": unused_count,
         "STANDOUTS_HTML": standouts_html,
         "DORMANT_COMMENTARY": analysis["dormant_commentary"],

--- a/skills/audit/templates/report.html.tmpl
+++ b/skills/audit/templates/report.html.tmpl
@@ -29,7 +29,7 @@
   <section class="pie-grid">
     <div class="pie-card">
       <div class="pie" style="--value: {{UTILIZATION_PCT}}%; --pie-color: var(--accent);">
-        <div class="pie-center"><strong>{{UTILIZATION_PCT_INT}}%</strong><span>active</span></div>
+        <div class="pie-center"><strong>{{UTILIZATION_PCT}}%</strong><span>active</span></div>
       </div>
       <div class="pie-copy">
         <h3>Skill utilization</h3>
@@ -38,7 +38,7 @@
     </div>
     <div class="pie-card">
       <div class="pie" style="--value: {{SESSION_SKILL_PCT}}%; --pie-color: var(--warm);">
-        <div class="pie-center"><strong>{{SESSION_SKILL_PCT_INT}}%</strong><span>sessions</span></div>
+        <div class="pie-center"><strong>{{SESSION_SKILL_PCT}}%</strong><span>sessions</span></div>
       </div>
       <div class="pie-copy">
         <h3>Sessions with skills</h3>


### PR DESCRIPTION
## Summary

The two hero doughnut charts in simple mode were driven by a float percentage (`.1f`) for the `conic-gradient` arc and an integer (`.0f`) for the label — so the arc and the label were never guaranteed to match. The arc also drifted in browsers that parse fractional percentages differently in `conic-gradient` stops (the issue's hypothesis #1). Collapsing both to the same integer via `_pct_int()` makes the pair authoritative and renders consistently across engines.

## Linked issue

Closes #71

## Type of change

- [x] `fix` — bug fix

## Testing performed

- [x] Ran `python3 scripts/render_report.py` against synthetic snapshots matching the issue's reproduction data (14/122 active, 18/58 sessions) and edge cases (0%, 1%, 33%, 50%, 99%, 100%).
- [x] Verified in a headless Chromium preview that each rendered `--value` matches the label text exactly and that the arc visually spans the right fraction (0% empty, 100% full, 50% half).
- [x] Confirmed the details-mode ("data junkie") view uses the same integer pair with no regression.
- [x] `python3 -m ruff check .` and `python3 -m ruff format --check scripts/render_report.py` pass.

## Screenshots

11% / 31% with the issue's reproduction data — arcs now unambiguously match their labels:

- Skill utilization: 11% teal wedge (~40°)
- Sessions with skills: 31% orange wedge (~111°)

Verified at 0%, 50%, and 100% as well. (Screenshots available in the worktree; easy to re-generate by rendering against a synthetic snapshot.)

## Root cause note

Per the issue's ask to identify which of the four suspected causes was real: it was hypothesis **#1** (fractional percentage in `conic-gradient`) combined with the structural issue that the arc and label were sourced from two different numbers. Using one integer for both eliminates both problems in a single change.

## Checklist

- [x] PR title is a Conventional Commit
- [x] Linked to an issue (`Closes #71`)
- [x] Tests added or updated — deferred to #24 (test infrastructure) per the issue's acceptance note
- [x] Docs updated where behavior changed — N/A (internal template change, no user-facing docs touched)
- [x] No references to private maintainer resources
- [x] I will not self-merge

---

<details>
<summary>Agent checklist</summary>

- [x] Commits signed with the bot's SSH key and identity
- [x] Branch named `claude/<short-topic>`

</details>