### PR TITLE
feat(skills): add authoring standard

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -37,6 +37,7 @@ Closes #
 - [ ] PR title is a Conventional Commit.
 - [ ] Linked to an issue or this PR is the canonical spec.
 - [ ] Docs updated where behavior changed.
+- [ ] Packaged skill changes follow `docs/skill-authoring.md`.
 - [ ] CI is green.
 - [ ] No tenant secrets, signed Mini App URLs, private backend URLs, local-only
       paths, or internal docs are included.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -54,12 +54,20 @@ bash .github/scripts/check_packaging.sh
 python3 scripts/validate_openclaw_package.py
 python3 -m compileall -q scripts
 node --check src/index.js
+node --test
 pipx run ruff check .
 pipx run ruff format --check .
 ```
 
 See [docs/local-development.md](docs/local-development.md) for the
 short development loop and manual OpenClaw smoke-test guidance.
+
+## Skill Authoring
+
+Packaged skills under [`skills/`](skills) must follow
+[`docs/skill-authoring.md`](docs/skill-authoring.md). In short: keep
+skills trigger-led, focused, compact, public-safe, and routed through
+named Tinyhat tools rather than raw platform URLs.
 
 ## Scope
 

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ to use.
 | [`skills/tinyhat-platform/SKILL.md`](skills/tinyhat-platform/SKILL.md) | Compact first skill that teaches the agent the named platform operations. |
 | [`docs/capabilities.md`](docs/capabilities.md) | Public operation list, safety rules, and response boundaries. |
 | [`docs/architecture.md`](docs/architecture.md) | Runtime-vs-plugin ownership boundary. |
+| [`docs/skill-authoring.md`](docs/skill-authoring.md) | Standard for authoring packaged Tinyhat skills. |
 
 The focused router/default-skills expansion is tracked in
 [tinyhat-ai/tinyhat#94](https://github.com/tinyhat-ai/tinyhat/issues/94).
@@ -94,4 +95,6 @@ secrets, internal URLs, or private docs into this repository.
 ## Development
 
 See [docs/local-development.md](docs/local-development.md) for local
-checks and [AGENTS.md](AGENTS.md) for contribution rules.
+checks, [docs/skill-authoring.md](docs/skill-authoring.md) for
+packaged-skill standards, and [AGENTS.md](AGENTS.md) for contribution
+rules.

--- a/docs/local-development.md
+++ b/docs/local-development.md
@@ -42,7 +42,7 @@ pipx run ruff format --check .
 | --- | --- |
 | `scripts/check_dev_skills.py` | Ensures repo-local development skills and Claude adapters are wired. |
 | `.github/scripts/check_packaging.sh` | Ensures dev-only skills stay out of packaged plugin surfaces. |
-| `scripts/validate_openclaw_package.py` | Validates manifest/package/tool/skill consistency and guards against old reset artifacts. |
+| `scripts/validate_openclaw_package.py` | Validates manifest/package/tool/skill consistency, packaged-skill authoring checks, and retired-artifact guards. |
 | `node --check src/index.js` | Catches JavaScript syntax errors without needing OpenClaw installed. |
 | `node --test` | Runs pure JavaScript safety tests for redaction and command parsing. |
 | `ruff` | Lints and format-checks Python helper scripts. |

--- a/docs/skill-authoring.md
+++ b/docs/skill-authoring.md
@@ -1,0 +1,207 @@
+# Tinyhat Skill Authoring Standard
+
+Tinyhat skills teach an OpenClaw agent how to use Tinyhat platform
+capabilities safely. They are not backend docs, runtime runbooks, or
+long tutorials.
+
+This standard applies to packaged skills under [`skills/`](../skills).
+Repo-local development skills under [`.agents/skills/`](../.agents/skills)
+have their own adapter rules in [AGENTS.md](../AGENTS.md).
+
+## Research Basis
+
+This standard adapts the smallest useful subset of public skill guidance:
+
+- [Anthropic skill authoring best practices](https://platform.claude.com/docs/en/agents-and-tools/agent-skills/best-practices):
+  skill metadata is loaded first, so names and descriptions must be
+  specific, while the body should stay concise and use progressive
+  disclosure.
+- [OpenAI Codex skills docs](https://developers.openai.com/codex/skills)
+  and the [OpenAI skills repository](https://github.com/openai/skills):
+  skills package instructions, scripts, and resources for repeatable
+  capabilities that agents can discover and use.
+- [AgentSkills.io best practices](https://agentskills.io/skill-creation/best-practices.md)
+  and [description guidance](https://agentskills.io/skill-creation/optimizing-descriptions.md):
+  skills should be grounded in real tasks, spend context carefully, keep
+  `SKILL.md` focused, and make the description explicit about when the
+  skill should trigger.
+
+## What Belongs Where
+
+| Surface | Owns | Does not own |
+| --- | --- | --- |
+| `skills/` in this repo | Agent-facing decision rules, Tinyhat capability routing, safety boundaries, response contracts. | Backend endpoint specs, runtime boot/apply details, tenant secrets, raw URLs. |
+| `src/` plugin code | OpenClaw tool registration, Tinyhat HAPI calls, payload shaping, redaction, command handlers. | Long natural-language guidance. |
+| OpenClaw runtime repo | Boot, supervision, config/apply, health, pinning this plugin repo/ref. | Tinyhat skill wording or capability semantics. |
+| Tinyhat platform backend | Authenticated APIs, Computer assignment, Telegram Mini App auth, package inventory. | Packaged skill instructions. |
+| User-installed skills | User-specific workflows layered on top of Tinyhat. | Platform-default safety policy. |
+
+If a skill needs implementation detail to make one decision, summarize
+the decision rule and link to a reference. Do not copy a runbook into
+`SKILL.md`.
+
+## Package Shape
+
+Every packaged skill is a directory:
+
+```text
+skills/<skill-name>/
+|-- SKILL.md
+|-- references/   optional long examples or background
+|-- scripts/      optional deterministic helpers
+`-- assets/       optional output resources
+```
+
+Do not add `README.md`, changelogs, install guides, or unrelated files
+inside skill directories. The skill folder should contain only artifacts
+the agent may need while using that skill.
+
+## Frontmatter
+
+`SKILL.md` must start with YAML frontmatter:
+
+```yaml
+---
+name: tinyhat-platform
+description: Use Tinyhat platform capabilities from a managed OpenClaw Computer. Trigger when the user asks to add or manage secrets, open Manage Computer, open terminal access, check runtime status, list installed Tinyhat packages, ask what platform this agent runs on, or report a Tinyhat Computer problem.
+---
+```
+
+Rules:
+
+- `name` uses lowercase kebab-case and matches the directory name.
+- `description` is trigger-led: it says what the skill does and when to
+  use it.
+- Include realistic user-intent words such as "add a secret", "open
+  terminal", "Manage Computer", "status", "packages", or "report a
+  problem".
+- Keep the description under 1024 characters.
+- Avoid vague summaries such as "Helps with Tinyhat."
+
+## Body
+
+Keep `SKILL.md` compact. For this repo:
+
+- Target 40-120 lines.
+- Hard limit: 200 lines.
+- Use imperative, operational language.
+- Put routing tables, safety boundaries, response contracts, and final
+  checks in the body.
+- Move long examples, troubleshooting, fixtures, and background into
+  `references/` or scripts.
+
+The body should answer:
+
+1. Which user intents route here?
+2. Which Tinyhat tool or operation should the agent use?
+3. What must never be exposed to the user?
+4. What should the user-facing response look like?
+5. When should the agent explain that the channel cannot support the
+   action?
+
+## Thin Harness, Focused Skills, Router Model
+
+Tinyhat uses a thin harness plus focused skills:
+
+- The plugin manifest declares the capability contract.
+- `src/` registers tools and command handlers.
+- A small router skill can map broad user intent to focused skills.
+- Focused skills teach one bounded platform workflow, such as secret
+  entry or terminal access.
+
+Do not create one giant Tinyhat manual. If a skill has multiple
+independent workflows, split it.
+
+## Safety Rules
+
+Packaged Tinyhat skills must never:
+
+- ask the user to paste a secret value in chat;
+- print raw Telegram Mini App URLs, signed intent tokens, private
+  backend URLs, or Computer-private URLs;
+- tell the agent to call undocumented raw platform URLs;
+- include private repo paths, local machine paths, Drive paths,
+  internal hostnames, or tenant-specific examples;
+- put secret values into terminal commands;
+- claim that secret values are available through Tinyhat tools.
+
+Use named Tinyhat tools and structured Telegram button payloads. If the
+current channel cannot render the button, say the action must be retried
+from Telegram or Manage Computer.
+
+## Good And Bad Examples
+
+### Secret Entry
+
+Good:
+
+```markdown
+When the user asks to add `OPENAI_API_KEY`, infer the non-secret name
+and a short description, call `tinyhat_request_runtime_secret`, and
+present the Telegram Mini App button. Say the value must be entered in
+Telegram, not chat.
+```
+
+Bad:
+
+```markdown
+Ask the user to paste the API key so you can save it, or send them the
+Mini App URL if the button does not render.
+```
+
+Why: the bad version asks for a secret in chat and exposes a raw URL.
+
+### Terminal Or Manage Computer
+
+Good:
+
+```markdown
+When the user asks to open a terminal, call `tinyhat_open_terminal_link`.
+Treat any command as an admin-reviewed launch hint, never as a place for
+secret values. Render the Telegram button when supported.
+```
+
+Bad:
+
+```markdown
+Build a backend URL for the terminal page and paste it into chat. If the
+user included a token, put it in the command so the terminal starts
+ready.
+```
+
+Why: the bad version invents raw platform URLs and moves secrets into a
+command string.
+
+## Reviewer Checklist
+
+Before merging a packaged skill change:
+
+- [ ] The `description` says what the skill does and when to use it.
+- [ ] The skill is focused on one bounded Tinyhat workflow or a narrow
+      router role.
+- [ ] `SKILL.md` is under 200 lines.
+- [ ] Long examples or troubleshooting live in `references/`, scripts,
+      or docs instead of the main body.
+- [ ] The skill uses named Tinyhat tools, not raw backend URLs.
+- [ ] The skill never asks for secret values in chat.
+- [ ] The skill never tells the agent to print raw Mini App URLs or
+      signed/private URLs.
+- [ ] The skill contains no private paths, internal hostnames, or tenant
+      data.
+- [ ] Any router or default skill from #94 shipping in the same release
+      has been reviewed against this checklist.
+- [ ] `python3 scripts/validate_openclaw_package.py` passes.
+
+## Machine Checks
+
+CI enforces the cheap checks we can make reliable:
+
+- frontmatter exists and includes `name` plus `description`;
+- directory and frontmatter `name` match;
+- descriptions are trigger-led and under the length limit;
+- `SKILL.md` stays under the line limit;
+- only supported skill subdirectories are used;
+- packaged skills do not contain raw URL patterns, private-path
+  patterns, raw HAPI paths, or phrases that ask users to paste secrets.
+
+Subjective writing quality remains a reviewer responsibility.

--- a/scripts/validate_openclaw_package.py
+++ b/scripts/validate_openclaw_package.py
@@ -30,6 +30,33 @@ REQUIRED_OPERATIONS = {
     "support.report_problem": "tinyhat_report_problem",
 }
 
+SKILL_MD_MAX_LINES = 200
+SKILL_DESCRIPTION_MAX_CHARS = 1024
+ALLOWED_SKILL_SUBDIRS = {"assets", "references", "scripts"}
+TRIGGER_PHRASES = (
+    "use when",
+    "trigger when",
+    "when the user",
+    "when asked",
+)
+FORBIDDEN_SKILL_PATTERNS = {
+    "raw URL": re.compile(r"https?://", re.IGNORECASE),
+    "raw HAPI path": re.compile(r"/hapi/", re.IGNORECASE),
+    "Mini App URL field": re.compile(r"\bmini_app_url\b", re.IGNORECASE),
+    "signed URL field": re.compile(r"\bsigned_url\b", re.IGNORECASE),
+    "private URL field": re.compile(r"\bprivate_url\b", re.IGNORECASE),
+    "local user path": re.compile(r"/Users/|~/", re.IGNORECASE),
+    "Google Drive path": re.compile(r"GoogleDrive|Shared drives", re.IGNORECASE),
+}
+SECRET_PASTE_REQUEST = re.compile(
+    r"\b(ask|tell|have)\s+the\s+user\s+to\s+paste\b.*\b(secret|token|key)\b",
+    re.IGNORECASE,
+)
+SECRET_PASTE_NEGATION = re.compile(
+    r"\b(never|do not|don't|must not)\b.*\b(ask|tell|have)\b.*\buser\b.*\bpaste\b",
+    re.IGNORECASE,
+)
+
 RETIRED_PUBLIC_TERMS = (
     "gather_snapshot",
     "render_report",
@@ -72,6 +99,28 @@ def read_json(path: Path) -> dict[str, Any]:
 def require(condition: bool, message: str) -> None:
     if not condition:
         fail(message)
+
+
+def parse_skill_frontmatter(
+    display_path: Path,
+    text: str,
+) -> tuple[dict[str, str], str]:
+    if not text.startswith("---\n"):
+        fail(f"{display_path} must start with frontmatter")
+    end = text.find("\n---\n", 4)
+    if end == -1:
+        fail(f"{display_path} frontmatter must close with ---")
+    raw = text[4:end]
+    body = text[end + len("\n---\n") :]
+    metadata: dict[str, str] = {}
+    for line in raw.splitlines():
+        if not line.strip():
+            continue
+        key, separator, value = line.partition(":")
+        if not separator:
+            fail(f"{display_path} frontmatter line is not key: value: {line!r}")
+        metadata[key.strip()] = value.strip().strip('"').strip("'")
+    return metadata, body
 
 
 def validate_versions(root: Path, manifest: dict[str, Any], package: dict[str, Any]) -> None:
@@ -148,18 +197,79 @@ def validate_skills(root: Path) -> None:
     require(skill_files, "skills/ must contain at least one SKILL.md")
     for skill_file in skill_files:
         text = skill_file.read_text(encoding="utf-8")
-        require(text.startswith("---\n"), f"{skill_file} must start with frontmatter")
+        relative_path = skill_file.relative_to(root)
+        metadata, body = parse_skill_frontmatter(relative_path, text)
+        name = metadata.get("name", "")
+        description = metadata.get("description", "")
         require(
-            re.search(r"^name:\s*[A-Za-z0-9_-]+\s*$", text, re.MULTILINE) is not None,
-            f"{skill_file} is missing frontmatter name",
+            re.fullmatch(r"[a-z0-9]+(?:-[a-z0-9]+)*", name) is not None,
+            f"{relative_path} frontmatter name must be lowercase kebab-case",
         )
         require(
-            re.search(r"^description:\s*\S", text, re.MULTILINE) is not None,
-            f"{skill_file} is missing frontmatter description",
+            skill_file.parent.name == name,
+            f"{relative_path} frontmatter name must match its directory",
+        )
+        require(description, f"{relative_path} is missing frontmatter description")
+        require(
+            len(description) <= SKILL_DESCRIPTION_MAX_CHARS,
+            f"{relative_path} description must be <= {SKILL_DESCRIPTION_MAX_CHARS} characters",
+        )
+        description_lower = description.lower()
+        require(
+            any(phrase in description_lower for phrase in TRIGGER_PHRASES),
+            f"{relative_path} description must say when to use or trigger the skill",
+        )
+        line_count = len(text.splitlines())
+        require(
+            line_count <= SKILL_MD_MAX_LINES,
+            f"{relative_path} has {line_count} lines; limit is {SKILL_MD_MAX_LINES}",
         )
         require(
             "Never ask the user to paste a secret value in chat." in text,
-            f"{skill_file} must include the secret-entry safety rule",
+            f"{relative_path} must include the secret-entry safety rule",
+        )
+        require(
+            "raw Mini App URL" in text,
+            f"{relative_path} must explicitly forbid raw Mini App URLs",
+        )
+
+        for child in skill_file.parent.iterdir():
+            if child.name == "SKILL.md":
+                continue
+            if child.is_dir() and child.name in ALLOWED_SKILL_SUBDIRS:
+                continue
+            fail(
+                f"{child.relative_to(root)} is not allowed in a packaged skill directory; "
+                f"use only SKILL.md or {sorted(ALLOWED_SKILL_SUBDIRS)}"
+            )
+
+        for label, pattern in FORBIDDEN_SKILL_PATTERNS.items():
+            if pattern.search(body):
+                fail(f"{relative_path} contains forbidden {label}")
+        for line_number, line in enumerate(body.splitlines(), start=1):
+            if SECRET_PASTE_REQUEST.search(line) and not SECRET_PASTE_NEGATION.search(line):
+                fail(f"{relative_path}:{line_number} contains a forbidden secret paste request")
+
+
+def validate_authoring_standard(root: Path) -> None:
+    authoring = root / "docs" / "skill-authoring.md"
+    require(authoring.is_file(), "docs/skill-authoring.md is missing")
+    text = authoring.read_text(encoding="utf-8")
+    required_phrases = (
+        "trigger-led",
+        "What Belongs Where",
+        "Thin Harness, Focused Skills, Router Model",
+        "Safety Rules",
+        "Reviewer Checklist",
+        "Good And Bad Examples",
+    )
+    for phrase in required_phrases:
+        require(phrase in text, f"docs/skill-authoring.md must include {phrase!r}")
+
+    for path in (root / "README.md", root / "CONTRIBUTING.md"):
+        require(
+            "docs/skill-authoring.md" in path.read_text(encoding="utf-8"),
+            f"{path.name} must link to docs/skill-authoring.md",
         )
 
 
@@ -212,6 +322,7 @@ def main() -> int:
     validate_versions(root, manifest, package)
     validate_package_metadata(package)
     validate_manifest(manifest)
+    validate_authoring_standard(root)
     validate_skills(root)
     validate_source(root)
     validate_retired_terms_absent(root)


### PR DESCRIPTION
## Summary

Adds a public Tinyhat packaged-skill authoring standard grounded in current public Anthropic, OpenAI/Codex, and AgentSkills.io guidance, then links it from README, CONTRIBUTING, local development docs, and the PR checklist.

Extends `scripts/validate_openclaw_package.py` with cheap machine checks for packaged skills: frontmatter shape, trigger-led descriptions, line limits, required safety rules, allowed skill folder contents, and forbidden raw URL / private path / secret-paste patterns.

## Linked Issue

Closes #95

## Type Of Change

- [x] `feat` - new feature
- [ ] `fix` - bug fix
- [x] `docs` - documentation only
- [ ] `refactor` - no behavior change
- [ ] `test` - tests only
- [x] `chore` / `ci` / `build` - tooling
- [ ] Breaking change

## Testing Performed

- [x] `git diff --check`
- [x] `python3 scripts/check_dev_skills.py`
- [x] `bash .github/scripts/check_packaging.sh`
- [x] `python3 scripts/validate_openclaw_package.py`
- [x] `python3 -m compileall -q scripts`
- [x] `node --check src/index.js`
- [x] `node --test`
- [x] `ruff check .` and `ruff format --check .` via `uvx --from ruff==0.6.9`
- [ ] Manual OpenClaw plugin smoke test, if applicable

## Screenshots Or Logs

Not applicable. This is a docs and validator change with no visible Telegram/OpenClaw UI surface.

## Checklist

- [x] PR title is a Conventional Commit.
- [x] Linked to an issue or this PR is the canonical spec.
- [x] Docs updated where behavior changed.
- [x] Packaged skill changes follow `docs/skill-authoring.md`.
- [ ] CI is green.
- [x] No tenant secrets, signed Mini App URLs, private backend URLs, local-only
      paths, or internal docs are included.
- [x] I will not self-merge.

<details>
<summary>Agent checklist</summary>

- [x] Commits follow the repo bot-identity/signing rules in `AGENTS.md`.
- [x] Branch named with an agent or contributor prefix.

</details>
