### PR TITLE
feat(skills): add create-issue skill for filing high-quality issues

### DIFF
--- a/.claude/skills/create-issue/SKILL.md
+++ b/.claude/skills/create-issue/SKILL.md
@@ -1,0 +1,149 @@
+---
+name: create-issue
+description: Use when filing a new issue on the tinyhat repo (or another tracker) — covers when to file vs comment, duplicate search, accepted issue types with `skill` first-class, title and body structure, the INVEST rubric Tinyhat adopts as its canonical issue-quality rule, and GitHub / Jira / Linear field mappings. Invoke before opening any new issue.
+---
+
+# create-issue — turn rough context into a high-quality work item
+
+Small, focused issues become small, focused PRs. This skill is the
+rubric for getting from "there's a problem" to a ticket someone —
+agent or human — can finish in one sitting.
+
+## 1. File, update, or comment?
+
+| Situation | Action |
+|---|---|
+| Same root cause as an open issue | Comment there with new evidence; don't file. |
+| Same root cause as a closed issue, regression | Reopen if the trail is short; otherwise file new with `Regresses #N`. |
+| Continuation of an in-flight PR's discussion | Comment on the PR. |
+| New, distinct concern | File a new issue. |
+| Vulnerability or sensitive disclosure | Use [`SECURITY.md`](../../../SECURITY.md), never a public issue. |
+
+## 2. Search for duplicates
+
+```bash
+gh issue list --repo tinyhat-ai/tinyhat --state all --search "<keyword>"
+gh issue list --repo tinyhat-ai/tinyhat --state all --label <label>
+```
+
+Search by symptom, not by your proposed fix — different reporters
+describe the same bug differently. Open the top 3 hits even if their
+titles look unrelated.
+
+## 3. Choose the type
+
+Use the **title prefix** as the primary signal (the issue templates
+default to it), the **GitHub native issue type** where one matches,
+and a **label** as the catch-all secondary tag. Verify the current
+native types with `gh api /orgs/tinyhat-ai/issue-types`.
+
+| Type | Title prefix | GitHub native | Label | When |
+|---|---|---|---|---|
+| Bug | `bug:` | Bug | `bug` | Broken behavior, regression. |
+| Feature | `feat:` | Feature | `enhancement` | New product behavior. |
+| Skill | `feat(skills):` / `chore(skills):` | Feature / Task | `skill` (always) | Create, sharpen, or govern an agent skill. |
+| Docs | `docs:` | Task | `documentation` | Documentation or guidance edits. |
+| Test | `test:` | Task | — | Test coverage or test infrastructure. |
+| Refactor | `refactor:` | Task | — | Internal restructuring, no behavior change. |
+| Chore | `chore:` | Task | — | Maintenance that doesn't fit elsewhere. |
+| CI / build | `ci:` / `build:` | Task | — | Automation, release plumbing. |
+| Security | — | — | — | **Don't file publicly** — use `SECURITY.md`. |
+
+`skill` is first-class: any issue that touches `.claude/skills/`,
+proposes a new skill, or governs how skills are written **must** carry
+the `skill` label, even when its primary type is `bug` or `docs`. The
+org doesn't yet have a native `Skill` issue type — until it does, the
+label is the source of truth for skill triage.
+
+## 4. Title
+
+`<type>(<optional scope>): <imperative subject under 72 chars>` —
+mirrors the Conventional-Commit format the repo uses for commits. The
+subject reads like a headline, not a question:
+`bug(report): doughnut charts render off from labeled %`, not
+`Charts look weird?`. Search-friendly nouns first.
+
+## 5. Body
+
+Use the matching form in `.github/ISSUE_TEMPLATE/` when one exists.
+Whether or not it does, every non-trivial issue carries: **Problem**
+(one paragraph, user terms), **Evidence** (traceback / screenshot /
+repro / log — no hand-waving), **Proposal** (write `open question`
+if unsure), **Acceptance criteria** (section 6), **Out of scope** (so
+the implementer doesn't scope-creep), and **Dependencies / links**
+(`Blocked by #N`, `Related to #M`, prior art).
+
+Use file paths, function names, and exact commands wherever you can.
+Agents handed an issue execute much faster against
+`scripts/render_report.py:42` than against "the audit script."
+
+## 6. INVEST — Tinyhat's canonical issue-quality rule
+
+Tinyhat adopts **INVEST** (Bill Wake, 2003 —
+https://xp123.com/articles/invest-in-good-stories-and-smart-tasks/) as
+the rubric every non-trivial issue is judged against:
+
+- **I**ndependent — workable without first finishing another issue,
+  or its `Blocked by` is explicit.
+- **N**egotiable — describes the desired outcome, not a frozen
+  implementation.
+- **V**aluable — the Problem paragraph names who feels the pain.
+- **E**stimable — small enough to guess "a day, two days, a week"
+  without re-reading three threads.
+- **S**mall — bigger than a single PR? Split into `parent` + `subtask`.
+- **T**estable — each acceptance criterion is a check the reviewer
+  runs (good: "`.claude/skills/create-issue/SKILL.md` exists and is
+  under 150 lines"; bad: "skill is well-organized"). Required for
+  non-trivial issues; for typo fixes write `trivial` and skip.
+
+If an issue can't pass all six, rewrite or split. **Small + Testable**
+is the tightest gate — a one-week issue with criteria like "the audit
+feels nicer" fails both.
+
+## 7. Tracker mappings
+
+| Concept | GitHub | Jira | Linear |
+|---|---|---|---|
+| Type | title prefix + native issue type + label | Issue Type | Type / Label |
+| Acceptance | `## Acceptance` in body | "Acceptance Criteria" custom field, else body | "Acceptance" subsection |
+| Dependencies | `Blocked by #N` / `Related to #M` in body | Issue links (`is blocked by`, `relates to`) | Sub-issues + relation `is blocked by` |
+| Triage queue | `triage` label | Backlog status | `Triage` workflow state |
+
+If the tracker isn't listed, mirror GitHub and ask the maintainer
+where the custom fields live.
+
+## 8. Example — a well-formed `skill` issue
+
+```text
+Title: feat(skills): add a development skill for creating high-quality issues
+Type: Feature   Labels: enhancement, skill
+
+## Problem
+Issue format drifts ticket to ticket: some are vague, some bury the
+acceptance criteria, some skip the duplicate search.
+
+## Proposal
+Add `.claude/skills/create-issue/SKILL.md` covering type taxonomy,
+title format, body structure, and one canonical rubric.
+
+## Acceptance
+- `.claude/skills/create-issue/SKILL.md` exists, listed in AGENTS.md.
+- Defines accepted types and includes `skill` first-class.
+- Names INVEST as the canonical rubric and shows how to apply it.
+- `.github/ISSUE_TEMPLATE/skill_proposal.yml` matches the skill body.
+
+## Out of scope
+Cross-tracker automation (Jira sync, Linear sync).
+```
+
+## 9. Non-negotiables
+
+- **Never paste private context** into a public issue: no
+  `CLAUDE.local.md` content, no internal Drive paths, no Slack
+  threads, no internal hostnames.
+- **Never sign an issue as the agent.** Don't append "filed by Claude
+  Code" footers; the GitHub author is enough.
+- **Never file a vulnerability publicly.** Always use `SECURITY.md`.
+- **Never file an issue that fails Small + Testable.** Split it first.
+- **Never duplicate-file** without first reading the top 3 search
+  hits, even if their titles look unrelated.

--- a/.github/ISSUE_TEMPLATE/skill_proposal.yml
+++ b/.github/ISSUE_TEMPLATE/skill_proposal.yml
@@ -1,0 +1,71 @@
+name: Skill proposal
+description: Propose a new agent skill, sharpen an existing one, or change how skills are governed.
+title: "feat(skills): "
+labels: ["enhancement", "skill", "triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this for any work that touches `.claude/skills/`. Before
+        filing, skim the [`create-issue`](../.claude/skills/create-issue/SKILL.md)
+        skill — especially the **INVEST** rubric and the
+        **Small + Testable** gate.
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem
+      description: One paragraph in user / agent terms. Who feels the pain?
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposal
+      description: |
+        New skill, edit, or governance change. If proposing a new
+        skill, suggest the directory name (`.claude/skills/<name>/`)
+        and a one-line `description:` for its frontmatter.
+    validations:
+      required: true
+
+  - type: textarea
+    id: acceptance
+    attributes:
+      label: Acceptance criteria
+      description: |
+        Concrete checks the reviewer can run — file paths, line-count
+        budgets, registration in `AGENTS.md`, etc. See section 6 of
+        the `create-issue` skill.
+      placeholder: |
+        - `.claude/skills/<name>/SKILL.md` exists, under 150 lines.
+        - Listed in `AGENTS.md`'s skills index.
+        - …
+    validations:
+      required: true
+
+  - type: textarea
+    id: out_of_scope
+    attributes:
+      label: Out of scope
+      description: What this issue intentionally won't cover.
+
+  - type: textarea
+    id: links
+    attributes:
+      label: Dependencies / links
+      description: |
+        `Blocked by #N`, `Related to #M`, prior art, upstream docs.
+
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Pre-flight
+      options:
+        - label: I searched existing issues (including the `skill` label) and didn't find a duplicate.
+          required: true
+        - label: This issue passes the **Small + Testable** gate from the `create-issue` skill.
+          required: true
+        - label: No private maintainer context (no `CLAUDE.local.md` content, internal paths, or hostnames).
+          required: true

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,6 +39,7 @@ and open the relevant `SKILL.md` before executing the operation.
 
 | Operation | Skill | When to invoke |
 |---|---|---|
+| File a new issue | [`create-issue`](.claude/skills/create-issue/SKILL.md) | Before opening any issue on the tinyhat repo (or another tracker). Covers duplicate search, type taxonomy with `skill` first-class, the INVEST rubric, and tracker mappings. |
 | Make a commit | [`commit`](.claude/skills/commit/SKILL.md) | Before every commit, especially the first on a fresh clone. Covers bot-identity preflight, signing, Conventional Commits. |
 | Open a pull request | [`open-pr`](.claude/skills/open-pr/SKILL.md) | After commits are on a branch, before `gh pr create`. Covers branch naming, PR template, review routing, no-self-merge. |
 | Cut a release | [`release`](.claude/skills/release/SKILL.md) | Reviewing or merging a release-please PR, smoke-testing a published release, or rolling one back. Covers the pre-1.0 versioning policy and the manual-release escape hatch. |


### PR DESCRIPTION
## Summary

Adds a `create-issue` development skill so agents and humans file
small, focused, well-typed tickets the same way every time.

## Linked issue

Closes #79

## Type of change

- [x] `feat` — new feature

## What's in the diff

- `.claude/skills/create-issue/SKILL.md` — the new skill, 149 lines.
  Covers when to file vs comment, duplicate search, accepted issue
  types with `skill` first-class, title and body structure, the
  **INVEST** rubric (Bill Wake, 2003) Tinyhat adopts as its canonical
  issue-quality rule, and GitHub / Jira / Linear field mappings.
  Includes a worked `skill` issue example.
- `.github/ISSUE_TEMPLATE/skill_proposal.yml` — issue form whose
  fields mirror the body structure the skill teaches, defaults the
  title to `feat(skills): ` and stamps `enhancement` + `skill` +
  `triage` labels.
- `AGENTS.md` — registers the new skill at the top of the skills
  index.

## Notes for review

- The issue asked for one canonical best-practice standard. I picked
  **INVEST** because it's the broadest well-cited rubric (six
  concrete checks), and its **Small + Testable** subset doubles as
  the tightest gate, which matches the issue's framing.
- I checked `gh api /orgs/tinyhat-ai/issue-types` — only `Task`,
  `Bug`, and `Feature` exist, no native `Skill` type. The skill
  documents this and uses the `skill` label as the source of truth
  until a native type is added.
- The repo already has a `skill` label (purple `#5319e7`), so no
  label changes were needed.

## Testing performed

- [x] `wc -l .claude/skills/create-issue/SKILL.md` → 149 (under the
  150-line ceiling).
- [x] `wc -l AGENTS.md` → 89 (under the 120-line ceiling).
- [x] All cross-file links resolve from the worktree
  (`SECURITY.md`, sibling skills, ISSUE_TEMPLATE).
- [ ] Issue-template YAML rendering will be verified on the PR
  preview after push.

## Checklist

- [x] PR title is a Conventional Commit
- [x] Linked to an issue (`Closes #79`)
- [x] Docs updated (the skill *is* the doc)
- [x] No references to private maintainer resources
- [x] I will not self-merge

<details>
<summary>Agent checklist</summary>

- [x] Commit signed with the bot's SSH key under `Claude Code <claude.farid@tinyloop.co>`
- [x] Branch named `claude-code-bot/issue-79-create-issue-skill`

</details>