### PR TITLE
docs(readme): rewrite opening in a warmer, more personal voice

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,29 +1,36 @@
 # Tinyhat
 
-**The improvement loop for your Claude Code skills.**
+**See which skills are part of your workflow — and which ones you may be missing.**
 
 [![CI](https://github.com/tinyhat-ai/tinyhat/actions/workflows/ci.yml/badge.svg)](https://github.com/tinyhat-ai/tinyhat/actions/workflows/ci.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 [![Version](https://img.shields.io/github/v/tag/tinyhat-ai/tinyhat?label=version&sort=semver)](https://github.com/tinyhat-ai/tinyhat/releases)
 [![Conventional Commits](https://img.shields.io/badge/Conventional%20Commits-1.0.0-blue.svg)](https://www.conventionalcommits.org)
 
-![Top of a Tinyhat audit report asking "Which skills are actually earning their keep?" with two summary cards: 11% skill utilization — 14 of 122 installed skills had at least one run — and 31% of sessions with skills, meaning 18 of 58 recent sessions fired at least one skill.](docs/images/audit-summary.png)
+Tinyhat is a small Claude Code plugin that looks at your recent usage and turns it into a report.
 
-*The top of a fresh Tinyhat audit — a local, read-only report on which of your Claude Code skills actually show up in the work you've been doing. Every run is written by the Claude agent from your own session history, not a canned template.*
+I built it because I wanted a more honest view of my setup: what I was actually using, what was just sitting there installed, and what kinds of work kept coming up without a fitting skill.
 
-Tinyhat is a Claude Code plugin that uses that report to close a simple loop: **create what you use, retire what you don't, share what works.**
+Instead of guessing what skills you need, you can start from your actual workflow.
 
-Other tools hand you a pre-built skill library.
-Tinyhat bets the opposite way — a skill shaped by your real work beats any starter skill copied from elsewhere.
-The first version of a skill isn't the product; the loop is.
-
-Team skill-sharing follows naturally once the individual loop is working.
+That usually leads to three useful actions:
+- improve the skills you already rely on
+- remove unused skills
+- create the skills you seem to be missing
 
 Everything runs locally. No hooks, no daemons, no network calls.
 
+![Top of a Tinyhat audit report asking "Which skills are actually earning their keep?" with two summary cards: 11% skill utilization — 14 of 122 installed skills had at least one run — and 31% of sessions with skills, meaning 18 of 58 recent sessions fired at least one skill.](docs/images/audit-summary.png)
+
+*A local report built from your recent Claude Code usage, showing which skills seem active, which look unused, and where you may be missing a skill.*
+
 ## Why "Tinyhat"?
 
-I keep coming back to the way humans swap roles: *"put on your marketing hat."* I wonder if AI agents will land there too — a role, a hat, the skills that come with it. Tinyhat is the observability for those skills, so a team can see what's used and what's worth keeping.
+I kept coming back to the way people switch roles: "put on your marketing hat," "put on your ops hat."
+
+This project started from wondering whether agents might work that way too: different hats, different skills, different ways of working.
+
+Tinyhat is just a small tool to help make those skills easier to see.
 
 ## Install
 


### PR DESCRIPTION
## Summary

Follow-up to #74 (merged) to drop the "improvement loop" thesis framing in favor of a smaller, more personal voice. A first-time visitor now gets, in order: **what Tinyhat is → why I built it → the three useful actions it tends to lead to → then the screenshot.**

Key changes:

- Subtitle: *"The improvement loop for your Claude Code skills."* → *"See which skills are part of your workflow — and which ones you may be missing."*
- Opening prose: prose-first, personal ("I built it because…"), no thesis about beating pre-built skill libraries.
- Three actions as a short bullet list: improve / remove / create.
- Screenshot + caption move **below** the prose and the bullets, so the idea lands in words first.
- `## Why "Tinyhat"?` rewritten smaller and more personal — keeps the hat metaphor, keeps "tiny", drops the team-observability claim.

No changes to install, usage, docs index, community, or license sections. No code touched.

## Linked issue

No issue — this is a direct maintainer-requested refinement of the opening that shipped in #74.

## Type of change

- [x] `docs` — documentation only

## Testing performed

- [x] Re-read the first screen cold: flow is subtitle → prose → 3-bullet list → "Everything runs locally" → screenshot → caption → Why.
- [x] Confirmed install, usage, docs, community, license sections render unchanged.
- [x] Image path `docs/images/audit-summary.png` unchanged from #74 (file is already in the repo).
- [x] Alt text preserved verbatim from #74 for screen-reader continuity.

N/A for this doc-only change: snapshot/render scripts, plugin smoke test, ruff, tests.

## Screenshots (if UI)

README preview on GitHub renders the change directly — diff is self-illustrating.

## Checklist

- [x] PR title is a Conventional Commit
- [x] Linked to context (the merged #74 this follows up on)
- [x] Tests added or updated (or this PR is docs/chore only) — docs only
- [x] Docs updated where behavior changed — this PR is the doc update
- [x] CI is green — will monitor after push
- [x] No references to private maintainer resources
- [x] I will not self-merge

---

<details>
<summary>Agent checklist</summary>

- [x] Commit signed with the bot's SSH key and identity (Claude Code, `claude.farid@tinyloop.co`)
- [x] Branch named `claude/readme-tone-refresh` — `<agent>/<short-topic>` form

</details>