### PR TITLE
docs(skills): standardize SKILL.md frontmatter policy

### DIFF
--- a/.claude/skills/update-guidance/SKILL.md
+++ b/.claude/skills/update-guidance/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: update-guidance
-description: Use when editing any contribution-guidance file in the tinyhat repo — AGENTS.md, CLAUDE.md, CLAUDE.local.md(.example), or a SKILL.md under .claude/skills/. Covers where each piece of content belongs, anchor-link hygiene, the line-count budget per file, and the thin-harness-fat-skills rule that keeps eagerly-loaded files small.
+description: Use when editing any contribution-guidance file in the tinyhat repo — AGENTS.md, CLAUDE.md, CLAUDE.local.md(.example), or a SKILL.md under .claude/skills/ or skills/. Covers where each piece of content belongs, anchor-link hygiene, the line-count budget per file, the thin-harness-fat-skills rule that keeps eagerly-loaded files small, and the SKILL.md frontmatter policy (which YAML keys to set, which to reject, how surfaces differ).
 ---
 
 # update-guidance — edit policy files without breaking the pattern
@@ -19,6 +19,7 @@ where the change actually belongs.
 | Claude-Code-specific tone, framing, scope guards | `CLAUDE.md` | Loaded per-turn by Claude Code. Keep tight. |
 | Maintainer-private context | `CLAUDE.local.md` (gitignored) | Must not ship in the public repo. |
 | Public-safe example of a local override | `CLAUDE.local.md.example` | Committed; no private URLs, no internal names. |
+| New / changed `SKILL.md` frontmatter | `SKILL.md` header + [§ 8](#8-skillmd-frontmatter-policy) | Policy decides which YAML keys are required, optional, or rejected. |
 
 **Test:** if the content is *procedure* (a sequence of steps, a
 checklist, an error-handling recipe), it's almost always a skill. If
@@ -84,3 +85,43 @@ work — on the repo's own plumbing.
 - Never paste internal-only content into a committed file.
 - Never leave a broken anchor link after renaming a section.
 - Never let `CLAUDE.md` or `CLAUDE.local.md` drift past its ceiling.
+
+## 8. SKILL.md frontmatter policy
+
+The headline rules — full reasoning and the gbrain reconciliation
+live in [`references/skill-frontmatter.md`](references/skill-frontmatter.md).
+Read the reference the first time you author or audit a SKILL.md.
+
+- **Required, both surfaces:** `name`, `description`. Set `name`
+  even on packaged `skills/` files — Claude Code falls back to the
+  directory name silently, but strict Agent Skills validators reject
+  the omission.
+- **Constraints:** `name` must match the directory and the regex
+  `^[a-z0-9]+(-[a-z0-9]+)*$`, max 64 chars, no `anthropic`/`claude`
+  substring. `description` is third-person, ≤1024 chars, and bakes
+  routing phrases inline.
+- **Optional, when warranted:** `argument-hint` for skills that take
+  args; `allowed-tools` for skills that invoke scripts;
+  `disable-model-invocation` for user-only commands. All
+  Claude-Code-specific.
+- **Rejected as top-level keys:** `triggers`, `tools`, `mutating`,
+  `version`, `writes_pages`, `writes_to`. These are gbrain
+  conventions Claude Code does not parse — `description`,
+  `allowed-tools`, an ALL-CAPS gate prefix, and git history cover the
+  same ground without dead frontmatter.
+- **Tinyhat extensions go under `metadata.*`** per the Agent Skills
+  spec's extension namespace recommendation. Do not invent new
+  top-level keys.
+- **Surface gating:** repo-scoped `.claude/skills/` keep frontmatter
+  minimal (`name` + `description` unless a script forces more);
+  packaged `skills/` add `argument-hint` + `allowed-tools` whenever
+  the skill ships a runnable script.
+
+Validate before pushing:
+
+```bash
+python3 scripts/validate_skill_frontmatter.py
+```
+
+CI's `lint` job runs the same script, so a header that drifts past
+the policy fails the build.

--- a/.claude/skills/update-guidance/references/skill-frontmatter.md
+++ b/.claude/skills/update-guidance/references/skill-frontmatter.md
@@ -1,0 +1,232 @@
+# SKILL.md frontmatter — Tinyhat header policy
+
+This is the long-form policy. The headline rules live in
+[`SKILL.md` § 8](../SKILL.md#8-skillmd-frontmatter-policy); read that
+first. Come here when you need the *why*, the field-by-field reasoning,
+or the gbrain-vs-Claude-Code reconciliation.
+
+## TL;DR
+
+- Required on every `SKILL.md`: `name`, `description`. Nothing else is
+  required by anyone.
+- Recommended-when-warranted: `argument-hint`, `allowed-tools`,
+  `disable-model-invocation`. All Claude-Code-only.
+- Reject: `triggers`, `tools`, `mutating`, `version` as top-level keys.
+  These are gbrain conventions Claude Code does not parse — adopting
+  them costs maintenance for zero runtime benefit. The information they
+  carry belongs in `description`, `allowed-tools`, or the body.
+- Tinyhat-specific extension keys go under `metadata.*`, per the Agent
+  Skills spec recommendation.
+
+## What different ecosystems actually parse
+
+Two specs govern an `SKILL.md` header. They overlap on `name` +
+`description` and diverge on everything else.
+
+| Source | Fields parsed | Behavior on unknown fields |
+|---|---|---|
+| Agent Skills spec ([agentskills.io/specification](https://agentskills.io/specification)) | Required `name`, `description`. Optional `license`, `compatibility`, `allowed-tools` (experimental), `metadata` (extension namespace). | Not strict; `metadata.*` is the documented extension point. |
+| Anthropic platform (`platform.claude.com/.../agent-skills/best-practices`) | Required `name`, `description`. | Silent on unknowns. |
+| Claude Code ([code.claude.com/docs/en/skills](https://code.claude.com/docs/en/skills)) | Adds optional `when_to_use`, `argument-hint`, `arguments`, `disable-model-invocation`, `user-invocable`, `allowed-tools`, `model`, `effort`, `context`, `agent`, `hooks`, `paths`, `shell`. | Silently ignores unknowns (no doc warning). |
+| Cursor `.cursor/rules/*.mdc` ([cursor.com/docs/context/rules](https://cursor.com/docs/context/rules)) | `description`, `globs`, `alwaysApply`. **Different file extension; does not read `SKILL.md`.** | n/a |
+| OpenAI Codex ([academy.openai.com/.../skills](https://academy.openai.com/public/resources/skills)) | No SKILL.md frontmatter contract. Codex reads `AGENTS.md`. | n/a |
+
+So portability across surfaces is decided almost entirely by `name` +
+`description`. Everything else is Claude-Code-only or Anthropic-only —
+and that is fine, because Tinyhat's distribution surface is Claude
+Code via `/plugin install`.
+
+## Field-by-field policy
+
+### `name` (required, both surfaces)
+
+Stable machine-readable id for the skill.
+
+- Constraints (Anthropic + Agent Skills): max 64 chars, lowercase
+  letters / digits / hyphens, must not start or end with a hyphen,
+  cannot contain `anthropic` or `claude`, cannot match an XML tag.
+- Must equal the directory name. The Agent Skills validator enforces
+  this; Claude Code falls back silently if missing, which is what
+  tripped the four packaged skills before #82.
+- No plugin-namespace prefix (the `tinyhat:` you see in
+  `/tinyhat:audit` is added by Claude Code at load time from
+  `.claude-plugin/plugin.json`, not by the skill).
+
+### `description` (required, both surfaces)
+
+Discovery text. Pre-loaded into the system prompt and used by Claude to
+decide when to invoke.
+
+- Hard cap: 1024 characters. (Claude Code truncates the
+  `description` + `when_to_use` listing at 1536.)
+- Third-person, present-tense imperative — describe what the skill
+  *does* and *when to use it*, not what the agent should do.
+- Bake routing phrases into the description rather than splitting them
+  into a `triggers:` field. Claude Code routes off the description; a
+  separate `triggers:` key is unparsed dead weight.
+- For destructive or restricted skills, lead with an ALL-CAPS gate
+  word so the discovery surface makes the danger obvious. The
+  `dev-reset` skill leads with `INTERNAL DEV ONLY —` and the CI
+  packaging-guard enforces that prefix; copy that pattern for any new
+  destructive skill.
+
+### `argument-hint` (optional)
+
+Display-only string shown next to the slash command in autocomplete.
+
+- Use when the skill takes positional or flag arguments and an end
+  user would not guess them.
+- Format: square-bracket flags (`[--archive] [--open]`) or
+  pipe-separated subcommands (`status | on | off | where | clear`).
+- Skip when the skill takes no args. Adding a hollow hint adds noise
+  to the autocomplete and forces a re-edit later.
+
+### `allowed-tools` (optional)
+
+Pre-approves the listed tools while the skill is active so the user is
+not prompted on every invocation. **Not a sandbox** — other tools
+remain callable, governed by the harness permission settings.
+
+- List only the tools the skill actually invokes from inline `` !`` ``
+  blocks or from documented Bash/Read/Write usage. Over-listing widens
+  the trust boundary for no benefit.
+- Format mirrors the Claude Code permission grammar:
+  `Bash(python3 *) Read Write` — space-separated, parameter globs
+  inside parentheses.
+
+### `disable-model-invocation` (optional)
+
+Set `true` to make the skill user-invocable only via `/<name>` and
+prevent the model from auto-loading it. Use sparingly — it disables
+the routing surface that makes a skill discoverable.
+
+### `model`, `effort`, `context`, `agent`, `paths`, `hooks`, `shell` (optional)
+
+Claude-Code-specific runtime knobs. None of Tinyhat's current skills
+use them. If you reach for one, document the reason in the `SKILL.md`
+body in one sentence so a future reviewer doesn't strip it as
+boilerplate.
+
+### `metadata.*` (optional, extension namespace)
+
+The Agent Skills spec carves `metadata` out as a string→string map for
+client-specific extensions. If Tinyhat ever needs to track ownership,
+review dates, or contract versions on a skill, namespace them here:
+
+```yaml
+metadata:
+  owner: tinyhat-maintainers
+  contract_version: 1
+  last_reviewed: 2026-04-25
+```
+
+Do **not** promote any of these to top-level keys. Top-level extension
+keys risk colliding with future Anthropic / Claude Code additions.
+
+## Rejected gbrain conventions
+
+[`gbrain`](https://github.com/garrytan/gbrain) ships every skill with
+`triggers`, `tools`, `mutating`, and `version` in the header. Those
+keys are consumed by gbrain's own conformance tests and its OpenClaw
+harness — Claude Code's loader ignores them. Tinyhat does not adopt
+any of the four. The reasoning per field:
+
+| gbrain key | Why Tinyhat rejects it | Where the information goes instead |
+|---|---|---|
+| `triggers` (list of phrases) | Claude Code routes from `description`; a parallel `triggers:` list duplicates that text and silently drifts. The MECE invariant gbrain enforces against it does not exist in Claude Code. | Inline in `description` — most Tinyhat skills already do this (e.g. `Triggers on "..."`). |
+| `tools` (capability advertisement) | Conflated with Claude Code's `allowed-tools` (which is a permission list, not a capability list). Two keys with similar names cause confusion. | If you mean *permissions*, use `allowed-tools`. If you mean *what the skill needs*, write a sentence in the body. |
+| `mutating` (boolean) | Not enforced anywhere; readers ignore booleans they don't recognize. | Lead the `description` with an ALL-CAPS gate (`INTERNAL DEV ONLY`, `DESTRUCTIVE —`) and put the destructive scope in the body. The `dev-reset` skill is the canonical example. |
+| `version` (semver) | Claude Code never reads it; git history is the authoritative version record; release-please tags the plugin as a whole. A skill-level version diverges from both. | If a contract version is genuinely needed (e.g. a script-API change), put it under `metadata.contract_version` so it cannot collide with a future top-level key. |
+
+`writes_pages` and `writes_to`, also from gbrain, are rejected for the
+same reason — they encode a filing audit specific to gbrain's brain
+ops; Tinyhat has no equivalent surface to enforce against.
+
+## Surface gating
+
+Two surfaces ship `SKILL.md` files in this repo, with slightly
+different defaults.
+
+### `.claude/skills/` (development skills, repo-scoped)
+
+Loaded automatically when an agent works inside this checkout. The
+audience is contributors, not end users.
+
+- Required: `name`, `description`.
+- Optional but discouraged for these skills: `argument-hint`,
+  `allowed-tools`. Add only when the skill genuinely takes args or
+  invokes scripts (`dev-reset` is the only current example).
+- Do not add `disable-model-invocation: true` here — agents need to
+  route to these skills automatically.
+
+### `skills/` (packaged plugin skills, end-user-facing)
+
+Bundled into `/plugin install tinyhat@tinyloop`. Audience is real
+users of any plugin install.
+
+- Required: `name` (Tinyhat policy goes beyond Claude Code's
+  directory-name fallback so strict Agent Skills validators stay
+  green), `description`.
+- Recommended: `argument-hint` for any skill that takes args;
+  `allowed-tools` for any skill that calls scripts. End users rely on
+  these for autocomplete + permission preflight.
+- Forbidden: any reference to `dev-reset` or other dev-only scripts
+  (CI's `.github/scripts/check_packaging.sh` enforces this).
+
+## Validation
+
+Run the stdlib-only checker before opening a PR:
+
+```bash
+python3 scripts/validate_skill_frontmatter.py
+```
+
+It enforces:
+
+1. The frontmatter block exists and is well-formed (`---`-fenced YAML
+   at the top of the file).
+2. `name` and `description` are present.
+3. `name` matches the directory name and the Anthropic regex
+   (`^[a-z0-9]+(-[a-z0-9]+)*$`, ≤64 chars, no `anthropic`/`claude`
+   substring).
+4. `description` is ≤1024 characters.
+5. No top-level `triggers`, `tools`, `mutating`, `version`,
+   `writes_pages`, or `writes_to` keys leak in. (Use `metadata.*` if
+   you really need a custom field.)
+
+CI runs the validator in the `lint` job, so a header that drifts past
+the policy fails the build. To wire it into pre-commit, add this hook
+locally:
+
+```yaml
+- repo: local
+  hooks:
+    - id: validate-skill-frontmatter
+      name: validate SKILL.md frontmatter
+      entry: python3 scripts/validate_skill_frontmatter.py
+      language: system
+      pass_filenames: false
+      files: ^(\.claude/)?skills/.*/SKILL\.md$
+```
+
+The validator deliberately does not use `pyyaml` so the smoke matrix
+and end-user installs stay dep-free, matching `pyproject.toml`'s
+"stdlib only" stance.
+
+## Audit log — where the existing skills landed
+
+A pre-#82 audit caught two classes of drift:
+
+- All four packaged skills (`skills/audit`, `skills/history`,
+  `skills/open`, `skills/routine`) omitted `name`. Fixed in #82 —
+  they now declare `name: <dir>` so Agent-Skills-strict validators
+  pass.
+- Every `.claude/skills/*/SKILL.md` already conforms (`name` +
+  `description`; `dev-reset` adds `argument-hint` + `allowed-tools`,
+  which is appropriate for the only repo-scoped skill that actually
+  runs a script).
+
+When you add or edit a skill, run the validator and append a one-line
+audit entry to the relevant PR description rather than expanding this
+section — the policy is the durable artifact; the audit log lives in
+git history.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,9 @@ jobs:
       - name: ruff format --check
         run: ruff format --check .
 
+      - name: Validate every SKILL.md frontmatter
+        run: python3 scripts/validate_skill_frontmatter.py
+
   smoke:
     name: smoke
     runs-on: ${{ matrix.os }}

--- a/scripts/validate_skill_frontmatter.py
+++ b/scripts/validate_skill_frontmatter.py
@@ -1,0 +1,264 @@
+#!/usr/bin/env python3
+"""Validate every SKILL.md frontmatter against Tinyhat's header policy.
+
+Policy lives at ``.claude/skills/update-guidance/references/skill-frontmatter.md``.
+This script enforces the machine-checkable parts so a header that drifts
+past the policy fails CI.
+
+Stdlib only — the validator must run in the smoke matrix (Python 3.9, 3.11,
+3.12 on Ubuntu and macOS) without an extra ``pip install`` step, matching
+the "stdlib only" stance in ``pyproject.toml``.
+
+Exit 0 on a clean tree, 1 on any policy violation. With ``--fix`` it would
+attempt automatic repairs, but no auto-fix exists yet — every violation in
+the current tree was a one-time backfill landed in the same PR that added
+this script.
+
+Usage::
+
+    python3 scripts/validate_skill_frontmatter.py                # repo root
+    python3 scripts/validate_skill_frontmatter.py path/to/SKILL.md ...
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+# Anthropic's published constraints on `name` and `description`. Mirrored from
+# https://platform.claude.com/docs/en/agents-and-tools/agent-skills/best-practices
+# and https://agentskills.io/specification.
+NAME_RE = re.compile(r"^[a-z0-9]+(-[a-z0-9]+)*$")
+NAME_MAX_LEN = 64
+NAME_FORBIDDEN_SUBSTRINGS = ("anthropic", "claude")
+DESCRIPTION_MAX_LEN = 1024
+
+# gbrain ships these as top-level keys; Claude Code does not parse them.
+# Tinyhat rejects them at the top level — see the policy reference for the
+# per-key reasoning. Use ``metadata.*`` for genuine extension keys.
+DISALLOWED_TOP_LEVEL_KEYS = (
+    "triggers",
+    "tools",
+    "mutating",
+    "version",
+    "writes_pages",
+    "writes_to",
+)
+
+# Top-level keys Tinyhat policy treats as known-good. Anything else is
+# warned (not failed) so a future Claude Code addition is surfaced for
+# review without breaking the build.
+KNOWN_TOP_LEVEL_KEYS = frozenset(
+    {
+        "name",
+        "description",
+        "when_to_use",
+        "argument-hint",
+        "arguments",
+        "allowed-tools",
+        "disable-model-invocation",
+        "user-invocable",
+        "model",
+        "effort",
+        "context",
+        "agent",
+        "hooks",
+        "paths",
+        "shell",
+        "license",
+        "compatibility",
+        "metadata",
+    }
+)
+
+
+def _find_skill_files(roots: list[Path]) -> list[Path]:
+    """Discover every ``SKILL.md`` under the given roots."""
+    found: list[Path] = []
+    for root in roots:
+        if root.is_file():
+            found.append(root)
+            continue
+        if not root.is_dir():
+            continue
+        for path in sorted(root.rglob("SKILL.md")):
+            # Ignore nested worktrees that sit under the scan root, but not
+            # the worktree we're scanning *from* (the absolute path always
+            # contains ".claude/worktrees" in that case).
+            try:
+                relative = path.relative_to(root)
+            except ValueError:
+                relative = path
+            if ".claude/worktrees" in relative.as_posix():
+                continue
+            found.append(path)
+    return found
+
+
+def _extract_frontmatter(text: str) -> tuple[str, int] | None:
+    """Return the YAML frontmatter block and the line number it ends on.
+
+    Returns ``None`` if the file does not start with a ``---`` fence.
+    """
+    lines = text.splitlines()
+    if not lines or lines[0].strip() != "---":
+        return None
+    for idx in range(1, len(lines)):
+        if lines[idx].strip() == "---":
+            return ("\n".join(lines[1:idx]), idx + 1)
+    return None
+
+
+# Minimal YAML reader for the bounded shape SKILL.md frontmatter actually
+# uses. We only need to enumerate top-level keys and read the string value
+# of ``name`` + ``description``. A full YAML parser would pull pyyaml as
+# a dependency; the SKILL.md surface is small enough to hand-parse.
+_KEY_LINE_RE = re.compile(r"^([A-Za-z_][\w-]*)\s*:\s*(.*)$")
+
+
+def _parse_top_level_keys(block: str) -> dict[str, str | None]:
+    """Return ``{key: scalar_or_None}`` for top-level keys in the block.
+
+    A scalar value is the raw text after the colon (whitespace-stripped).
+    A key with a list / block / nested-mapping value is returned as ``None``
+    — that is enough for the checks this script needs to perform.
+    """
+    keys: dict[str, str | None] = {}
+    for line in block.splitlines():
+        if not line or line.startswith("#"):
+            continue
+        # A top-level key starts at column 0; nested keys are indented.
+        if line[0] in (" ", "\t"):
+            continue
+        match = _KEY_LINE_RE.match(line)
+        if not match:
+            continue
+        key, raw_value = match.group(1), match.group(2).strip()
+        if not raw_value or raw_value in ("|", ">"):
+            keys[key] = None
+        else:
+            keys[key] = _strip_quotes(raw_value)
+    return keys
+
+
+def _strip_quotes(value: str) -> str:
+    if len(value) >= 2 and value[0] == value[-1] and value[0] in ("'", '"'):
+        return value[1:-1]
+    return value
+
+
+def _check_skill(path: Path) -> list[str]:
+    """Return a list of human-readable violation strings; empty == clean."""
+    violations: list[str] = []
+    try:
+        text = path.read_text(encoding="utf-8")
+    except OSError as exc:
+        return [f"{path}: cannot read file ({exc})"]
+
+    extracted = _extract_frontmatter(text)
+    if extracted is None:
+        violations.append(f"{path}: missing YAML frontmatter (expected '---' at line 1)")
+        return violations
+
+    block, _ = extracted
+    keys = _parse_top_level_keys(block)
+
+    # 1. Required keys.
+    for required in ("name", "description"):
+        if required not in keys:
+            violations.append(f"{path}: missing required frontmatter key `{required}`")
+
+    # 2. Disallowed gbrain-style top-level keys.
+    for bad in DISALLOWED_TOP_LEVEL_KEYS:
+        if bad in keys:
+            violations.append(
+                f"{path}: top-level key `{bad}` is rejected by Tinyhat policy "
+                f"(see references/skill-frontmatter.md). Move under `metadata.*` "
+                f"if a custom field is genuinely needed."
+            )
+
+    # 3. Unknown keys → warning, not failure (surface in stderr but exit 0).
+    unknown = sorted(set(keys) - KNOWN_TOP_LEVEL_KEYS - set(DISALLOWED_TOP_LEVEL_KEYS))
+    for key in unknown:
+        print(
+            f"{path}: warning — unrecognized top-level key `{key}`. "
+            f"If this is a Claude Code addition, update KNOWN_TOP_LEVEL_KEYS "
+            f"in {Path(__file__).name}.",
+            file=sys.stderr,
+        )
+
+    # 4. `name` shape + directory match.
+    name = keys.get("name")
+    if name is not None:
+        if name is None or name == "":
+            violations.append(f"{path}: `name` is empty")
+        elif len(name) > NAME_MAX_LEN:
+            violations.append(f"{path}: `name` exceeds {NAME_MAX_LEN} chars (got {len(name)})")
+        elif not NAME_RE.match(name):
+            violations.append(
+                f"{path}: `name` must match {NAME_RE.pattern} "
+                f"(lowercase letters/digits/hyphens, no leading/trailing hyphen). Got: {name!r}"
+            )
+        else:
+            for forbidden in NAME_FORBIDDEN_SUBSTRINGS:
+                if forbidden in name:
+                    violations.append(f"{path}: `name` cannot contain {forbidden!r}")
+            expected_dir = path.parent.name
+            if name != expected_dir:
+                violations.append(
+                    f"{path}: `name: {name}` must equal the parent directory name `{expected_dir}`"
+                )
+
+    # 5. `description` length.
+    description = keys.get("description")
+    if isinstance(description, str) and len(description) > DESCRIPTION_MAX_LEN:
+        violations.append(
+            f"{path}: `description` exceeds {DESCRIPTION_MAX_LEN} chars (got {len(description)})"
+        )
+
+    return violations
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument(
+        "paths",
+        nargs="*",
+        type=Path,
+        help="SKILL.md files or directories to scan. Defaults to .claude/skills and skills.",
+    )
+    args = parser.parse_args(argv)
+
+    if args.paths:
+        roots = args.paths
+    else:
+        repo_root = Path(__file__).resolve().parent.parent
+        roots = [repo_root / ".claude" / "skills", repo_root / "skills"]
+
+    skill_files = _find_skill_files(roots)
+    if not skill_files:
+        print("validate_skill_frontmatter: no SKILL.md files found", file=sys.stderr)
+        return 0
+
+    all_violations: list[str] = []
+    for path in skill_files:
+        all_violations.extend(_check_skill(path))
+
+    if all_violations:
+        for line in all_violations:
+            print(line, file=sys.stderr)
+        print(
+            f"\nvalidate_skill_frontmatter: {len(all_violations)} violation(s) "
+            f"across {len(skill_files)} SKILL.md file(s).",
+            file=sys.stderr,
+        )
+        return 1
+
+    print(f"validate_skill_frontmatter: ok ({len(skill_files)} SKILL.md files clean).")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/skills/audit/SKILL.md
+++ b/skills/audit/SKILL.md
@@ -1,4 +1,5 @@
 ---
+name: audit
 description: Audit which Claude Code skills you actually use, which look dormant, and what to create next. Produces an agent-authored local HTML+markdown report on the data already on disk. Triggers on "audit my skills", "run a skill audit", "review my skill usage", "clean up unused skills", "trim my skill set", "which skills should I remove", "how am I using Claude", "which skills am I actually using", "what skills should I create", "refresh my tinyhat report", or explicit /tinyhat:audit invocations.
 argument-hint: [--archive] [--open]
 allowed-tools: Bash(python3 *) Bash(CLAUDE_PLUGIN_DATA=* python3 *) Bash(open *) Bash(xdg-open *) Bash(start *) Read Write

--- a/skills/history/SKILL.md
+++ b/skills/history/SKILL.md
@@ -1,4 +1,5 @@
 ---
+name: history
 description: Open the skill-audit history page — a local index of the latest report plus every dated archive snapshot (up to 31), with links to each. Triggers on "show my skill audit history", "browse my tinyhat audits over time", "list all my skill audits", "see previous skill audits", "open the audit archive", "show the tinyhat archive", or explicit /tinyhat:history invocations.
 allowed-tools: Bash(open *) Bash(xdg-open *) Bash(start *) Bash(python3 *) Bash(CLAUDE_PLUGIN_DATA=* python3 *) Read
 ---

--- a/skills/open/SKILL.md
+++ b/skills/open/SKILL.md
@@ -1,4 +1,5 @@
 ---
+name: open
 description: Open the most recent Tinyhat skill-audit report (HTML) in the user's default browser, or answer a specific question about it from the persisted JSON — does NOT regenerate. Triggers on "open my latest skill audit", "show my latest tinyhat report", "open the last skill audit", "what did the skill audit say", "remind me what the audit said about X", "which skills are dormant", "open the skill audit report", "open tinyhat", or explicit /tinyhat:open invocations. If no report exists yet, hand off to /tinyhat:audit to create the first one.
 allowed-tools: Bash(open *) Bash(xdg-open *) Bash(start *) Bash(python3 *) Bash(CLAUDE_PLUGIN_DATA=* python3 *) Read
 ---

--- a/skills/routine/SKILL.md
+++ b/skills/routine/SKILL.md
@@ -1,4 +1,5 @@
 ---
+name: routine
 description: Manage the Tinyhat adaptive daily refresh and related housekeeping — show routine status, turn the daily auto-run on or off, print the paths Tinyhat reads and writes, or clear the dated-archive directory. Triggers on "is tinyhat's daily run on", "check tinyhat routine", "turn off tinyhat daily", "disable tinyhat auto-refresh", "enable tinyhat daily", "where does tinyhat save files", "clear tinyhat archive", "delete my tinyhat history", or explicit /tinyhat:routine invocations with an arg.
 argument-hint: status | on | off | where | clear
 allowed-tools: Bash(python3 *) Bash(CLAUDE_PLUGIN_DATA=* python3 *) Read


### PR DESCRIPTION
## Summary

Documents Tinyhat's `SKILL.md` YAML frontmatter policy after researching Anthropic's Agent Skills spec, Claude Code's extended frontmatter, [`gbrain`](https://github.com/garrytan/gbrain)'s conventions, Cursor's `.cursor/rules/*.mdc`, and OpenAI Codex (which has no `SKILL.md` contract). Adds a stdlib-only validator and backfills `name:` on the four packaged skills that were relying on Claude Code's directory-name fallback. Sets a forward-compatible header policy on both `.claude/skills/` (development skills) and `skills/` (packaged plugin skills).

## Linked issue

Closes #82

## Type of change

- [x] `docs` — documentation only
- [x] `chore` / `ci` / `build` — tooling (validator + CI step)

## What's in the change

- New policy reference `.claude/skills/update-guidance/references/skill-frontmatter.md` (~230 lines) with field-by-field reasoning, the gbrain reconciliation, and surface gating.
- New § 8 in `.claude/skills/update-guidance/SKILL.md` summarizing the rules, plus a row in the "Where does this change belong?" table; description expanded to mention frontmatter editing.
- `name:` added to `skills/audit`, `skills/history`, `skills/open`, `skills/routine` so strict Agent Skills validators stay green (Claude Code's directory-name fallback masked the omission).
- New `scripts/validate_skill_frontmatter.py` (stdlib-only, no `pyyaml`): enforces required keys, name regex + directory match, ≤1024-char description, and rejects gbrain-style top-level `triggers`/`tools`/`mutating`/`version`/`writes_pages`/`writes_to`. Warns (does not fail) on unknown keys so a future Claude Code addition is surfaced for review.
- Wired the validator into the `lint` job in `.github/workflows/ci.yml`.

## Policy summary (the `gbrain` evaluation the issue asked for)

| gbrain field | Tinyhat decision | Rationale |
|---|---|---|
| `triggers` | Reject as top-level | Claude Code routes from `description`; bake phrases inline. |
| `tools` | Reject as top-level | Conflated with Claude Code's `allowed-tools` (which is a permission list, not a capability list). Use `allowed-tools` for permissions; describe capabilities in the body. |
| `mutating` | Reject as top-level | Not enforced anywhere. Lead the `description` with an ALL-CAPS gate (`INTERNAL DEV ONLY`) — `dev-reset` is the canonical example, enforced by `check_packaging.sh`. |
| `version` | Reject as top-level | Claude Code never reads it; git history + release-please tags are authoritative. Use `metadata.contract_version` if a script-API version is genuinely needed. |
| `metadata.*` | Adopt as the extension namespace | Per Agent Skills spec: clients should namespace extension keys to avoid colliding with future top-level additions. |

## Testing performed

- [x] `python3 scripts/validate_skill_frontmatter.py` → `ok (12 SKILL.md files clean)`
- [x] Synthetic fixture with all four rejected gbrain keys + a malformed `name` → 5 violations reported, exit 1
- [x] `bash .github/scripts/check_packaging.sh` → `packaging-guard: ok`
- [x] `python3 -m ruff check .` and `python3 -m ruff format --check .` pass
- [ ] Did not run `gather_snapshot.py` / `render_report.py` — this PR doesn't touch the audit pipeline
- [ ] Did not exercise via `claude --plugin-dir` — pure docs + CI tooling change with no skill behavior change

## Audit (acceptance criterion)

Audited every existing `SKILL.md` against the proposed policy:

- All 8 `.claude/skills/*/SKILL.md` already conformed (`name` + `description`; `dev-reset` correctly adds `argument-hint` + `allowed-tools` because it runs a script).
- All 4 `skills/*/SKILL.md` were missing `name`. Backfilled in this PR.

## Checklist

- [x] PR title is a Conventional Commit
- [x] Linked to an issue (`Closes #82`)
- [x] Docs updated where behavior changed (the policy IS the docs)
- [x] No references to private maintainer resources
- [x] I will not self-merge

<details>
<summary>Agent checklist</summary>

- [x] Commit signed with the bot's SSH key and identity — verified with `git log --show-signature -1` (`Good "git" signature for claude.farid@tinyloop.co`).
- [x] Branch named `claude-code-bot/skill-frontmatter-policy`.

</details>