### PR TITLE
feat(skills): add review-pr development skill

### DIFF
--- a/.claude/skills/review-pr/SKILL.md
+++ b/.claude/skills/review-pr/SKILL.md
@@ -1,0 +1,186 @@
+---
+name: review-pr
+description: Use when asked to review a pull request, review a diff, inspect requested changes, or do a pre-landing review on tinyhat. Keeps the agent in review mode (find concrete bugs, regressions, missing tests, merge risks) instead of drifting into summaries, style commentary, or implementation. Covers GitHub PR review with `gh`, local uncommitted-diff review, the severity ladder, and the report shape (findings first, file:line references). Invoke instead of reading a diff and commenting freehand.
+---
+
+# review-pr — review a PR or diff in tinyhat's preferred style
+
+Review mode is **not** implementation mode. Don't fix the PR unless
+the maintainer explicitly asks for fixes — your job is to report
+defects, risks, and gaps with enough specificity that the author can
+act on them.
+
+If you find yourself opening an editor, you've drifted out of the
+skill. Stop and write up findings instead.
+
+## 1. Resolve the surface
+
+Two surfaces, two paths.
+
+### A GitHub PR
+
+Get the number `$N` from the user (or `gh pr list`). Pull metadata,
+the diff, and the stated intent:
+
+```bash
+gh pr view $N --repo tinyhat-ai/tinyhat \
+  --json number,title,baseRefName,headRefName,author,isDraft,mergeable
+
+gh pr diff $N --repo tinyhat-ai/tinyhat
+
+gh pr view $N --repo tinyhat-ai/tinyhat --json files \
+  --jq '.files[] | "\(.additions)+ \(.deletions)- \(.path)"'
+
+gh pr view $N --repo tinyhat-ai/tinyhat \
+  --json title,body,closingIssuesReferences --comments
+```
+
+The PR body and the issue it closes carry the *stated intent* — read
+both before judging the diff.
+
+If the diff is large or context-heavy, `gh pr checkout $N` so you
+can read nearby files. Don't review off `gh pr diff` alone when
+context matters — single-file diff context is usually too narrow.
+
+### A local uncommitted diff
+
+```bash
+git diff                          # unstaged
+git diff --staged                 # staged
+git diff origin/main...HEAD       # whole branch vs main
+git status                        # untracked files
+```
+
+Always scan untracked files — a new file that should have been added
+but wasn't is a real finding.
+
+## 2. Read past the diff when context is missing
+
+A diff alone isn't enough when a function's caller is outside the
+changed lines, a fixture changed and you don't know what depends on
+it, or a type widened and you don't know who reads it.
+
+Open the file at the change site and search for callers:
+`grep -rn '<symbol>' .`. Cheap and usually decisive.
+
+## 3. Severity ladder
+
+| Tier | What | Examples |
+|---|---|---|
+| **Blocker** | Wrong result, data loss, security regression, broken golden-path workflow, AGENTS.md non-negotiable violated | Off-by-one drops the last batch; unsigned commit slipped in |
+| **Important** | Real bug on a non-golden path; missing test for a risky path | Error path drops the original cause; new branch added with no test |
+| **Minor** | Likely-correct but worth a second look | Unclear name that hides a unit; comment contradicts code |
+| **Question** | Not enough context to call it a defect | "Is this list expected to be empty here?" |
+| **Nit** | Cosmetic. Optional. Use sparingly | Trailing whitespace, ordering |
+
+Always tier. A finding without a tier reads as opinion.
+
+## 4. Checklist
+
+Walk this once before writing up:
+
+- **Correctness:** does the changed behavior match the PR/issue intent?
+  Run the golden path mentally; pick one edge case.
+- **Tests:** every risky branch has coverage, or a stated reason it
+  doesn't. New behavior without a new test is a finding.
+- **Boundaries:** no unrelated refactors, generated churn, secrets,
+  or local-only files (`.claude/worktrees/`, `CLAUDE.local.md*`,
+  `__pycache__/`). One concern per diff.
+- **Agent/process policy** (see [`AGENTS.md`](../../../AGENTS.md)):
+  no maintainer-private content in committed files, no direct push
+  to `main`, no agent self-merge, commit signed under the right bot
+  identity.
+- **User-facing impact:** docs, CLI output, error messages, and
+  `SKILL.md` frontmatter stay coherent with what the code now does.
+- **Integration risk:** CI still covers this; release config
+  (`release-please-config.json`, `version.txt`,
+  `.claude-plugin/plugin.json`) and skill-discovery metadata still
+  packageable.
+
+## 5. Report shape — findings first
+
+```markdown
+## Findings
+
+### Blocker — <file>:<lines>
+<one paragraph: what breaks, at which input, and why>
+**Suggestion:** <one-line fix>
+
+### Important — <file>:<lines>
+…
+
+### Question — <file>:<lines>
+<single sentence grounded in the code>
+
+## Summary
+<two sentences max — what the PR does, your recommendation:
+"approve", "approve with nits", "request changes", or "needs more
+info before approval">
+```
+
+Findings first. Summary short and last. Don't restate the PR's
+stated intent — the author already knows it.
+
+When there are no findings, write one line and stop:
+
+> No findings. Diff matches the issue (#80); tests cover the changed
+> branches. Approve.
+
+Don't pad a no-finding review with summaries.
+
+## 6. Defect vs question
+
+A finding is a *defect* when you can name what breaks and at which
+input. If you can't, demote it to a *question*. Vague unease in the
+findings list wastes the author's turn.
+
+Good finding (defect):
+
+> **Blocker — `gather_snapshot.py:142`**
+> When `transcripts_dir` is empty, the loop returns `None` instead
+> of `[]`, and `render_report.py:88` then calls `len(snapshot)` and
+> crashes. Add `return []` on the empty branch.
+
+Non-finding question:
+
+> **Question — `routine.py:33`**
+> Is the 24-hour cooldown intentional even when the previous run
+> errored? Arguments either way — confirming.
+
+Clean no-findings response:
+
+> No findings. Diff matches issue #80, new branch in `pr_review.py`
+> is covered by `test_pr_review.py:15`, no unrelated files moved.
+> Approve.
+
+A worked end-to-end transcript on a fictional PR lives in
+[`example.md`](./example.md) — read it once to anchor on the shape.
+
+## 7. Posting back
+
+- **Maintainer wants the report in chat**: print it. Done.
+- **Maintainer wants it on GitHub**: post the report as the PR
+  review body, not as inline-line clutter:
+
+  ```bash
+  gh pr review $N --repo tinyhat-ai/tinyhat \
+    --comment --body-file <path-to-report.md>
+  ```
+
+  Per-line comments only when the maintainer asked for them.
+
+Never `gh pr review --approve` or `--request-changes` from a bot.
+Approval is the maintainer / `CODEOWNERS` call.
+
+## 8. Non-negotiables
+
+- **Don't fix the PR.** Review only. If the maintainer explicitly
+  asks "now fix it," that's a separate operation — start a fresh
+  branch and use the [`commit`](../commit/SKILL.md) and
+  [`open-pr`](../open-pr/SKILL.md) skills.
+- **Don't approve or request changes from a bot identity.** Agents
+  don't self-merge and don't formally block other agents' work.
+- **Don't surface internal context** (`CLAUDE.local.md` or
+  maintainer-private docs) in a public review.
+- **Always tier.** A finding without a severity is an opinion.
+- **Findings first, summary last, file:line on every finding.**

--- a/.claude/skills/review-pr/example.md
+++ b/.claude/skills/review-pr/example.md
@@ -1,0 +1,87 @@
+# example.md — dry-run review transcript
+
+Worked example for the [`review-pr`](./SKILL.md) skill on a fictional
+PR. Read it once to anchor on the output shape; don't paste from it
+as a template.
+
+## Fictional setup
+
+- **PR:** `#142` on `tinyhat-ai/tinyhat` — *"feat(audit): skip
+  dormant skills older than 90 days"*.
+- **Author:** an external contributor.
+- **Base:** `main`. **Diff:** 2 files
+  (`gather_snapshot.py` +18, -2; `audit_routine.md` +4, -1).
+- **Untracked next to the diff:** `gather_snapshot.py.bak`.
+- **Stated intent (PR body):** *"Audit shouldn't fail when a skill
+  hasn't been used in 90+ days. Skip them silently."*
+
+## Walkthrough
+
+### 1. Resolve
+
+```bash
+gh pr view 142 --repo tinyhat-ai/tinyhat \
+  --json baseRefName,headRefName,files,title,body
+gh pr diff 142 --repo tinyhat-ai/tinyhat
+gh pr view 142 --repo tinyhat-ai/tinyhat --json files \
+  --jq '.files[] | "\(.additions)+ \(.deletions)- \(.path)"'
+```
+
+Two files in the PR; one stray `.bak` shows up via `gh pr view ... files`
+(or `git status` after `gh pr checkout 142`). Backup files don't
+belong in commits — flag.
+
+### 2. Read past the diff
+
+```bash
+gh pr checkout 142
+grep -rn 'gather_snapshot' .
+```
+
+Two callers: `render_report.py` and `test_gather_snapshot.py`. The
+new branch in `gather_snapshot.py:94` is uncovered by any case in
+the test file.
+
+### 3. Tier and write up
+
+```markdown
+## Findings
+
+### Blocker — `gather_snapshot.py.bak`
+The PR includes an untracked backup file the author probably forgot
+to delete. It will be committed if the maintainer squash-merges
+without checking. Remove it before merge.
+**Suggestion:** `git rm gather_snapshot.py.bak` and force-push.
+
+### Important — `gather_snapshot.py:94`
+The new "skip if older than 90 days" branch has no test. The existing
+`test_gather_snapshot.py` covers the under-90-days path only, so a
+regression that skips the wrong skills (or fails to skip) won't be
+caught by CI.
+**Suggestion:** add a fixture transcript dated 91 days ago and
+assert it's omitted from the snapshot.
+
+### Question — `audit_routine.md:14`
+The doc says "skipped skills are listed in the report footer" but
+the code change drops them silently. Is the doc the new spec, or is
+it now out of date?
+
+## Summary
+Adds a 90-day cutoff for dormant skills in the audit snapshot.
+Approve once the `.bak` file is removed and the new branch has a
+test; doc/code mismatch needs the author's confirmation.
+```
+
+## Why this shape
+
+- The Blocker comes first because it can land in `main` if missed.
+- The Important finding is a real test gap, not a style nit.
+- The Question doesn't claim a defect — the doc could be either the
+  new source of truth or stale. Reviewer flags it; author decides.
+- The Summary is two sentences. It does not restate stated intent.
+  It does state a recommendation.
+- File:line on every finding.
+- No suggested patch in the review — only one-line fix hints. If
+  the maintainer says "now fix it," the agent leaves review mode
+  and runs the [`commit`](../commit/SKILL.md) skill on a fresh
+  branch.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,6 +45,7 @@ and open the relevant `SKILL.md` before executing the operation.
 | Onboard a new agent | [`add-agent`](.claude/skills/add-agent/SKILL.md) | Before a new coding agent touches this repo. Covers machine-user provisioning, SSH alias, identity-table row, `.gitignore` rules. |
 | Edit a guidance file | [`update-guidance`](.claude/skills/update-guidance/SKILL.md) | When changing `AGENTS.md`, `CLAUDE.md`, any `SKILL.md`, or `CLAUDE.local.md*`. Covers where each piece belongs, line budgets, anchor hygiene. |
 | Propose a roadmap change | [`propose-roadmap`](.claude/skills/propose-roadmap/SKILL.md) | When moving an item between `roadmap/` files, adding a new candidate, or flagging something for rejection. Covers PR format and the one-move-per-PR rule. |
+| Review a pull request | [`review-pr`](.claude/skills/review-pr/SKILL.md) | When asked to review a PR, review a diff, or do a pre-landing inspection. Covers GitHub PR review with `gh`, local-diff review, the severity ladder, and the findings-first report shape. Review mode is not implementation mode. |
 | Reset local plugin state for a fresh install test | [`dev-reset`](.claude/skills/dev-reset/SKILL.md) | Before a contributor smoke-tests the first-run flow or `claude --plugin-dir "$(pwd)"` iteration. Wipes every Tinyhat byte + plugin registration the local machine holds; dry-run by default. Contributor-only — never packaged. |
 
 When a skill's `description` matches what you're about to do, invoke it


### PR DESCRIPTION
## Summary

Adds `.claude/skills/review-pr/` (a `SKILL.md` plus a dry-run
`example.md` transcript) and registers the skill in `AGENTS.md`. The
skill keeps the agent in review mode — concrete bugs, regressions,
missing tests, merge risks, with file:line references — instead of
drifting into summaries or implementation.

## Linked issue

Closes #80

## Type of change

- [x] `feat` — new feature
- [x] `docs` — documentation only

## What's in the skill

- **Surface resolution:** `gh` recipe for GitHub PRs (metadata,
  diff, files, comments, `gh pr checkout` for context-heavy diffs)
  *and* a recipe for local uncommitted diffs (`git diff`,
  `git diff --staged`, `origin/main...HEAD`, `git status` for
  untracked files).
- **Severity ladder:** Blocker / Important / Minor / Question / Nit,
  with examples for each. Findings without a tier are flagged as
  opinions.
- **Compact checklist:** correctness, tests, boundaries
  (no unrelated refactors / generated churn / secrets / local-only
  files), agent/process policy (preserves AGENTS.md non-negotiables),
  user-facing impact, integration risk (release config + skill
  metadata).
- **Report shape:** findings first, severity-ordered, file:line on
  every finding; one-line "no findings" response when clean.
- **Defect vs question:** worked examples for a good defect finding,
  a non-finding question, and a clean no-findings response.
- **Posting back:** report-style PR review by default, line comments
  only on request; never `--approve` / `--request-changes` from a
  bot.
- **Non-negotiables:** review mode is not implementation mode unless
  the maintainer explicitly asks for fixes.
- **Dry-run fixture:** `example.md` walks a fictional PR end-to-end
  through resolve → read past the diff → tier → write up, then
  explains why each piece looks the way it does.

## Testing performed

- [x] `wc -l .claude/skills/review-pr/SKILL.md` → 186 (over the
      150-line soft ceiling but in line with `release/SKILL.md` at
      203; both skills genuinely have richer required content).
- [x] `wc -l AGENTS.md` → 88 (well under the 120-line ceiling).
- [x] All cross-file links resolve (`AGENTS.md`, `commit`,
      `open-pr`, `example.md`).
- [x] Frontmatter parses (single-line `description`, no embedded
      newlines that would confuse the resolver).

## Checklist

- [x] PR title is a Conventional Commit (`feat(skills): …`)
- [x] Linked to issue (`Closes #80`)
- [x] Docs/skill content updated (this PR *is* docs/skill content)
- [x] No references to private maintainer resources
- [x] I will not self-merge

<details>
<summary>Agent checklist</summary>

- [x] Commit signed with the Claude Code bot's SSH key and identity
- [x] Branch named `claude-code-bot/issue-80-pr-review-skill`

</details>