### PR TITLE
feat(skills): make development skills portable across Claude, Codex, Cursor (closes #83)

### DIFF
--- a/.agents/skills
+++ b/.agents/skills
@@ -1,0 +1,1 @@
+../.claude/skills

--- a/.claude/skills/add-agent/SKILL.md
+++ b/.claude/skills/add-agent/SKILL.md
@@ -85,6 +85,17 @@ If the agent reads a dedicated instruction file (like `CLAUDE.md`,
 `.clinerules`, `.windsurfrules`), add a **thin** file that defers to
 `AGENTS.md`. Do not duplicate policy.
 
+If the agent **reads `AGENTS.md` natively** (Codex), no extra
+instruction file is needed — `AGENTS.md` is the entry point and the
+`.agents/skills` symlink already exposes every dev skill via the
+agent's progressive disclosure. If the agent **does not read
+`SKILL.md`** (Cursor), it needs a `.cursor/rules/<name>.mdc` adapter
+per dev skill that points at the canonical `SKILL.md`. The fan-out
+rule lives in
+[`update-guidance`](../update-guidance/SKILL.md#6-cross-agent-fan-out-when-adding-or-editing-a-dev-skill);
+the layout rationale and matrix live in
+[`docs/cross-agent-skills.md`](../../../docs/cross-agent-skills.md).
+
 Add the agent's bot PAT to `gh` so the onboarding PR can be opened
 under the new agent's identity:
 

--- a/.claude/skills/update-guidance/SKILL.md
+++ b/.claude/skills/update-guidance/SKILL.md
@@ -19,6 +19,7 @@ where the change actually belongs.
 | Claude-Code-specific tone, framing, scope guards | `CLAUDE.md` | Loaded per-turn by Claude Code. Keep tight. |
 | Maintainer-private context | `CLAUDE.local.md` (gitignored) | Must not ship in the public repo. |
 | Public-safe example of a local override | `CLAUDE.local.md.example` | Committed; no private URLs, no internal names. |
+| Cross-agent skill discovery layout | `docs/cross-agent-skills.md` | Compatibility matrix + drift-prevention rule. Cite from `AGENTS.md` rather than inlining. |
 
 **Test:** if the content is *procedure* (a sequence of steps, a
 checklist, an error-handling recipe), it's almost always a skill. If
@@ -68,7 +69,34 @@ public repo learn something I only know from `CLAUDE.local.md` or
 other internal material?* If yes, rewrite or move it to
 `CLAUDE.local.md`.
 
-## 6. The meta-rule
+## 6. Cross-agent fan-out (when adding or editing a dev skill)
+
+`.claude/skills/<name>/SKILL.md` is canonical. Codex discovers it
+through the `.agents/skills` symlink (zero-drift). Cursor cannot read
+`SKILL.md` at all and needs a `.cursor/rules/<name>.mdc` adapter whose
+`description:` mirrors the canonical frontmatter description. Whenever
+you add, rename, or change the `description:` of a dev skill:
+
+- **New skill.** Drop a matching `.cursor/rules/<name>.mdc` adapter in
+  the same PR. Use an existing adapter as the template — frontmatter
+  is `description` (verbatim copy), `globs:` (empty), `alwaysApply:
+  false`, body is a 6–10 line pointer at the canonical `SKILL.md`.
+  Add the skill's row to the index in `AGENTS.md`.
+- **Renamed skill.** Rename the `.cursor/rules/<name>.mdc` adapter and
+  update the link target in its body. The `.agents/skills` symlink
+  follows the canonical directory rename automatically.
+- **Edited `description:`.** Copy the new value into the matching
+  `.cursor/rules/<name>.mdc` in the same commit. Run the drift check
+  in [`docs/cross-agent-skills.md`](../../../docs/cross-agent-skills.md)
+  to confirm.
+- **Deleted skill.** Delete the matching `.cursor/rules/<name>.mdc`
+  adapter and remove the row from the `AGENTS.md` index.
+
+The `.agents/skills` symlink and the matrix live in
+[`docs/cross-agent-skills.md`](../../../docs/cross-agent-skills.md).
+Don't inline the matrix into `AGENTS.md` or `CLAUDE.md` — link to it.
+
+## 7. The meta-rule
 
 This file you're reading is itself a skill. If a procedure in
 `AGENTS.md` or `CLAUDE.md` is longer than a paragraph, the right move
@@ -77,10 +105,14 @@ is almost always to extract it into a new skill under
 file. That's dogfooding Tinyhat's thesis — skills are the unit of
 work — on the repo's own plumbing.
 
-## 7. Non-negotiables
+## 8. Non-negotiables
 
 - Never edit a guidance file directly on `main` — every change goes
   through a PR.
 - Never paste internal-only content into a committed file.
 - Never leave a broken anchor link after renaming a section.
 - Never let `CLAUDE.md` or `CLAUDE.local.md` drift past its ceiling.
+- Never add a dev skill under `.claude/skills/` without the matching
+  `.cursor/rules/<name>.mdc` adapter and `AGENTS.md` index row in the
+  same PR. Codex picks it up automatically via the symlink, but Cursor
+  is invisible to it without an adapter.

--- a/.cursor/rules/add-agent.mdc
+++ b/.cursor/rules/add-agent.mdc
@@ -1,0 +1,17 @@
+---
+description: Use when the maintainer onboards a new AI coding agent (Aider, Gemini CLI, Windsurf, Cline, a new Claude/Cursor/Codex instance on a new machine, etc.) to contribute to the tinyhat repo under a bot identity. Covers machine-user provisioning, SSH key + host alias setup, adding the agent row to the private bot identity table in CLAUDE.local.md, and the `.gitignore` pattern for the agent's machine-local state.
+globs:
+alwaysApply: false
+---
+
+# add-agent (Cursor adapter)
+
+Tinyhat's authoritative procedure for this operation lives at
+[`.claude/skills/add-agent/SKILL.md`](../../.claude/skills/add-agent/SKILL.md).
+Open and follow that file verbatim before provisioning a new bot
+identity. Do not improvise from this adapter — `SKILL.md` has the
+full procedure, the SSH alias setup, and the non-negotiables.
+
+Why this adapter exists: see
+[`docs/cross-agent-skills.md`](../../docs/cross-agent-skills.md). The
+canonical file is the single source of truth.

--- a/.cursor/rules/commit.mdc
+++ b/.cursor/rules/commit.mdc
@@ -1,0 +1,17 @@
+---
+description: Use when making a commit to the tinyhat repo. If a maintainer-private bot identity table is present in CLAUDE.local.md, use the inline-override pattern described here so agent commits are SSH-signed under a bot identity. Otherwise commit as whoever owns the local git config. Also covers Conventional Commits. Invoke before every commit.
+globs:
+alwaysApply: false
+---
+
+# commit (Cursor adapter)
+
+Tinyhat's authoritative procedure for this operation lives at
+[`.claude/skills/commit/SKILL.md`](../../.claude/skills/commit/SKILL.md).
+Open and follow that file verbatim before staging or running
+`git commit`. Do not improvise from this adapter — `SKILL.md` has the
+full procedure, the preflight checks, and the non-negotiables.
+
+Why this adapter exists: see
+[`docs/cross-agent-skills.md`](../../docs/cross-agent-skills.md). The
+canonical file is the single source of truth.

--- a/.cursor/rules/dev-reset.mdc
+++ b/.cursor/rules/dev-reset.mdc
@@ -1,0 +1,16 @@
+---
+description: INTERNAL DEV ONLY — wipe every byte Tinyhat wrote on this machine so the maintainer can smoke-test a clean first-run install. Repo-scoped, never shipped to end users. Triggers on "reset tinyhat state", "reset my tinyhat for a fresh test", "wipe tinyhat", "pretend I've never installed tinyhat", or explicit `/tinyhat:dev:reset` / `/dev-reset` invocations. Do NOT invoke this on intent like "clean up my skills" (that's `/tinyhat:audit`).
+globs:
+alwaysApply: false
+---
+
+# dev-reset (Cursor adapter)
+
+Tinyhat's authoritative procedure for this operation lives at
+[`.claude/skills/dev-reset/SKILL.md`](../../.claude/skills/dev-reset/SKILL.md).
+Open and follow that file verbatim. This is INTERNAL DEV ONLY —
+contributor-facing, never shipped. Do not improvise from this adapter.
+
+Why this adapter exists: see
+[`docs/cross-agent-skills.md`](../../docs/cross-agent-skills.md). The
+canonical file is the single source of truth.

--- a/.cursor/rules/open-pr.mdc
+++ b/.cursor/rules/open-pr.mdc
@@ -1,0 +1,18 @@
+---
+description: Use when opening a pull request on the tinyhat repo. If a maintainer-private bot identity table is present in CLAUDE.local.md, push with the bot's SSH key and open the PR under the bot's GitHub user. Otherwise just push and open normally. Also covers branch naming and the no-self-merge rule. Invoke after commits land on a branch.
+globs:
+alwaysApply: false
+---
+
+# open-pr (Cursor adapter)
+
+Tinyhat's authoritative procedure for this operation lives at
+[`.claude/skills/open-pr/SKILL.md`](../../.claude/skills/open-pr/SKILL.md).
+Open and follow that file verbatim before pushing or running
+`gh pr create`. Do not improvise from this adapter — `SKILL.md` has
+the full procedure, the inline-override pattern, and the
+non-negotiables.
+
+Why this adapter exists: see
+[`docs/cross-agent-skills.md`](../../docs/cross-agent-skills.md). The
+canonical file is the single source of truth.

--- a/.cursor/rules/propose-roadmap.mdc
+++ b/.cursor/rules/propose-roadmap.mdc
@@ -1,0 +1,16 @@
+---
+description: Use when a contributor (human or agent) wants to propose a change to the Tinyhat roadmap — moving an item between now/next/later/considering, adding a new candidate, or flagging something for rejection. Covers the required PR format and what makes a proposal reviewable. Invoke instead of editing roadmap files directly.
+globs:
+alwaysApply: false
+---
+
+# propose-roadmap (Cursor adapter)
+
+Tinyhat's authoritative procedure for this operation lives at
+[`.claude/skills/propose-roadmap/SKILL.md`](../../.claude/skills/propose-roadmap/SKILL.md).
+Open and follow that file verbatim before editing any roadmap file or
+opening a roadmap-change PR. Do not improvise from this adapter.
+
+Why this adapter exists: see
+[`docs/cross-agent-skills.md`](../../docs/cross-agent-skills.md). The
+canonical file is the single source of truth.

--- a/.cursor/rules/release.mdc
+++ b/.cursor/rules/release.mdc
@@ -1,0 +1,18 @@
+---
+description: Use when cutting a Tinyhat release — reviewing the release-please PR, merging it, verifying the tag + GitHub release, smoke-testing the published plugin, or rolling back a bad release. Covers the automatic release-please flow, when to go off-script with a manual release, and the pre-1.0 versioning policy (bump-minor-pre-major). Invoke whenever you're about to land or review a release.
+globs:
+alwaysApply: false
+---
+
+# release (Cursor adapter)
+
+Tinyhat's authoritative procedure for this operation lives at
+[`.claude/skills/release/SKILL.md`](../../.claude/skills/release/SKILL.md).
+Open and follow that file verbatim before reviewing, merging, or
+rolling back a release. Do not improvise from this adapter — `SKILL.md`
+has the full procedure, the manual-release escape hatch, and the
+versioning policy.
+
+Why this adapter exists: see
+[`docs/cross-agent-skills.md`](../../docs/cross-agent-skills.md). The
+canonical file is the single source of truth.

--- a/.cursor/rules/review-changelog.mdc
+++ b/.cursor/rules/review-changelog.mdc
@@ -1,0 +1,16 @@
+---
+description: Use before merging a release-please PR on tinyhat to check that each CHANGELOG entry matches what actually shipped. Release-please cribs every bullet from the source PR's squashed-merge commit subject; if review replaced the mechanism that subject described, the bullet advertises an abandoned approach. This skill surfaces divergences and lands a rewrite on the release-please branch under the bot identity. Invoke from the `release` skill's pre-merge step, or standalone.
+globs:
+alwaysApply: false
+---
+
+# review-changelog (Cursor adapter)
+
+Tinyhat's authoritative procedure for this operation lives at
+[`.claude/skills/review-changelog/SKILL.md`](../../.claude/skills/review-changelog/SKILL.md).
+Open and follow that file verbatim before merging a release-please PR.
+Do not improvise from this adapter.
+
+Why this adapter exists: see
+[`docs/cross-agent-skills.md`](../../docs/cross-agent-skills.md). The
+canonical file is the single source of truth.

--- a/.cursor/rules/update-guidance.mdc
+++ b/.cursor/rules/update-guidance.mdc
@@ -1,0 +1,18 @@
+---
+description: Use when editing any contribution-guidance file in the tinyhat repo — AGENTS.md, CLAUDE.md, CLAUDE.local.md(.example), or a SKILL.md under .claude/skills/. Covers where each piece of content belongs, anchor-link hygiene, the line-count budget per file, and the thin-harness-fat-skills rule that keeps eagerly-loaded files small.
+globs:
+alwaysApply: false
+---
+
+# update-guidance (Cursor adapter)
+
+Tinyhat's authoritative procedure for this operation lives at
+[`.claude/skills/update-guidance/SKILL.md`](../../.claude/skills/update-guidance/SKILL.md).
+Open and follow that file verbatim before editing `AGENTS.md`,
+`CLAUDE.md`, any `SKILL.md`, or `CLAUDE.local.md*`. Do not improvise
+from this adapter — `SKILL.md` has the placement matrix, the line
+budget, and the cross-agent fan-out rule.
+
+Why this adapter exists: see
+[`docs/cross-agent-skills.md`](../../docs/cross-agent-skills.md). The
+canonical file is the single source of truth.

--- a/.gitignore
+++ b/.gitignore
@@ -51,12 +51,20 @@ build/
 .claude/shell-snapshots/
 .claude/worktrees/
 
-# Cursor — ignore all machine-local state
-.cursor/
+# Cursor — keep .cursor/rules/ (cross-agent skill adapters; see
+# docs/cross-agent-skills.md). Ignore everything else machine-local.
+.cursor/*
+!.cursor/rules/
 
 # Codex — AGENTS.md is the entry point; .codex is usually ~/.codex but
 # ignore project-local variants defensively.
 .codex/
+
+# Codex skills — keep .agents/skills (symlink to .claude/skills for
+# repo-local Codex discovery; see docs/cross-agent-skills.md). Ignore
+# everything else under .agents/ defensively.
+.agents/*
+!.agents/skills
 
 # Aider — keep .aider.conf.yml, .aiderignore if used
 .aider*

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,7 +5,9 @@ Agent-specific files (`CLAUDE.md`) defer here and do not duplicate.
 
 **Agents currently provisioned on the maintainer's machine:** Claude
 Code, Codex. The maintainer onboards new agents via the
-[`add-agent`](.claude/skills/add-agent/SKILL.md) skill.
+[`add-agent`](.claude/skills/add-agent/SKILL.md) skill. Cross-agent
+discovery (Codex via `.agents/skills/`, Cursor via `.cursor/rules/`) is
+documented in [`docs/cross-agent-skills.md`](docs/cross-agent-skills.md).
 
 ## External contributors — the short version
 
@@ -31,9 +33,14 @@ invoked. That keeps the files in every turn's context tight
 (`AGENTS.md`, `CLAUDE.md`) and the procedural detail
 rich where it actually needs to be.
 
-Agents without native skill resolution (Cursor, Codex, anything reading
-`AGENTS.md` directly) should treat the skills index below as a directory
-and open the relevant `SKILL.md` before executing the operation.
+Agents without native skill resolution (anything reading `AGENTS.md`
+directly) should treat the skills index below as a directory and open
+the relevant `SKILL.md` before executing the operation. Codex finds the
+same skills natively under `.agents/skills/` (a symlink to
+`.claude/skills/`); Cursor finds them via `.cursor/rules/<name>.mdc`
+adapters that point at the canonical `SKILL.md`. See
+[`docs/cross-agent-skills.md`](docs/cross-agent-skills.md) for the
+compatibility matrix and the rule that keeps the adapters in sync.
 
 ## Skills index — contribution operations
 
@@ -42,6 +49,7 @@ and open the relevant `SKILL.md` before executing the operation.
 | Make a commit | [`commit`](.claude/skills/commit/SKILL.md) | Before every commit, especially the first on a fresh clone. Covers bot-identity preflight, signing, Conventional Commits. |
 | Open a pull request | [`open-pr`](.claude/skills/open-pr/SKILL.md) | After commits are on a branch, before `gh pr create`. Covers branch naming, PR template, review routing, no-self-merge. |
 | Cut a release | [`release`](.claude/skills/release/SKILL.md) | Reviewing or merging a release-please PR, smoke-testing a published release, or rolling one back. Covers the pre-1.0 versioning policy and the manual-release escape hatch. |
+| Review a release CHANGELOG | [`review-changelog`](.claude/skills/review-changelog/SKILL.md) | Before merging a release-please PR. Compares each new bullet to the source PR's diff and review discussion, lands rewrites under the bot identity. Invoked from the `release` skill. |
 | Onboard a new agent | [`add-agent`](.claude/skills/add-agent/SKILL.md) | Before a new coding agent touches this repo. Covers machine-user provisioning, SSH alias, identity-table row, `.gitignore` rules. |
 | Edit a guidance file | [`update-guidance`](.claude/skills/update-guidance/SKILL.md) | When changing `AGENTS.md`, `CLAUDE.md`, any `SKILL.md`, or `CLAUDE.local.md*`. Covers where each piece belongs, line budgets, anchor hygiene. |
 | Propose a roadmap change | [`propose-roadmap`](.claude/skills/propose-roadmap/SKILL.md) | When moving an item between `roadmap/` files, adding a new candidate, or flagging something for rejection. Covers PR format and the one-move-per-PR rule. |

--- a/docs/cross-agent-skills.md
+++ b/docs/cross-agent-skills.md
@@ -1,0 +1,139 @@
+# Cross-agent skill compatibility
+
+Tinyhat's development skills (`.claude/skills/<name>/SKILL.md`) guide
+contribution operations like commits, PRs, releases, and onboarding.
+The maintainer uses Claude Code today and Codex in parallel; Cursor is
+a likely future entrant. This doc records how each tool finds the same
+skills, what's canonical, what's a generated view, and how we keep
+drift to zero.
+
+## TL;DR
+
+| Tool | Discovery path (project) | Reads `SKILL.md`? | What we ship | Maintenance per skill |
+|---|---|---|---|---|
+| Claude Code | `.claude/skills/<name>/SKILL.md` | yes (canonical) | the canonical files | n/a — canonical |
+| Codex | `.agents/skills/<name>/SKILL.md` + top-level `AGENTS.md` | yes | `.agents/skills` is a **symlink** to `.claude/skills` | none — symlink covers it |
+| Cursor | `.cursor/rules/*.mdc` + top-level `AGENTS.md` | **no** — only `.mdc` and `AGENTS.md` | a thin `.cursor/rules/<name>.mdc` adapter pointing at the canonical `SKILL.md` | one short `.mdc` per skill |
+
+Canonical source of truth is `.claude/skills/<name>/SKILL.md`. The
+symlink and adapters are generated views — never edit them directly,
+edit the canonical file and (for Cursor) refresh the description in the
+adapter.
+
+## Compatibility matrix
+
+| Aspect | Claude Code | Codex | Cursor |
+|---|---|---|---|
+| Project discovery | `.claude/skills/<name>/SKILL.md` (also nested in subdirs) | `.agents/skills/<name>/SKILL.md` walked from CWD up to repo root + `AGENTS.md` from project root down | `.cursor/rules/*.mdc` (any depth under `.cursor/rules/`) + top-level `AGENTS.md` |
+| User discovery | `~/.claude/skills/` | `~/.agents/skills/`, `~/.codex/AGENTS.md` | UI-managed user rules |
+| Frontmatter fields | `name`, `description`, `allowed-tools`, `paths`, `disable-model-invocation`, `user-invocable`, `model`, `hooks`, `arguments`, … | `name`, `description` (sidecar `agents/openai.yaml` for tool deps) | `description`, `globs`, `alwaysApply` |
+| Activation modes | progressive disclosure; `/<name>`; `paths` glob auto-load; `disable-model-invocation` for manual-only | progressive disclosure; `/skills`; `$name`; description match | Always Apply / Apply Intelligently (description) / Apply to Specific Files (`globs`) / Apply Manually (`@rule`) |
+| Tool restrictions | `allowed-tools` pre-approves (does not deny) | sidecar `agents/openai.yaml` for MCP deps | none documented |
+| Mutating-action metadata | none (workaround: `disable-model-invocation: true`) | none documented | none documented |
+| Honors top-level `AGENTS.md` | no — Claude Code reads `CLAUDE.md` | yes — primary instructions file | yes — auto-applied at project root |
+| Validation tooling | follows the [Agent Skills spec](https://agentskills.io/specification); `skills-ref validate` | follows Agent Skills spec; `skills-ref validate` | no schema validator documented |
+
+Sources: [Claude Code skills](https://code.claude.com/docs/en/skills),
+[Codex AGENTS.md](https://developers.openai.com/codex/guides/agents-md),
+[Codex skills](https://developers.openai.com/codex/skills),
+[Cursor rules](https://cursor.com/docs/context/rules),
+[agentskills.io](https://agentskills.io/specification). Verified April 2026.
+
+## Why this layout
+
+We considered four shapes. The chosen layout is the lightest one that
+gives all three tools first-class, low-drift discovery:
+
+- **Canonical at `.claude/skills/`** because Claude Code is the primary
+  agent, that path matches the agentskills.io spec verbatim, and the
+  existing skills are already there.
+- **Symlink for Codex** because Codex's `.agents/skills/` discovery is
+  identical in structure but lives at a different path. A symlink
+  costs one filesystem entry, scales to every future skill for free,
+  and cannot drift.
+- **`.mdc` adapters for Cursor** because Cursor does not read
+  `SKILL.md` files at all — only `.cursor/rules/*.mdc` and a top-level
+  `AGENTS.md`. The adapter is a 6–10 line file whose body just tells
+  Cursor's agent to open the canonical `SKILL.md`. Activation mode is
+  "Apply Intelligently" (`alwaysApply: false` + populated description),
+  so it loads only when the description matches the user's intent.
+- **`AGENTS.md` index** carries a one-line description of every skill
+  for any agent that auto-loads `AGENTS.md` (Codex, Cursor) or that
+  reads a top-level pointer (everything else). The index is
+  belt-and-suspenders coverage for non-Claude agents.
+
+We rejected:
+
+- **Generating duplicate `.agents/skills/<name>/SKILL.md` files**
+  (Codex stub directories) — adds drift without benefit when a
+  symlink works.
+- **Moving the canonical to a neutral path** like `skills-shared/` —
+  none of the three tools agree on a "neutral" location, and Claude
+  Code's plugin tooling already targets `.claude/skills/`. The move
+  would force every tool into adapter mode for no gain.
+- **A dedicated generator script** — eight skills today, low velocity.
+  The maintenance cost of one short `.mdc` per skill is below the
+  cost of a script + lint + CI hook. Re-evaluate if the dev skill
+  count grows past ~25.
+
+## Drift prevention
+
+The only fan-out point that can drift is the `description:` line in
+each `.cursor/rules/<name>.mdc`. The rule:
+
+> When you change a dev skill's `description:` in
+> `.claude/skills/<name>/SKILL.md`, copy the new value into the
+> matching `.cursor/rules/<name>.mdc` in the same commit.
+
+This rule is enforced by the
+[`update-guidance`](../.claude/skills/update-guidance/SKILL.md) skill's
+checklist. To audit by hand:
+
+```bash
+for skill in .claude/skills/*/SKILL.md; do
+  name=$(basename "$(dirname "$skill")")
+  mdc=".cursor/rules/${name}.mdc"
+  [[ -f "$mdc" ]] || { echo "missing adapter: $mdc"; continue; }
+  diff <(awk '/^description:/{sub(/^description: */,""); print; exit}' "$skill") \
+       <(awk '/^description:/{sub(/^description: */,""); print; exit}' "$mdc") \
+    >/dev/null || echo "drift: $name"
+done
+```
+
+The Codex symlink cannot drift by construction.
+
+## Cross-platform note
+
+The `.agents/skills` symlink works natively on macOS and Linux. On
+Windows, git materializes symlinks as plaintext files containing the
+target path unless symlink support is enabled (developer mode or
+admin). Tinyhat is maintained on macOS; if a Windows contributor needs
+Codex discovery, they can replace the symlink with a junction
+(`mklink /J .agents\skills .claude\skills`) locally. The repo only
+ships the symlink form.
+
+## Validation
+
+The `commit` skill is the canonical end-to-end test for this layout.
+It is reachable through every supported path:
+
+- Claude Code: `.claude/skills/commit/SKILL.md` (direct)
+- Codex: `.agents/skills/commit/SKILL.md` via the symlink, or via the
+  skills index in `AGENTS.md`
+- Cursor: `.cursor/rules/commit.mdc` triggers on commit-related
+  intent and instructs the agent to open
+  `.claude/skills/commit/SKILL.md`
+
+Each path resolves to the same content. Internal links inside the
+canonical `SKILL.md` (e.g., `../add-agent/SKILL.md`) are unchanged and
+still resolve correctly when the file is reached through the symlink.
+
+## What this doc does NOT cover
+
+- The packaged plugin skills under `skills/` (`audit`, `open`,
+  `history`, `routine`). Those are end-user Claude Code skills shipped
+  via the plugin marketplace; they are loaded by Claude Code's plugin
+  loader, not by this cross-agent layout.
+- User-level (machine-wide) skill installs. This doc is repo-local.
+- A formal generator/CI lint. We may add one if the dev skill count
+  outgrows manual maintenance.


### PR DESCRIPTION
## Summary

Tinyhat's development skills under `.claude/skills/` are now first-class for Claude Code, Codex, and Cursor without duplicating content. Canonical source stays at `.claude/skills/<name>/SKILL.md`. Codex picks up the same skills via a `.agents/skills` symlink (zero-drift, scales to new skills automatically). Cursor — which doesn't read `SKILL.md` at all — gets a thin `.cursor/rules/<name>.mdc` adapter per skill that points at the canonical file. Compatibility matrix, rationale, and a drift-check one-liner live in `docs/cross-agent-skills.md`.

## Linked issue

Closes #83

## Type of change

- [x] `feat` — new feature
- [x] `docs` — documentation only

## Testing performed

End-to-end validated `commit` skill resolves identically through every supported path:

- Claude Code: `.claude/skills/commit/SKILL.md` (direct)
- Codex: `.agents/skills/commit/SKILL.md` via the symlink
- Cursor: `.cursor/rules/commit.mdc` triggers on commit-related intent and instructs the agent to open the canonical `SKILL.md`

Internal cross-links inside `SKILL.md` (e.g. `../add-agent/SKILL.md`) resolve correctly through the symlink.

Drift audit (description-string equality across all 8 dev skills and their Cursor adapters) passes for every skill — see the script in `docs/cross-agent-skills.md#drift-prevention`.

- [x] `ruff check .` and `ruff format --check .` pass
- [x] `bash .github/scripts/check_packaging.sh` passes (dev-reset still repo-scoped, no leakage)
- [x] Symlink committed as mode 120000 (`git ls-files --stage .agents/skills`)

## Checklist

- [x] PR title is a Conventional Commit
- [x] Linked to an issue
- [x] Tests added or updated (this PR is docs / plumbing only — no code)
- [x] Docs updated where behavior changed
- [ ] CI is green (pending CI run)
- [x] No references to private maintainer resources
- [x] I will not self-merge

## What this changes

**New files**

- `docs/cross-agent-skills.md` — compatibility matrix, rationale, drift-check
- `.cursor/rules/{add-agent,commit,dev-reset,open-pr,propose-roadmap,release,review-changelog,update-guidance}.mdc` — Cursor adapter per dev skill
- `.agents/skills` — symlink to `../.claude/skills` for Codex's progressive-disclosure scanner

**Modified**

- `.gitignore` — track `.cursor/rules/` and `.agents/skills`, keep machine-local state ignored
- `AGENTS.md` — cross-agent pointer in the skills-index preamble; added the missing `review-changelog` row
- `.claude/skills/update-guidance/SKILL.md` — new section 6 codifies the cross-agent fan-out rule (new skill / rename / description edit / delete) and a non-negotiable that blocks merging a new dev skill without its `.cursor/rules/<name>.mdc` adapter and `AGENTS.md` row
- `.claude/skills/add-agent/SKILL.md` — note that Codex needs no extra instruction file (AGENTS.md + symlink covers it) and Cursor needs adapters per dev skill

## Why this layout

Researched current docs (April 2026) for all three tools, including the [agentskills.io](https://agentskills.io/specification) spec.

- **`.claude/skills/`** stays canonical because Claude Code is the primary agent, that path matches the agentskills.io spec verbatim, and the skills are already there.
- **Symlink for Codex** because Codex's `.agents/skills/` discovery has identical structure but a different path. A symlink costs one filesystem entry, scales to every future skill for free, and cannot drift.
- **`.mdc` adapters for Cursor** because Cursor only reads `.cursor/rules/*.mdc` and a top-level `AGENTS.md` — never `SKILL.md`. The adapter is short, uses Cursor's "Apply Intelligently" mode (`alwaysApply: false` + populated description), and just tells Cursor's agent to open the canonical file.
- Rejected: duplicate `.agents/skills/` stub files (drift risk for no benefit), neutral path (no tool agrees on one), and a generator script (not worth it at 8 skills).

## Cross-platform note

The `.agents/skills` symlink works natively on macOS and Linux. On Windows, git materializes symlinks as plaintext unless symlink support is enabled. Tinyhat is maintained on macOS; if a Windows contributor needs Codex discovery they can replace it with a junction locally. Documented in the new doc.

---

<details>
<summary>Agent checklist</summary>

- [x] Commits signed with the bot's SSH key and identity
- [x] Branch named `<agent>/<short-topic>` (`claude-code-bot/cross-agent-skills`)

</details>