### PR TITLE
feat(skills): add default capability router

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,15 +25,32 @@ to use.
 | --- | --- |
 | [`openclaw.plugin.json`](openclaw.plugin.json) | OpenClaw plugin manifest and capability contract metadata. |
 | [`src/index.js`](src/index.js) | Tinyhat tool plugin implementation. |
-| [`skills/tinyhat-platform/SKILL.md`](skills/tinyhat-platform/SKILL.md) | Compact first skill that teaches the agent the named platform operations. |
+| [`skills/tinyhat-platform/SKILL.md`](skills/tinyhat-platform/SKILL.md) | Router skill that maps broad Tinyhat/OpenClaw platform intent to focused default skills. |
+| [`skills/`](skills) | Focused default skills for secrets, Computer access, runtime status, package inventory, and support reports. |
 | [`docs/capabilities.md`](docs/capabilities.md) | Public operation list, safety rules, and response boundaries. |
 | [`docs/architecture.md`](docs/architecture.md) | Runtime-vs-plugin ownership boundary. |
 | [`docs/skill-authoring.md`](docs/skill-authoring.md) | Standard for authoring packaged Tinyhat skills. |
 
-The focused router/default-skills expansion is tracked in
-[tinyhat-ai/tinyhat#94](https://github.com/tinyhat-ai/tinyhat/issues/94).
-The skill-authoring standard that governs those skills is tracked in
-[tinyhat-ai/tinyhat#95](https://github.com/tinyhat-ai/tinyhat/issues/95).
+The skill-authoring standard that governs those skills lives in
+[`docs/skill-authoring.md`](docs/skill-authoring.md).
+
+## Default Skill Architecture
+
+The default skill layer is intentionally split into a thin router plus
+focused skills:
+
+| Skill | Owns |
+| --- | --- |
+| [`tinyhat-platform`](skills/tinyhat-platform/SKILL.md) | Routes broad platform requests to the right focused skill and named operation. |
+| [`tinyhat-secrets`](skills/tinyhat-secrets/SKILL.md) | Secret-entry buttons and secret metadata listing. |
+| [`tinyhat-computer-access`](skills/tinyhat-computer-access/SKILL.md) | Manage Computer and terminal button flows. |
+| [`tinyhat-runtime-status`](skills/tinyhat-runtime-status/SKILL.md) | Runtime/environment explanation and restart/reload boundaries. |
+| [`tinyhat-package-inventory`](skills/tinyhat-package-inventory/SKILL.md) | Tinyhat-installed defaults versus user-installed package inventory. |
+| [`tinyhat-support-report`](skills/tinyhat-support-report/SKILL.md) | Redacted support reports for platform problems. |
+
+The plugin layer exposes tools, button payloads, environment facts, and
+redacted diagnostics.
+The skills decide when to call those tools and how to respond safely.
 
 ## Capabilities
 

--- a/docs/capabilities.md
+++ b/docs/capabilities.md
@@ -17,6 +17,22 @@ call raw Tinyhat backend URLs.
 | `packages.list_installed` | `tinyhat_list_installed_packages` | none | Public package refs/SHAs and Tinyhat/user split when available. |
 | `support.report_problem` | `tinyhat_report_problem` | optional summary | Redacted support context. |
 
+## Default Skill Layer
+
+The default skill layer uses one router plus focused skills:
+
+| Skill | Primary operations |
+| --- | --- |
+| `tinyhat-platform` | Routes broad user intent to the focused skills below. |
+| `tinyhat-secrets` | `credentials.open_add_secret`, `credentials.list_metadata`. |
+| `tinyhat-computer-access` | `computer.open_manage`, `computer.open_terminal`. |
+| `tinyhat-runtime-status` | `computer.status` and the no-generic-restart boundary. |
+| `tinyhat-package-inventory` | `packages.list_installed`. |
+| `tinyhat-support-report` | `support.report_problem`. |
+
+Skills call named tools or documented operation identifiers.
+They must not call raw Tinyhat backend paths.
+
 ## Secret Entry
 
 Secret entry is a user action, not an agent-readable value.

--- a/scripts/validate_openclaw_package.py
+++ b/scripts/validate_openclaw_package.py
@@ -30,6 +30,15 @@ REQUIRED_OPERATIONS = {
     "support.report_problem": "tinyhat_report_problem",
 }
 
+REQUIRED_SKILLS = {
+    "tinyhat-platform",
+    "tinyhat-secrets",
+    "tinyhat-computer-access",
+    "tinyhat-runtime-status",
+    "tinyhat-package-inventory",
+    "tinyhat-support-report",
+}
+
 SKILL_MD_MAX_LINES = 200
 SKILL_DESCRIPTION_MAX_CHARS = 1024
 ALLOWED_SKILL_SUBDIRS = {"assets", "references", "scripts"}
@@ -195,6 +204,9 @@ def validate_manifest(manifest: dict[str, Any]) -> None:
 def validate_skills(root: Path) -> None:
     skill_files = sorted((root / "skills").glob("*/SKILL.md"))
     require(skill_files, "skills/ must contain at least one SKILL.md")
+    skill_names = {skill_file.parent.name for skill_file in skill_files}
+    missing_skills = REQUIRED_SKILLS.difference(skill_names)
+    require(not missing_skills, f"skills/ missing default skills: {sorted(missing_skills)}")
     for skill_file in skill_files:
         text = skill_file.read_text(encoding="utf-8")
         relative_path = skill_file.relative_to(root)
@@ -277,6 +289,10 @@ def validate_source(root: Path) -> None:
     source = (root / "src" / "index.js").read_text(encoding="utf-8")
     for tool_name in REQUIRED_TOOLS:
         require(f'name: "{tool_name}"' in source, f"src/index.js missing tool {tool_name}")
+    for skill_name in REQUIRED_SKILLS:
+        require(
+            f'name: "{skill_name}"' in source, f"src/index.js missing default skill {skill_name}"
+        )
     for command in (
         "tinyhat_secrets",
         "tinyhat_secrets_manage",

--- a/skills/tinyhat-computer-access/SKILL.md
+++ b/skills/tinyhat-computer-access/SKILL.md
@@ -1,0 +1,51 @@
+---
+name: tinyhat-computer-access
+description: Open authenticated Tinyhat Manage Computer and terminal access. Use when the user asks to manage, inspect, configure, administer, or open a terminal or shell for this Tinyhat-managed OpenClaw Computer.
+---
+
+# Tinyhat Computer Access
+
+Use Tinyhat Computer access capabilities when the user needs an
+authenticated platform surface instead of an agent-written URL.
+
+## Route User Intent
+
+| User ask | Operation / tool |
+| --- | --- |
+| Open Manage Computer, inspect the Computer, manage settings | `computer.open_manage` / `tinyhat_open_manage_computer_link` |
+| Open a terminal, shell, SSH-like session, or run one admin-reviewed command | `computer.open_terminal` / `tinyhat_open_terminal_link` |
+
+## Manage Computer
+
+1. Call `tinyhat_open_manage_computer_link`.
+2. Render the returned Telegram button payload when buttons are
+   supported.
+3. Say that Manage Computer is the authenticated place to inspect or
+   change platform settings.
+
+## Terminal Access
+
+1. If the user supplied a command, treat it as an admin-reviewed launch
+   hint.
+2. Do not put secret values into the command hint.
+3. Call `tinyhat_open_terminal_link`, passing the command only when it
+   is non-secret.
+4. Render the returned Telegram button payload when buttons are
+   supported.
+5. Say that the terminal opens through Tinyhat authentication.
+
+## Safe Degradation
+
+- If the channel cannot render a Telegram button, say the user must
+  retry from Telegram or Manage Computer.
+- Do not invent a terminal route or platform page path.
+- Do not paste a raw Mini App URL, even if a tool response contains one
+  for transport.
+
+## Safety Rules
+
+- Never ask the user to paste a secret value in chat.
+- Never print a raw Mini App URL, signed intent token, private backend
+  URL, or Computer-private URL in user-facing text.
+- Secret values are not terminal launch hints.
+- Use named Tinyhat tools only.

--- a/skills/tinyhat-package-inventory/SKILL.md
+++ b/skills/tinyhat-package-inventory/SKILL.md
@@ -1,0 +1,46 @@
+---
+name: tinyhat-package-inventory
+description: List and explain Tinyhat-installed and user-installed package inventory. Use when the user asks what Tinyhat installed, which plugins or default skills are present, what repo/ref is running, or how Tinyhat defaults differ from user-installed skills.
+---
+
+# Tinyhat Package Inventory
+
+Use package inventory when the user asks what Tinyhat installed into
+this OpenClaw Computer or how platform defaults differ from user-added
+skills.
+
+## Route User Intent
+
+| User ask | Operation / tool |
+| --- | --- |
+| What did Tinyhat install, which plugin/ref is active | `packages.list_installed` / `tinyhat_list_installed_packages` |
+| Which skills are Tinyhat defaults versus user-installed | `packages.list_installed` / `tinyhat_list_installed_packages` |
+
+## Inventory Response
+
+1. Call `tinyhat_list_installed_packages`.
+2. Report Tinyhat-installed defaults separately from user-installed
+   skills or packages.
+3. For Tinyhat defaults, summarize public package refs, versions, SHAs,
+   and named capabilities when present.
+4. For user-installed items, summarize only the public names and refs
+   the platform reports.
+5. If the platform does not report a user-installed split yet, say that
+   the current inventory does not distinguish user-installed skills.
+
+## Boundaries
+
+- Package inventory is for public refs, versions, SHAs, capability
+  names, and safe install state.
+- Do not infer private repository names, local checkout paths, or hidden
+  deployment metadata.
+- Do not treat package inventory as proof that a secret value exists;
+  use `tinyhat-secrets` for secret metadata.
+
+## Safety Rules
+
+- Never ask the user to paste a secret value in chat.
+- Never print a raw Mini App URL, signed intent token, private backend
+  URL, or Computer-private URL in user-facing text.
+- Do not expose private package URLs or internal environment details.
+- Use named Tinyhat tools only.

--- a/skills/tinyhat-platform/SKILL.md
+++ b/skills/tinyhat-platform/SKILL.md
@@ -1,55 +1,43 @@
 ---
 name: tinyhat-platform
-description: Use Tinyhat platform capabilities from a managed OpenClaw Computer. Trigger when the user asks to add or manage secrets, open Manage Computer, open terminal access, check runtime status, list installed Tinyhat packages, ask what platform this agent runs on, or report a Tinyhat Computer problem.
+description: Route Tinyhat platform capability requests from a managed OpenClaw Computer. Use when the user asks broadly about Tinyhat/OpenClaw platform actions, including secrets, Manage Computer, terminal access, runtime status, installed packages, restart or reload boundaries, or support reports.
 ---
 
-# Tinyhat Platform
+# Tinyhat Platform Router
 
 You are running inside a Tinyhat-managed OpenClaw Computer.
-Use the named Tinyhat tools instead of inventing platform URLs or asking
-the user to paste privileged data into chat.
+Use this router to choose the focused Tinyhat skill, then follow that
+skill's instructions for the capability call and user-facing response.
 
 ## Route User Intent
 
-| User ask | Use |
-| --- | --- |
-| Add, set, replace, or configure a secret/API key/token | `tinyhat_request_runtime_secret` |
-| List configured secret metadata | `tinyhat_list_runtime_secrets` |
-| Open or inspect Manage Computer | `tinyhat_open_manage_computer_link` |
-| Open a terminal or SSH-like shell | `tinyhat_open_terminal_link` |
-| Ask what this agent is running on | `tinyhat_get_platform_status` |
-| Ask what Tinyhat installed | `tinyhat_list_installed_packages` |
-| Report a Tinyhat/OpenClaw problem | `tinyhat_report_problem` |
+| User ask | Focused skill | Operation / tool |
+| --- | --- | --- |
+| Add, set, replace, or configure a secret/API key/token | `tinyhat-secrets` | `credentials.open_add_secret` / `tinyhat_request_runtime_secret` |
+| List configured secret metadata | `tinyhat-secrets` | `credentials.list_metadata` / `tinyhat_list_runtime_secrets` |
+| Open or inspect Manage Computer | `tinyhat-computer-access` | `computer.open_manage` / `tinyhat_open_manage_computer_link` |
+| Open a terminal or SSH-like shell | `tinyhat-computer-access` | `computer.open_terminal` / `tinyhat_open_terminal_link` |
+| Ask what this agent is running on | `tinyhat-runtime-status` | `computer.status` / `tinyhat_get_platform_status` |
+| Ask to restart, reload, update, or apply runtime config | `tinyhat-runtime-status` | explain the exposed boundary; do not invent a restart tool |
+| Ask what Tinyhat installed | `tinyhat-package-inventory` | `packages.list_installed` / `tinyhat_list_installed_packages` |
+| Report a Tinyhat/OpenClaw problem | `tinyhat-support-report` | `support.report_problem` / `tinyhat_report_problem` |
+
+## Router Rules
+
+- Prefer the focused skill whenever the request matches one row above.
+- Use named operations or tools only; never construct platform URLs.
+- If the user asks for a platform action not exposed by this contract,
+  say that Tinyhat has not exposed that action to the agent yet.
+- If the action needs user authentication, render the returned Telegram
+  button payload when the channel supports buttons.
+- If buttons are unavailable, say the action must be retried from
+  Telegram or Manage Computer.
 
 ## Safety Rules
 
 - Never ask the user to paste a secret value in chat.
 - Never print a raw Mini App URL, signed intent token, private backend
   URL, or Computer-private URL in user-facing text.
-- For privileged actions, render the returned Telegram `web_app` button
-  payload when the channel supports buttons.
-- If the current channel cannot render a Telegram button, explain that
-  the action must be retried from Telegram or Manage Computer.
-- Terminal command text is only a launch hint for admin review.
-  Do not include secret values in terminal commands.
 - Secret metadata means names, descriptions, status, and revision
   information only.
   Secret values are never available through Tinyhat tools.
-
-## First Response Patterns
-
-For secret entry:
-
-1. Infer a non-secret name and description from the conversation.
-2. Call `tinyhat_request_runtime_secret`.
-3. Present the Telegram Mini App button.
-4. Say the value must be entered in Telegram, not chat.
-
-For status or inventory:
-
-1. Call the status or package tool.
-2. Summarize only public package refs, versions, and safe runtime state.
-3. Avoid raw backend endpoints and private URLs.
-
-Focused default skills and the router expansion are tracked in
-tinyhat-ai/tinyhat#94.

--- a/skills/tinyhat-runtime-status/SKILL.md
+++ b/skills/tinyhat-runtime-status/SKILL.md
@@ -1,0 +1,48 @@
+---
+name: tinyhat-runtime-status
+description: Explain Tinyhat runtime status, environment facts, and restart or reload boundaries. Use when the user asks what this OpenClaw Computer is running on, whether Tinyhat is installed, what can be restarted or reloaded, or why a platform action is unavailable.
+---
+
+# Tinyhat Runtime Status
+
+Use runtime status guidance when the user is asking about where the
+agent is running, what Tinyhat exposes, or whether the agent can restart
+or reload platform-managed components.
+
+## Route User Intent
+
+| User ask | Operation / tool |
+| --- | --- |
+| What am I running on, what is Tinyhat, is this managed by Tinyhat | `computer.status` / `tinyhat_get_platform_status` |
+| Is a capability available, why is a button/tool missing | `computer.status` / `tinyhat_get_platform_status` |
+| Restart, reload, upgrade, apply config, or reboot platform runtime | explain the boundary; do not invent a restart tool |
+
+## Status Response
+
+1. Call `tinyhat_get_platform_status`.
+2. Summarize only secret-free platform facts: Computer identity label,
+   runtime state, plugin version/ref, and capability availability.
+3. If status includes capabilities, name the relevant operation and
+   whether it is available.
+4. Do not expose backend endpoints, metadata server details, bearer
+   tokens, tenant ids, or private hostnames.
+
+## Restart Or Reload Boundary
+
+- The v0.5 capability contract does not expose a generic agent-callable
+  restart, reload, upgrade, or reboot tool.
+- If the user wants to inspect or change platform settings, route to
+  `tinyhat-computer-access` and open Manage Computer.
+- If the user reports a broken runtime, route to `tinyhat-support-report`
+  and call `tinyhat_report_problem`.
+- If the user asks what Tinyhat installed, route to
+  `tinyhat-package-inventory`.
+
+## Safety Rules
+
+- Never ask the user to paste a secret value in chat.
+- Never print a raw Mini App URL, signed intent token, private backend
+  URL, or Computer-private URL in user-facing text.
+- Do not claim access to secret values, private URLs, or internal
+  runtime controls.
+- Prefer a clear boundary over an invented platform action.

--- a/skills/tinyhat-secrets/SKILL.md
+++ b/skills/tinyhat-secrets/SKILL.md
@@ -1,0 +1,53 @@
+---
+name: tinyhat-secrets
+description: Request and list Tinyhat runtime secret metadata. Use when the user asks to add, set, update, replace, configure, list, or manage a secret, API key, token, credential, env var, or runtime secret for this OpenClaw Computer.
+---
+
+# Tinyhat Secrets
+
+Use Tinyhat secret capabilities when the user wants this Computer to
+receive a runtime secret without exposing the secret value to the agent.
+
+## Route User Intent
+
+| User ask | Operation / tool |
+| --- | --- |
+| Add, set, update, replace, or configure one secret | `credentials.open_add_secret` / `tinyhat_request_runtime_secret` |
+| List configured secret metadata | `credentials.list_metadata` / `tinyhat_list_runtime_secrets` |
+| Open the secret manager from a slash-command surface | `/tinyhat_secrets manage` or `/tinyhat_secrets_manage` when available |
+
+## Request A Secret
+
+1. Infer a non-secret env-style name from the conversation, such as
+   `OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, or `DATABASE_URL`.
+2. Infer a short non-secret description of why this Computer needs it.
+3. If the name is ambiguous, ask for the name only. Do not ask for the
+   value.
+4. Call `tinyhat_request_runtime_secret` with `name` and `description`.
+5. Render the returned Telegram button payload when the channel supports
+   buttons.
+6. Tell the user that the value must be entered in Telegram, not chat.
+
+## List Secret Metadata
+
+1. Call `tinyhat_list_runtime_secrets`.
+2. Summarize names, descriptions, status, and revision information only.
+3. If no secrets are configured, say that and offer to request a secret
+   button for a named secret.
+
+## Safe Degradation
+
+- If the current channel cannot render the Telegram button, say the
+  action must be retried from Telegram or Manage Computer.
+- Never paste a raw Mini App URL as a fallback.
+- Never claim that the agent can read, verify, echo, or migrate secret
+  values directly.
+
+## Safety Rules
+
+- Never ask the user to paste a secret value in chat.
+- Never print a raw Mini App URL, signed intent token, private backend
+  URL, or Computer-private URL in user-facing text.
+- Secret values are never returned by Tinyhat tools.
+- Terminal commands and support summaries must not contain secret
+  values.

--- a/skills/tinyhat-support-report/SKILL.md
+++ b/skills/tinyhat-support-report/SKILL.md
@@ -1,0 +1,42 @@
+---
+name: tinyhat-support-report
+description: Collect redacted Tinyhat/OpenClaw support context. Use when the user says the Tinyhat Computer, OpenClaw runtime, plugin capability, Telegram button, terminal, secret entry, status, or package inventory is broken or behaving unexpectedly.
+---
+
+# Tinyhat Support Report
+
+Use support reports when the user is describing a Tinyhat/OpenClaw
+problem and the agent needs redacted platform context.
+
+## Route User Intent
+
+| User ask | Operation / tool |
+| --- | --- |
+| Report a problem, bug, broken Computer, broken button, failed secret entry, failed terminal | `support.report_problem` / `tinyhat_report_problem` |
+| Ask for diagnostics to send to Tinyhat support | `support.report_problem` / `tinyhat_report_problem` |
+
+## Report Flow
+
+1. If the problem summary is clear, use it directly.
+2. If the summary is missing, ask for a short non-secret description of
+   what failed and what the user expected.
+3. Call `tinyhat_report_problem` with the non-secret summary.
+4. Return the redacted support context and a concise explanation of what
+   was captured.
+
+## What To Capture In The Summary
+
+- Which action failed: secret entry, Manage Computer, terminal, status,
+  package inventory, or another capability.
+- What the user saw in ordinary words, without signed links or tokens.
+- Whether the current channel could render Telegram buttons.
+
+## Safety Rules
+
+- Never ask the user to paste a secret value in chat.
+- Never print a raw Mini App URL, signed intent token, private backend
+  URL, or Computer-private URL in user-facing text.
+- Do not ask for bearer tokens, local files, tenant ids, or private
+  deployment details.
+- Redacted support context is safe to summarize; secret values are not
+  available through Tinyhat tools.

--- a/src/index.js
+++ b/src/index.js
@@ -5,6 +5,14 @@ import { parseSecretCommand, redactObject } from "./platform_helpers.js";
 const METADATA_BASE_URL_KEY = "tinyhat-platform-base-url";
 const METADATA_AUDIENCE_KEY = "tinyhat-backend-audience";
 const DEV_RUNTIME_BEARER = "dev-runtime";
+const DEFAULT_SKILLS = [
+  { name: "tinyhat-platform", role: "router" },
+  { name: "tinyhat-secrets", role: "secrets" },
+  { name: "tinyhat-computer-access", role: "computer_access" },
+  { name: "tinyhat-runtime-status", role: "runtime_status" },
+  { name: "tinyhat-package-inventory", role: "package_inventory" },
+  { name: "tinyhat-support-report", role: "support_report" },
+];
 
 const configSchema = {
   type: "object",
@@ -484,6 +492,7 @@ function packageInventoryFromStatus(status) {
     ok: true,
     installed_by_tinyhat: {
       plugin,
+      default_skills: DEFAULT_SKILLS,
       capabilities,
     },
     user_installed: status?.user_installed ?? [],


### PR DESCRIPTION
## Summary

Adds the default Tinyhat skill layer as a thin router plus focused skills for the v0.5 platform capability contract.

The router now maps broad Tinyhat/OpenClaw requests to focused skills for secrets, Computer access, runtime status and restart/reload boundaries, package inventory, and redacted support reports. Package inventory output also includes the Tinyhat default skill list, and the package validator now requires the router and focused default skills to stay present.

## Linked Issue

Closes #94

## Type Of Change

- [x] `feat` - new feature
- [ ] `fix` - bug fix
- [x] `docs` - documentation only
- [ ] `refactor` - no behavior change
- [ ] `test` - tests only
- [x] `chore` / `ci` / `build` - tooling
- [ ] Breaking change

## Testing Performed

- [x] `git diff --check`
- [x] `python3 scripts/check_dev_skills.py`
- [x] `bash .github/scripts/check_packaging.sh`
- [x] `python3 scripts/validate_openclaw_package.py`
- [x] `python3 -m compileall -q scripts`
- [x] `node --check src/index.js`
- [x] `node --test`
- [x] `ruff check .` and `ruff format --check .` via `uvx --from ruff==0.6.9`
- [ ] Manual OpenClaw plugin smoke test, if applicable

## Screenshots Or Logs

Not applicable. This change adds packaged skill guidance, docs, validator checks, and inventory metadata; it does not change a visible Telegram/OpenClaw UI surface.

## Checklist

- [x] PR title is a Conventional Commit.
- [x] Linked to an issue or this PR is the canonical spec.
- [x] Docs updated where behavior changed.
- [x] Packaged skill changes follow `docs/skill-authoring.md`.
- [ ] CI is green.
- [x] No tenant secrets, signed Mini App URLs, private backend URLs, local-only
      paths, or internal docs are included.
- [x] I will not self-merge.

<details>
<summary>Agent checklist</summary>

- [x] Commits follow the repo bot-identity/signing rules in `AGENTS.md`.
- [x] Branch named with an agent or contributor prefix.

</details>
