### PR TITLE
docs(agents): require atomic agent commits

### DIFF
--- a/.claude/skills/commit/SKILL.md
+++ b/.claude/skills/commit/SKILL.md
@@ -20,8 +20,8 @@ defined in the repo's `CLAUDE.local.md` (gitignored, maintainer-only).
 
 The rest of this skill describes the inline-override pattern for the
 first case. If you're in the second case, skip to section 5
-(Conventional Commits) and section 6 (non-negotiables that apply to
-everyone).
+(atomicity), section 6 (Conventional Commits), and section 7
+(non-negotiables that apply to everyone).
 
 ## 2. Preflight (once per machine, not per repo)
 
@@ -70,7 +70,6 @@ bot_git() {
     -c gpg.ssh.allowedSignersFile="$HOME/.ssh/<allowed-signers-file>" \
     "$@"
 }
-# then: bot_git commit -m "..." ; bot_git tag ... ; etc.
 ```
 
 ## 4. After the commit (inline-override path)
@@ -95,7 +94,31 @@ correct inline overrides, amending with
 pushed and shared, leave it and open a new commit noting the mistake —
 never rewrite shared history.
 
-## 5. Conventional Commits (everyone)
+## 5. What atomic means
+
+Before committing, inspect `git diff --cached --stat` and `--name-only`.
+The staged diff must tell one story:
+
+- One logical change per commit. Code plus direct tests/docs is fine;
+  unrelated feature, refactor, release, or CI work is not.
+- The commit should build, pass relevant tests, or be documentation-only
+  on its own. Do not create tiny checkpoint commits that need a later
+  commit to become meaningful.
+- The subject says what changed; the body explains why the change was
+  needed, what constraint shaped it, or what failure mode it prevents.
+- If the body needs a bullet list of unrelated outcomes, split the diff
+  with `git add -p`, separate branches, or a stacked-PR workflow.
+
+Anti-patterns include:
+- `misc fixes`, `bulk update docs`, or `address review feedback` as a
+  landed subject. Follow-up commits during review are fine; final
+  history must say what and why.
+- A grab-bag PR like tinyhat PR #8: skill renames, a new `routine`
+  skill, version reset, release-please config, workflow bumps, and a
+  changelog rewrite landed together. Split into separate skill,
+  release, and CI commits or PRs.
+
+## 6. Conventional Commits (everyone)
 
 Format: `<type>(<optional scope>): <subject>`, imperative, **under 72
 characters**. Body optional, explains *why*, wrap at ~72.
@@ -104,10 +127,10 @@ Types: `feat`, `fix`, `docs`, `refactor`, `test`, `chore`, `ci`,
 `build`. Breaking change: append `!` to the type or add a
 `BREAKING CHANGE:` footer.
 
-Separate commits for separate concerns. Don't bundle a refactor with a
-feature.
+Atomicity is required in addition to Conventional Commits; see
+[AGENTS.md](../../../AGENTS.md#atomic-commits-and-prs).
 
-## 6. Non-negotiables
+## 7. Non-negotiables
 
 - Never push directly to `main`. Commits travel through PRs — see
   [`open-pr`](../open-pr/SKILL.md).

--- a/.claude/skills/open-pr/SKILL.md
+++ b/.claude/skills/open-pr/SKILL.md
@@ -13,18 +13,54 @@ description: Use when opening a pull request on the tinyhat repo. If a maintaine
 - One concern per branch. Rebase onto `main`; do not merge `main` into
   your branch.
 
-## 2. Which identity to push and open under?
+## 2. Scope check before PR creation
+
+Before pushing or running `gh pr create`, list the logical changes:
+
+```bash
+git log --oneline --decorate main..HEAD
+git diff --stat main...HEAD
+git diff --name-only main...HEAD
+```
+
+Then write a short scope note:
+
+```text
+Logical changes:
+1. ...
+2. ...
+```
+
+If the count is more than one, stop. Keep a multi-commit PR only when
+every commit is part of one related thread and the PR can be summarized
+in one sentence. Otherwise split before review.
+
+To split an already bundled branch without losing signed commits:
+
+1. Create new branches from `main`, one per logical change.
+2. Use `git cherry-pick -n <commit>` plus `git add -p`, or restore
+   specific paths from the bundled branch, to stage only one change.
+3. Commit each branch through the [`commit`](../commit/SKILL.md) skill
+   so the new commits are signed under the correct identity.
+4. Push the replacement branches and close or supersede the grab-bag
+   PR. If the original branch was already pushed and reviewed, prefer
+   forward replacement PRs over force-rewriting shared signed history.
+
+Stack dependent changes when they must land in order; each PR in the
+stack still needs to be independently reviewable.
+
+## 3. Which identity to push and open under?
 
 Check whether a **bot identity table** exists in `CLAUDE.local.md`
 (gitignored, maintainer-only).
 
 - **Table present** → use the bot's SSH key on push and switch `gh` to
-  the bot's GitHub user for PR creation. Follow sections 3–4.
+  the bot's GitHub user for PR creation. Follow sections 4–5.
 - **Table absent** → push and open the PR as whoever owns the local
-  git / `gh` config. Skip sections 3–4 and read only section 5
+  git / `gh` config. Skip sections 4–5 and read only section 6
   (non-negotiables).
 
-## 3. Push with the agent's SSH key (inline-override path)
+## 4. Push with the agent's SSH key (inline-override path)
 
 The repo's `remote.origin.url` is the plain
 `git@github.com:tinyhat-ai/tinyhat.git`, so whoever owns the local SSH
@@ -47,7 +83,7 @@ git push git@<ssh-host-alias>:tinyhat-ai/tinyhat.git \
 Either way, do **not** set `remote.origin.url` to an alias — that would
 trap the working-tree owner into always pushing through a bot's key.
 
-## 4. Open the PR as the bot (inline-override path)
+## 5. Open the PR as the bot (inline-override path)
 
 `gh` uses whichever account is marked active. Switch to the bot's
 GitHub user for the PR-creation call, then switch back to the
@@ -67,12 +103,15 @@ gh auth switch --user <maintainer-github-user>
 - Title mirrors the primary commit (Conventional-Commits-shaped).
 - Fill
   [`.github/pull_request_template.md`](../../../.github/pull_request_template.md).
+- Include the scope note from section 2. For research-backed guidance
+  changes, include the sources read, top 3 takeaways, and top 2
+  surprises in the PR body.
 - Don't paste content from `CLAUDE.local.md` or any other
   maintainer-private source into the PR body.
 - Agents never self-merge. Only `CODEOWNERS` merges an agent-authored
   PR.
 
-## 5. Non-negotiables
+## 6. Non-negotiables
 
 - Never push to `main` directly.
 - Never self-merge an agent PR.
@@ -81,7 +120,7 @@ gh auth switch --user <maintainer-github-user>
   docs, Slack threads, internal services) in a PR visible on the
   public repo.
 
-## 6. When a PR is blocked
+## 7. When a PR is blocked
 
 - **Hook / CI failure**: investigate the underlying cause. Never use
   `--no-verify` to bypass.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,8 +15,11 @@ Thanks for wanting to contribute. Here's all you actually need:
 2. Use [Conventional Commits](https://www.conventionalcommits.org) for the
    commit subject if you can — e.g. `fix: typo in README`. Not a hard
    requirement for first-time contributors.
-3. Keep the PR focused on one thing. Describe what and why in a sentence
-   or two.
+3. Keep changes atomic:
+   1. One logical change per commit.
+   2. One related thread per PR.
+   3. Explain the why, not just the what.
+   4. Split unrelated work before asking for review.
 
 That's it. The dense policy below is plumbing for the AI agents the
 maintainer runs under dedicated bot identities. You can skip it.
@@ -68,12 +71,38 @@ contributors can ignore this section.
   explicit OK. Never commit keys, tokens, or credentials. Never reuse
   one agent's signing key on another agent.
 
+## Atomic commits and PRs
+
+Atomic commits are the default expectation for agent work. A commit is
+atomic when a future reviewer can answer "what does this do?" in one
+sentence, the diff builds or documents one coherent state, and the
+message body explains the constraint, failure mode, or tradeoff that
+made the change necessary.
+
+- **One logical change per commit.** Code plus its tests can be one
+  commit; a refactor plus a feature plus a CI bump cannot.
+- **One related thread per PR.** Multiple commits may ship together
+  only when they are all needed to tell one reviewable story. If two
+  commits could be reviewed, reverted, or released independently, split
+  them into separate PRs or a stack of PRs.
+- **Messages explain why.** The subject summarizes what changed. The
+  body explains why now, what alternative was rejected, or what bad
+  future state the commit prevents.
+- **When in doubt, split.** Agents pay little cost for small branches;
+  reviewers pay real cost for grab-bag diffs. Use stacked PRs when
+  small dependent changes must land in order.
+
+Anti-patterns: `misc fixes`, `bulk update docs`, `address review
+feedback` as a landed commit subject, and any PR mixing unrelated
+feature, refactor, release, documentation, or CI work.
+
 ## Commit and versioning conventions
 
 - **Conventional Commits** for commit subjects: `<type>(<scope>): <subject>`,
   imperative, <72 chars. Types: `feat`, `fix`, `docs`, `refactor`, `test`,
   `chore`, `ci`, `build`. Breaking: `!` or `BREAKING CHANGE:` footer.
   Strongly encouraged for everyone; strictly required for agent commits.
+- **Atomicity:** see [Atomic commits and PRs](#atomic-commits-and-prs).
 - **Versioning:** [SemVer 2.0](https://semver.org), tags `vX.Y.Z`.
   Maintainer creates tags on merged `main`. Pre-1.0, breaking changes
   bump **minor**, not major.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -51,6 +51,8 @@ docs: clarify the plugin vs script-only testing paths
 
 The PR title must also be a Conventional Commit — it becomes the squash
 commit message on `main`, and release tooling reads it to bump the version.
+Keep commits and PRs focused on one logical change; agents follow the
+stricter atomicity rules in [AGENTS.md](AGENTS.md#atomic-commits-and-prs).
 
 ### 4. Sign your commits (DCO — optional)
 


### PR DESCRIPTION
## Summary

Tightens the agent contribution guidance so atomic commits and single-thread PRs are the default expectation, with concrete commit checks, PR scope checks, anti-patterns, and a split procedure for already-bundled branches.

## Scope note

Logical changes:
1. Document researched atomic commit and PR discipline for agents.

This is one related documentation-policy change across the requested guidance surfaces: `AGENTS.md`, `.claude/skills/commit/SKILL.md`, `.claude/skills/open-pr/SKILL.md`, and `CONTRIBUTING.md`.

## Research summary

Sources read:

- Anthropic Claude Code best practices: https://code.claude.com/docs/en/best-practices
- Claude Managed Agents GitHub access: https://platform.claude.com/docs/en/managed-agents/github
- GitHub Copilot cloud agent docs: https://docs.github.com/en/copilot/concepts/agents/cloud-agent/about-cloud-agent
- Aider git integration: https://aider.chat/docs/git.html
- Cursor background agents: https://docs.cursor.com/en/background-agents
- Devin GitHub signing docs: https://docs.devin.ai/integrations/gh
- Windsurf PR Reviews: https://docs.windsurf.com/windsurf-reviews/windsurf-reviews
- Graphite stacked PR review guidance: https://graphite.com/docs/best-practices-for-reviewing-stacks
- GitHub Stacked PRs: https://github.github.com/gh-stack/introduction/overview/
- git-spice docs: https://abhinav.github.io/git-spice/
- AIDev 2026 dataset paper: https://arxiv.org/abs/2602.09185
- 2026 empirical study of unmerged AI-agent fix PRs: https://arxiv.org/abs/2602.00164

Top 3 takeaways:

1. Modern coding agents increasingly automate branch creation, commit messages, pushes, and PR creation, but the major docs mostly describe mechanics rather than defining what a good review unit is. That leaves repo-local `AGENTS.md`/skill guidance responsible for atomicity.
2. Stacked-PR tooling has made small dependent review units practical: Graphite and GitHub Stacked PRs both frame each PR in a stack as independently understandable and reviewable, while tools like git-spice reduce the operational cost of splitting.
3. Signed bot commits make timing matter. Before a branch is shared, amend/split freely with the correct identity; after it is pushed or reviewed, prefer forward replacement commits/PRs over rewriting shared signed history.

Top 2 surprises:

1. Aider is unusually explicit about git history as an agent safety and review tool: it commits agent edits with descriptive messages and separates preexisting dirty user work before editing. That maps neatly to this repo's need to separate agent changes from unrelated work.
2. GitHub Copilot cloud agent documents a one-branch/one-PR task model and automated commit-message writing, while stacked-PR tools push the opposite pressure valve for larger work: keep each PR atomic and stack dependent units instead of bundling.

## Linked issues

Closes #22
Follow-up: #84

## Type of change

- [x] `docs` — documentation only

## Testing performed

- [x] `git diff --check` passes
- [x] Checked guidance line budgets from `update-guidance`
- [x] Checked updated `AGENTS.md` anchors referenced from guidance files
- [x] Code tests not run; docs-only policy change

## Checklist

- [x] PR title is a Conventional Commit (e.g. `feat(skills): …`, `fix: …`)
- [x] Linked to an issue (`Closes #…`) or this PR is the canonical spec
- [x] Tests added or updated (or this PR is docs/chore only)
- [x] Docs updated where behavior changed
- [ ] CI is green
- [x] No references to private maintainer resources (see [AGENTS.md](../AGENTS.md#local-override-files))
- [x] I will not self-merge

---

<details>
<summary>Agent checklist (only if a bot opened this PR)</summary>

- [x] Commits signed with the bot's SSH key and identity — see [`commit` skill](../.claude/skills/commit/SKILL.md).
- [x] Branch named `<agent>/<short-topic>`.

</details>
