### PR TITLE
fix(plugin): keep Mini App URLs transport-only

### DIFF
--- a/docs/capabilities.md
+++ b/docs/capabilities.md
@@ -9,10 +9,10 @@ call raw Tinyhat backend URLs.
 
 | Operation | Tool | Input | Output policy |
 | --- | --- | --- | --- |
-| `credentials.open_add_secret` | `tinyhat_request_runtime_secret` | `name`, optional `description` | Telegram button payload; no secret values. |
-| `credentials.list_metadata` | `tinyhat_list_runtime_secrets` | none | Secret names/descriptions/status only. |
-| `computer.open_manage` | `tinyhat_open_manage_computer_link` | none | Telegram button payload. |
-| `computer.open_terminal` | `tinyhat_open_terminal_link` | optional admin-reviewed `command` | Telegram button payload. |
+| `credentials.open_add_secret` | `tinyhat_request_runtime_secret` | `name`, optional `description` | Safe copy plus Telegram button transport; no secret values or raw URL prose. |
+| `credentials.list_metadata` | `tinyhat_list_runtime_secrets` | none | Secret names/descriptions/status only; Manage Secrets button transport when available. |
+| `computer.open_manage` | `tinyhat_open_manage_computer_link` | none | Safe copy plus Telegram button transport. |
+| `computer.open_terminal` | `tinyhat_open_terminal_link` | optional admin-reviewed `command` | Safe copy plus Telegram button transport. |
 | `computer.status` | `tinyhat_get_platform_status` | none | Secret-free status and platform contract. |
 | `packages.list_installed` | `tinyhat_list_installed_packages` | none | Public package refs/SHAs and Tinyhat/user split when available. |
 | `support.report_problem` | `tinyhat_report_problem` | optional summary | Redacted support context. |
@@ -42,9 +42,11 @@ Tinyhat returns a Telegram Mini App button payload.
 The user enters the value inside Telegram, and the agent never receives
 the value.
 
-If a tool response contains a raw Mini App URL for transport reasons,
-skills must not paste that URL into chat.
-The only user-facing representation is the structured button payload.
+If a tool response contains a raw Mini App URL inside Telegram
+`channelData` for transport reasons, skills must not paste that URL
+into chat.
+The only user-facing representation is the safe `text` copy and the
+structured Telegram button.
 
 ## Runtime Boundary
 

--- a/docs/capabilities.md
+++ b/docs/capabilities.md
@@ -42,9 +42,9 @@ Tinyhat returns a Telegram Mini App button payload.
 The user enters the value inside Telegram, and the agent never receives
 the value.
 
-If a tool response contains a raw Mini App URL inside Telegram
-`channelData` for transport reasons, skills must not paste that URL
-into chat.
+If a tool response contains Telegram transport metadata, only the
+renderer should use it.
+Skills must not paste any Mini App URL into chat.
 The only user-facing representation is the safe `text` copy and the
 structured Telegram button.
 

--- a/scripts/validate_openclaw_package.py
+++ b/scripts/validate_openclaw_package.py
@@ -244,6 +244,12 @@ def validate_skills(root: Path) -> None:
             "raw Mini App URL" in text,
             f"{relative_path} must explicitly forbid raw Mini App URLs",
         )
+        if name == "tinyhat-secrets":
+            require(
+                "Plain-English Name Inference" in text
+                and "Do not require the user to know the exact env var name." in text,
+                f"{relative_path} must teach agents to infer secret names from plain English",
+            )
 
         for child in skill_file.parent.iterdir():
             if child.name == "SKILL.md":

--- a/skills/tinyhat-platform/SKILL.md
+++ b/skills/tinyhat-platform/SKILL.md
@@ -30,6 +30,9 @@ skill's instructions for the capability call and user-facing response.
   say that Tinyhat has not exposed that action to the agent yet.
 - If the action needs user authentication, render the returned Telegram
   button payload when the channel supports buttons.
+- Preserve structured button payloads for Telegram rendering, but do
+  not print any button URL, Mini App link field, signed token, or raw
+  URL field from the tool result.
 - If buttons are unavailable, say the action must be retried from
   Telegram or Manage Computer.
 

--- a/skills/tinyhat-secrets/SKILL.md
+++ b/skills/tinyhat-secrets/SKILL.md
@@ -34,8 +34,10 @@ receive a runtime secret without exposing the secret value to the agent.
 - Treat `channelData.telegram.buttons` as transport-only button data.
   Preserve it for Telegram rendering, but never quote or summarize any
   transport URL.
-- Treat `presentation` as fallback presentation only. If it does not
-  include a button, do not invent one from raw URL fields.
+- Button-capable Telegram replies may intentionally omit `presentation`
+  so the Telegram renderer can send native buttons without exposing
+  transport URLs. If a fallback presentation exists, never invent a
+  button from raw URL fields.
 - If the tool returns `unsupported_channel_text`, use that copy when
   the current channel cannot render the Telegram Mini App button.
 - Never copy Mini App link fields, button URL fields, signed link

--- a/skills/tinyhat-secrets/SKILL.md
+++ b/skills/tinyhat-secrets/SKILL.md
@@ -32,8 +32,8 @@ receive a runtime secret without exposing the secret value to the agent.
 
 - Treat `text` as the user-facing copy.
 - Treat `channelData.telegram.buttons` as transport-only button data.
-  Preserve it for Telegram rendering, but never quote or summarize the
-  URL inside it.
+  Preserve it for Telegram rendering, but never quote or summarize any
+  transport URL.
 - Treat `presentation` as fallback presentation only. If it does not
   include a button, do not invent one from raw URL fields.
 - If the tool returns `unsupported_channel_text`, use that copy when

--- a/skills/tinyhat-secrets/SKILL.md
+++ b/skills/tinyhat-secrets/SKILL.md
@@ -24,9 +24,23 @@ receive a runtime secret without exposing the secret value to the agent.
 3. If the name is ambiguous, ask for the name only. Do not ask for the
    value.
 4. Call `tinyhat_request_runtime_secret` with `name` and `description`.
-5. Render the returned Telegram button payload when the channel supports
-   buttons.
+5. Render the returned Telegram button payload exactly as structured
+   button transport when the channel supports buttons.
 6. Tell the user that the value must be entered in Telegram, not chat.
+
+## Secret Button Contract
+
+- Treat `text` as the user-facing copy.
+- Treat `channelData.telegram.buttons` as transport-only button data.
+  Preserve it for Telegram rendering, but never quote or summarize the
+  URL inside it.
+- Treat `presentation` as fallback presentation only. If it does not
+  include a button, do not invent one from raw URL fields.
+- If the tool returns `unsupported_channel_text`, use that copy when
+  the current channel cannot render the Telegram Mini App button.
+- Never copy Mini App link fields, button URL fields, signed link
+  fields, private link fields, intent values, or tokens into
+  user-facing text.
 
 ## List Secret Metadata
 

--- a/skills/tinyhat-secrets/SKILL.md
+++ b/skills/tinyhat-secrets/SKILL.md
@@ -28,9 +28,13 @@ receive a runtime secret without exposing the secret value to the agent.
    non-secret detail only, such as provider or target system. Do not ask
    for the value.
 5. Call `tinyhat_request_runtime_secret` with `name` and `description`.
-6. Render the returned Telegram button payload exactly as structured
-   button transport when the channel supports buttons.
-7. Tell the user that the value must be entered in Telegram, not chat.
+6. If the tool reports `delivered: true`, the Telegram Mini App button
+   has already been sent directly. Do not call another message-sending
+   tool for the button.
+7. If direct delivery is unavailable and the tool returns
+   `channelData.telegram.buttons`, render that structured button
+   transport when the channel supports buttons.
+8. Tell the user that the value must be entered in Telegram, not chat.
 
 ## Plain-English Name Inference
 
@@ -54,6 +58,9 @@ provider or when one goal clearly needs several independent secrets.
 ## Secret Button Contract
 
 - Treat `text` as the user-facing copy.
+- If `delivered: true` is present, the plugin has already sent the
+  native Telegram button. Acknowledge briefly only if needed; do not
+  send a duplicate button.
 - Treat `channelData.telegram.buttons` as transport-only button data.
   Preserve it for Telegram rendering, but never quote or summarize any
   transport URL.

--- a/skills/tinyhat-secrets/SKILL.md
+++ b/skills/tinyhat-secrets/SKILL.md
@@ -21,12 +21,35 @@ receive a runtime secret without exposing the secret value to the agent.
 1. Infer a non-secret env-style name from the conversation, such as
    `OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, or `DATABASE_URL`.
 2. Infer a short non-secret description of why this Computer needs it.
-3. If the name is ambiguous, ask for the name only. Do not ask for the
-   value.
-4. Call `tinyhat_request_runtime_secret` with `name` and `description`.
-5. Render the returned Telegram button payload exactly as structured
+3. Do not require the user to know the exact env var name. If the
+   service/tool/purpose is clear, choose the conventional key name and
+   prefill a useful description.
+4. If multiple credentials are equally plausible, ask for the missing
+   non-secret detail only, such as provider or target system. Do not ask
+   for the value.
+5. Call `tinyhat_request_runtime_secret` with `name` and `description`.
+6. Render the returned Telegram button payload exactly as structured
    button transport when the channel supports buttons.
-6. Tell the user that the value must be entered in Telegram, not chat.
+7. Tell the user that the value must be entered in Telegram, not chat.
+
+## Plain-English Name Inference
+
+When the user describes the goal in plain English, translate it into the
+most conventional non-secret environment variable name. Use concise,
+purpose-shaped descriptions that help the user confirm the right secret
+inside the Mini App.
+
+| User ask | Name | Description |
+| --- | --- | --- |
+| "Use OpenRouter for models" | `OPENROUTER_API_KEY` | Used by this Computer to call OpenRouter models. |
+| "Connect to OpenAI" | `OPENAI_API_KEY` | Used by this Computer to call OpenAI APIs. |
+| "Use Anthropic/Claude" | `ANTHROPIC_API_KEY` | Used by this Computer to call Anthropic models. |
+| "Send Slack messages" | `SLACK_BOT_TOKEN` | Used by this Computer to call the Slack API. |
+| "Connect to Postgres" | `DATABASE_URL` | Used by this Computer to connect to the application database. |
+| "Use Stripe" | `STRIPE_SECRET_KEY` | Used by this Computer to call Stripe server-side APIs. |
+
+Ask a clarification only when the user's wording does not identify a
+provider or when one goal clearly needs several independent secrets.
 
 ## Secret Button Contract
 

--- a/src/index.js
+++ b/src/index.js
@@ -6,6 +6,10 @@ import {
   formatSecretListReply,
   formatSecretRequestReply,
 } from "./presentation_helpers.js";
+import {
+  markTelegramDelivered,
+  sendTelegramMiniAppButton,
+} from "./telegram_delivery.js";
 
 const METADATA_BASE_URL_KEY = "tinyhat-platform-base-url";
 const METADATA_AUDIENCE_KEY = "tinyhat-backend-audience";
@@ -145,28 +149,44 @@ const plugin = defineToolPlugin({
     tool({
       name: "tinyhat_request_runtime_secret",
       description:
-        "Create a Telegram Mini App button payload so the owner can add or " +
-        "replace one runtime secret value outside chat.",
+        "Create and, on Telegram, directly send a Mini App button so the " +
+        "owner can add or replace one runtime secret value outside chat.",
       parameters: requestSecretParameters,
-      execute: async ({ name, description, hint }, config, context) => {
-        const runtime = resolveExecutionRuntime(config, context);
-        runtime.signal?.throwIfAborted?.();
-        return formatSecretRequestReply(
-          await callTinyhat(
-            runtime.config,
-            "/hapi/v1/computers/me/runtime-secrets/add-link",
-            {
-              method: "POST",
-              body: JSON.stringify({
-                name,
-                description: description || hint,
-                hint,
-              }),
-            },
-            runtime.signal,
-          ),
-        );
-      },
+      factory: ({ api, config, toolContext }) => ({
+        name: "tinyhat_request_runtime_secret",
+        label: "tinyhat_request_runtime_secret",
+        description:
+          "Create and, on Telegram, directly send a Mini App button so the " +
+          "owner can add or replace one runtime secret value outside chat.",
+        parameters: requestSecretParameters,
+        execute: async (_toolCallId, { name, description, hint }, signal) => {
+          const runtime = resolveExecutionRuntime(config, { signal });
+          runtime.signal?.throwIfAborted?.();
+          const reply = formatSecretRequestReply(
+            await callTinyhat(
+              runtime.config,
+              "/hapi/v1/computers/me/runtime-secrets/add-link",
+              {
+                method: "POST",
+                body: JSON.stringify({
+                  name,
+                  description: description || hint,
+                  hint,
+                }),
+              },
+              runtime.signal,
+            ),
+          );
+          const delivery = await sendTelegramMiniAppButton({
+            api,
+            toolContext,
+            reply,
+            text: reply.text,
+            signal: runtime.signal,
+          });
+          return jsonToolResult(markTelegramDelivered(reply, delivery));
+        },
+      }),
     }),
     tool({
       name: "tinyhat_open_manage_computer_link",
@@ -342,6 +362,13 @@ function resolveExecutionRuntime(configArg, contextArg) {
   return {
     config: configCandidate,
     signal: contextArg?.signal ?? configArg?.signal,
+  };
+}
+
+function jsonToolResult(payload) {
+  return {
+    content: [{ type: "text", text: JSON.stringify(payload, null, 2) }],
+    details: payload,
   };
 }
 

--- a/src/index.js
+++ b/src/index.js
@@ -1,10 +1,16 @@
 import { defineToolPlugin } from "openclaw/plugin-sdk/tool-plugin";
 
 import { parseSecretCommand, redactObject } from "./platform_helpers.js";
+import {
+  formatButtonReply,
+  formatSecretListReply,
+  formatSecretRequestReply,
+} from "./presentation_helpers.js";
 
 const METADATA_BASE_URL_KEY = "tinyhat-platform-base-url";
 const METADATA_AUDIENCE_KEY = "tinyhat-backend-audience";
 const DEV_RUNTIME_BEARER = "dev-runtime";
+const SECRET_REPLY_SAFETY = "Do not paste the value in chat.";
 const DEFAULT_SKILLS = [
   { name: "tinyhat-platform", role: "router" },
   { name: "tinyhat-secrets", role: "secrets" },
@@ -131,7 +137,9 @@ const plugin = defineToolPlugin({
       execute: async (_params, config, context) => {
         const runtime = resolveExecutionRuntime(config, context);
         runtime.signal?.throwIfAborted?.();
-        return fetchSecretStatuses(runtime.config, runtime.signal);
+        return formatSecretListReply(
+          await fetchSecretStatuses(runtime.config, runtime.signal),
+        );
       },
     }),
     tool({
@@ -143,18 +151,20 @@ const plugin = defineToolPlugin({
       execute: async ({ name, description, hint }, config, context) => {
         const runtime = resolveExecutionRuntime(config, context);
         runtime.signal?.throwIfAborted?.();
-        return callTinyhat(
-          runtime.config,
-          "/hapi/v1/computers/me/runtime-secrets/add-link",
-          {
-            method: "POST",
-            body: JSON.stringify({
-              name,
-              description: description || hint,
-              hint,
-            }),
-          },
-          runtime.signal,
+        return formatSecretRequestReply(
+          await callTinyhat(
+            runtime.config,
+            "/hapi/v1/computers/me/runtime-secrets/add-link",
+            {
+              method: "POST",
+              body: JSON.stringify({
+                name,
+                description: description || hint,
+                hint,
+              }),
+            },
+            runtime.signal,
+          ),
         );
       },
     }),
@@ -166,7 +176,11 @@ const plugin = defineToolPlugin({
       execute: async (_params, config, context) => {
         const runtime = resolveExecutionRuntime(config, context);
         runtime.signal?.throwIfAborted?.();
-        return fetchManageComputerLink(runtime.config, runtime.signal);
+        return formatButtonReply(
+          await fetchManageComputerLink(runtime.config, runtime.signal),
+          "Manage computer",
+          "computer.open_manage",
+        );
       },
     }),
     tool({
@@ -178,7 +192,11 @@ const plugin = defineToolPlugin({
       execute: async ({ command } = {}, config, context) => {
         const runtime = resolveExecutionRuntime(config, context);
         runtime.signal?.throwIfAborted?.();
-        return fetchTerminalLink(runtime.config, runtime.signal, command);
+        return formatButtonReply(
+          await fetchTerminalLink(runtime.config, runtime.signal, command),
+          "Open secure terminal",
+          "computer.open_terminal",
+        );
       },
     }),
     tool({
@@ -206,20 +224,24 @@ const plugin = defineToolPlugin({
           return secretCommandUsage();
         }
         if (parsed.action === "list") {
-          return fetchSecretStatuses(runtime.config, runtime.signal);
+          return formatSecretListReply(
+            await fetchSecretStatuses(runtime.config, runtime.signal),
+          );
         }
-        return callTinyhat(
-          runtime.config,
-          "/hapi/v1/computers/me/runtime-secrets/add-link",
-          {
-            method: "POST",
-            body: JSON.stringify({
-              name: parsed.name,
-              description: parsed.description,
-              hint: parsed.description,
-            }),
-          },
-          runtime.signal,
+        return formatSecretRequestReply(
+          await callTinyhat(
+            runtime.config,
+            "/hapi/v1/computers/me/runtime-secrets/add-link",
+            {
+              method: "POST",
+              body: JSON.stringify({
+                name: parsed.name,
+                description: parsed.description,
+                hint: parsed.description,
+              }),
+            },
+            runtime.signal,
+          ),
         );
       },
     }),
@@ -239,7 +261,7 @@ plugin.register = (api) => {
     channels: ["telegram"],
     acceptsArgs: true,
     agentPromptGuidance: [
-      "Use /tinyhat_secrets list to show runtime secret metadata and /tinyhat_secrets add NAME to request a Telegram Mini App secret-entry button. Never ask for secret values in chat.",
+      `Use /tinyhat_secrets list to show runtime secret metadata and /tinyhat_secrets add NAME to request a Telegram Mini App secret-entry button. Never ask for secret values in chat. ${SECRET_REPLY_SAFETY}`,
     ],
     handler: async (ctx) => {
       const parsed = parseSecretCommand(ctx.args || "");
@@ -292,7 +314,7 @@ plugin.register = (api) => {
     ],
     handler: async () => {
       const payload = await fetchManageComputerLink(platformConfig);
-      return formatButtonReply(payload, "Manage computer");
+      return formatButtonReply(payload, "Manage computer", "computer.open_manage");
     },
   });
 
@@ -307,7 +329,7 @@ plugin.register = (api) => {
     ],
     handler: async (ctx) => {
       const payload = await fetchTerminalLink(platformConfig, undefined, ctx.args);
-      return formatButtonReply(payload, "Open secure terminal");
+      return formatButtonReply(payload, "Open secure terminal", "computer.open_terminal");
     },
   });
 };
@@ -360,81 +382,6 @@ function secretCommandUsage() {
       "",
       "Secret values are added in the Tinyhat Mini App, not in chat.",
     ],
-  };
-}
-
-function formatSecretListReply(payload) {
-  const secrets = Array.isArray(payload?.secrets) ? payload.secrets : [];
-  const button = payload?.telegram_button;
-  const lines =
-    secrets.length === 0
-      ? ["No Tinyhat runtime secrets are configured for this Computer yet."]
-      : [
-          "Tinyhat runtime secrets:",
-          ...secrets.map((secret) => {
-            const name = normalizeString(secret?.name) || "(unnamed)";
-            const saved = secret?.in_platform || secret?.has_value ? "saved" : "not saved";
-            const available =
-              normalizeString(secret?.vps_status) === "available"
-                ? "available"
-                : "not available";
-            const description = normalizeString(secret?.description);
-            return `- ${name}: ${saved}, ${available}${description ? ` - ${description}` : ""}`;
-          }),
-        ];
-  return {
-    text: lines.join("\n"),
-    ...(button?.web_app?.url ? buttonPresentation(button, "Manage secrets") : {}),
-  };
-}
-
-function formatSecretRequestReply(payload) {
-  const secretName = normalizeString(payload?.secret?.name) || "this secret";
-  const button = payload?.telegram_button;
-  if (!button?.web_app?.url) {
-    return {
-      text:
-        `I could not render a Telegram button for ${secretName}. ` +
-        "Retry from Telegram or open Manage Computer. Do not paste the value in chat.",
-    };
-  }
-  return {
-    text: `Open the Telegram Mini App button to add ${secretName}. Do not paste the value in chat.`,
-    ...buttonPresentation(button, `Add ${secretName}`),
-  };
-}
-
-function formatButtonReply(payload, fallbackLabel) {
-  const button = payload?.telegram_button;
-  const message = normalizeString(payload?.message);
-  if (!button?.web_app?.url) {
-    return {
-      text: message || `${fallbackLabel} is not available from this channel.`,
-    };
-  }
-  return {
-    text: message || `${fallbackLabel} is available from the Telegram button.`,
-    ...buttonPresentation(button, fallbackLabel),
-  };
-}
-
-function buttonPresentation(button, fallbackLabel) {
-  const label = normalizeString(button.text) || fallbackLabel;
-  return {
-    channelData: { telegram: { buttons: [[button]] } },
-    presentation: {
-      blocks: [
-        {
-          type: "buttons",
-          buttons: [
-            {
-              label,
-              webApp: { url: button.web_app.url },
-            },
-          ],
-        },
-      ],
-    },
   };
 }
 

--- a/src/presentation_helpers.js
+++ b/src/presentation_helpers.js
@@ -1,0 +1,143 @@
+const SECRET_BUTTON_UNAVAILABLE_TEXT =
+  "Retry from Telegram or open Manage Computer. Do not paste the value in chat.";
+
+const TRANSPORT_ONLY_INSTRUCTIONS = [
+  "Render the Telegram button payload when the channel supports buttons.",
+  "Do not print, summarize, or fallback to any Mini App URL from channelData.",
+  "If buttons are unavailable, tell the user to retry from Telegram or Manage Computer.",
+];
+
+export function formatSecretListReply(payload) {
+  const secrets = Array.isArray(payload?.secrets) ? payload.secrets : [];
+  const button = payload?.telegram_button;
+  const lines =
+    secrets.length === 0
+      ? ["No Tinyhat runtime secrets are configured for this Computer yet."]
+      : [
+          "Tinyhat runtime secrets:",
+          ...secrets.map((secret) => {
+            const name = normalizeString(secret?.name) || "(unnamed)";
+            const saved = secret?.in_platform || secret?.has_value ? "saved" : "not saved";
+            const available =
+              normalizeString(secret?.vps_status) === "available"
+                ? "available"
+                : "not available";
+            const description = normalizeString(secret?.description);
+            return `- ${name}: ${saved}, ${available}${description ? ` - ${description}` : ""}`;
+          }),
+        ];
+
+  return withSafeButtonTransport({
+    action: "credentials.list_metadata",
+    text: lines.join("\n"),
+    secrets: secrets.map(publicSecretMetadata),
+    button,
+    fallbackLabel: "Manage secrets",
+  });
+}
+
+export function formatSecretRequestReply(payload) {
+  const secret = publicSecretMetadata(payload?.secret);
+  const secretName = secret.name || "this secret";
+  const button = payload?.telegram_button;
+
+  if (!hasTelegramWebAppButton(button)) {
+    return {
+      ok: false,
+      action: "credentials.open_add_secret",
+      text:
+        `I could not render a Telegram button for ${secretName}. ` +
+        SECRET_BUTTON_UNAVAILABLE_TEXT,
+      secret,
+      unsupported_channel_text: SECRET_BUTTON_UNAVAILABLE_TEXT,
+      agent_instructions: TRANSPORT_ONLY_INSTRUCTIONS,
+    };
+  }
+
+  return withSafeButtonTransport({
+    action: "credentials.open_add_secret",
+    text: `Open the Telegram Mini App button to add ${secretName}. Do not paste the value in chat.`,
+    secret,
+    button,
+    fallbackLabel: `Add ${secretName}`,
+  });
+}
+
+export function formatButtonReply(payload, fallbackLabel, action = "computer.open") {
+  const button = payload?.telegram_button;
+  const message = normalizeString(payload?.message);
+  if (!hasTelegramWebAppButton(button)) {
+    return {
+      ok: false,
+      action,
+      text: message || `${fallbackLabel} is not available from this channel.`,
+      unsupported_channel_text: `${fallbackLabel} must be opened from Telegram or Manage Computer.`,
+      agent_instructions: TRANSPORT_ONLY_INSTRUCTIONS,
+    };
+  }
+  return withSafeButtonTransport({
+    action,
+    text: message || `${fallbackLabel} is available from the Telegram button.`,
+    button,
+    fallbackLabel,
+  });
+}
+
+export function buttonTransport(button, fallbackLabel) {
+  const label = normalizeString(button?.text) || fallbackLabel;
+  return {
+    button: {
+      label,
+      kind: "telegram_web_app",
+      transport_only: true,
+    },
+    channelData: { telegram: { buttons: [[button]] } },
+    presentation: {
+      blocks: [
+        {
+          type: "text",
+          text: `${label} is attached as a Telegram Mini App button.`,
+        },
+      ],
+    },
+  };
+}
+
+export function publicSecretMetadata(secret) {
+  return {
+    name: normalizeString(secret?.name) || undefined,
+    description: normalizeString(secret?.description) || undefined,
+    status: normalizeString(secret?.status) || undefined,
+    revision: secret?.revision ?? undefined,
+    in_platform: Boolean(secret?.in_platform || secret?.has_value),
+    vps_status: normalizeString(secret?.vps_status) || undefined,
+  };
+}
+
+function withSafeButtonTransport({ action, text, secret, secrets, button, fallbackLabel }) {
+  const base = {
+    ok: true,
+    action,
+    text,
+    ...(secret ? { secret } : {}),
+    ...(secrets ? { secrets } : {}),
+    unsupported_channel_text:
+      "This action needs a Telegram Mini App button. Retry from Telegram or Manage Computer.",
+    agent_instructions: TRANSPORT_ONLY_INSTRUCTIONS,
+  };
+  if (!hasTelegramWebAppButton(button)) {
+    return base;
+  }
+  return {
+    ...base,
+    ...buttonTransport(button, fallbackLabel),
+  };
+}
+
+function hasTelegramWebAppButton(button) {
+  return Boolean(button?.web_app?.url);
+}
+
+function normalizeString(value) {
+  return String(value || "").trim();
+}

--- a/src/presentation_helpers.js
+++ b/src/presentation_helpers.js
@@ -1,9 +1,11 @@
 const SECRET_BUTTON_UNAVAILABLE_TEXT =
   "Retry from Telegram or open Manage Computer. Do not paste the value in chat.";
+const TELEGRAM_BUTTON_UNAVAILABLE_TEXT =
+  "This action needs a Telegram Mini App button. Retry from Telegram or Manage Computer.";
 
 const TRANSPORT_ONLY_INSTRUCTIONS = [
   "Render the Telegram button payload when the channel supports buttons.",
-  "Do not print, summarize, or fallback to any Mini App URL from channelData.",
+  "Do not print, summarize, or fallback to any Mini App URL.",
   "If buttons are unavailable, tell the user to retry from Telegram or Manage Computer.",
 ];
 
@@ -63,7 +65,7 @@ export function formatSecretRequestReply(payload) {
   });
 }
 
-export function formatButtonReply(payload, fallbackLabel, action = "computer.open") {
+export function formatButtonReply(payload, fallbackLabel, action) {
   const button = payload?.telegram_button;
   const message = normalizeString(payload?.message);
   if (!hasTelegramWebAppButton(button)) {
@@ -121,12 +123,13 @@ function withSafeButtonTransport({ action, text, secret, secrets, button, fallba
     text,
     ...(secret ? { secret } : {}),
     ...(secrets ? { secrets } : {}),
-    unsupported_channel_text:
-      "This action needs a Telegram Mini App button. Retry from Telegram or Manage Computer.",
     agent_instructions: TRANSPORT_ONLY_INSTRUCTIONS,
   };
   if (!hasTelegramWebAppButton(button)) {
-    return base;
+    return {
+      ...base,
+      unsupported_channel_text: TELEGRAM_BUTTON_UNAVAILABLE_TEXT,
+    };
   }
   return {
     ...base,

--- a/src/presentation_helpers.js
+++ b/src/presentation_helpers.js
@@ -94,14 +94,6 @@ export function buttonTransport(button, fallbackLabel) {
       transport_only: true,
     },
     channelData: { telegram: { buttons: [[button]] } },
-    presentation: {
-      blocks: [
-        {
-          type: "text",
-          text: `${label} is attached as a Telegram Mini App button.`,
-        },
-      ],
-    },
   };
 }
 

--- a/src/telegram_delivery.js
+++ b/src/telegram_delivery.js
@@ -1,0 +1,92 @@
+export async function sendTelegramMiniAppButton({
+  api,
+  toolContext,
+  reply,
+  text,
+  signal,
+  fetchImpl = globalThis.fetch,
+}) {
+  const buttons = reply?.channelData?.telegram?.buttons;
+  if (!Array.isArray(buttons) || buttons.length === 0) {
+    return { sent: false, reason: "missing_button_payload" };
+  }
+
+  const deliveryContext = toolContext?.deliveryContext;
+  if (deliveryContext?.channel !== "telegram") {
+    return { sent: false, reason: "not_telegram_delivery_context" };
+  }
+
+  const chatId = telegramChatIdFromDeliveryContext(deliveryContext, toolContext);
+  const token = telegramBotTokenFromConfig(
+    toolContext?.getRuntimeConfig?.() || toolContext?.runtimeConfig || toolContext?.config || api?.config,
+    deliveryContext?.accountId,
+  );
+  if (!chatId || !token) {
+    return { sent: false, reason: chatId ? "missing_telegram_bot_token" : "missing_telegram_chat_id" };
+  }
+
+  const response = await fetchImpl(`https://api.telegram.org/bot${token}/sendMessage`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({
+      chat_id: chatId,
+      text: String(text || "Open the Telegram Mini App button."),
+      ...(deliveryContext?.threadId
+        ? { message_thread_id: Number(deliveryContext.threadId) }
+        : {}),
+      reply_markup: { inline_keyboard: buttons },
+    }),
+    signal,
+  });
+  const payload = await response.json().catch(() => ({}));
+  if (!response.ok || payload?.ok !== true) {
+    return {
+      sent: false,
+      reason: "telegram_send_failed",
+      status: response.status,
+      error_code: payload?.error_code,
+      description: payload?.description,
+    };
+  }
+
+  return {
+    sent: true,
+    channel: "telegram",
+    chat_id: String(payload.result?.chat?.id || chatId),
+    message_id: String(payload.result?.message_id || ""),
+  };
+}
+
+export function markTelegramDelivered(reply, delivery) {
+  if (!delivery?.sent) {
+    return reply;
+  }
+  const { channelData: _channelData, ...safeReply } = reply || {};
+  return {
+    ...safeReply,
+    telegram_delivery: delivery,
+    delivered: true,
+    agent_instructions: [
+      ...(Array.isArray(reply?.agent_instructions) ? reply.agent_instructions : []),
+      "The Telegram Mini App button has already been sent directly. Do not call the message tool for this button, and never print the Mini App URL.",
+    ],
+  };
+}
+
+export function telegramChatIdFromDeliveryContext(deliveryContext, toolContext) {
+  const raw =
+    deliveryContext?.to ||
+    deliveryContext?.chatId ||
+    toolContext?.requesterSenderId ||
+    "";
+  const text = String(raw || "").trim();
+  if (!text) return "";
+  return text.startsWith("telegram:") ? text.slice("telegram:".length) : text;
+}
+
+export function telegramBotTokenFromConfig(config, accountId = "default") {
+  const telegram = config?.channels?.telegram || {};
+  const account =
+    telegram?.accounts && accountId ? telegram.accounts[String(accountId)] : null;
+  return String(account?.botToken || telegram?.botToken || "").trim();
+}

--- a/test/presentation_helpers.test.mjs
+++ b/test/presentation_helpers.test.mjs
@@ -1,0 +1,131 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  formatButtonReply,
+  formatSecretListReply,
+  formatSecretRequestReply,
+} from "../src/presentation_helpers.js";
+
+const MINI_APP_URL =
+  "https://tinyhat.example/mini/runtime-secret/add?intent=signed-token&name=OPENAI_API_KEY";
+
+function sampleSecretPayload(overrides = {}) {
+  return {
+    mini_app_url: MINI_APP_URL,
+    secret: {
+      name: "OPENAI_API_KEY",
+      description: "Used for model access",
+      status: "missing",
+      revision: 2,
+      secret_value: "sk-never-visible",
+    },
+    telegram_button: {
+      text: "Add OPENAI_API_KEY",
+      web_app: { url: MINI_APP_URL },
+    },
+    ...overrides,
+  };
+}
+
+function withoutChannelData(value) {
+  const copy = structuredClone(value);
+  delete copy.channelData;
+  return copy;
+}
+
+function assertNoRawSecretTransportInVisibleReply(reply) {
+  const visible = JSON.stringify(withoutChannelData(reply));
+  assert(!visible.includes(MINI_APP_URL));
+  assert(!visible.includes("signed-token"));
+  assert(!visible.includes("mini_app_url"));
+  assert(!visible.includes("secret_value"));
+  assert(!visible.includes("sk-never-visible"));
+}
+
+test("formatSecretRequestReply returns safe text plus Telegram transport button", () => {
+  const reply = formatSecretRequestReply(sampleSecretPayload());
+
+  assert.equal(reply.ok, true);
+  assert.equal(reply.action, "credentials.open_add_secret");
+  assert.equal(
+    reply.text,
+    "Open the Telegram Mini App button to add OPENAI_API_KEY. Do not paste the value in chat.",
+  );
+  assert.deepEqual(reply.button, {
+    label: "Add OPENAI_API_KEY",
+    kind: "telegram_web_app",
+    transport_only: true,
+  });
+  assert.equal(reply.channelData.telegram.buttons[0][0].web_app.url, MINI_APP_URL);
+  assertNoRawSecretTransportInVisibleReply(reply);
+});
+
+test("formatSecretRequestReply does not put URLs in presentation fallback", () => {
+  const reply = formatSecretRequestReply(sampleSecretPayload());
+
+  assert.deepEqual(reply.presentation, {
+    blocks: [
+      {
+        type: "text",
+        text: "Add OPENAI_API_KEY is attached as a Telegram Mini App button.",
+      },
+    ],
+  });
+  assertNoRawSecretTransportInVisibleReply(reply);
+});
+
+test("formatSecretRequestReply degrades without raw URL when no button exists", () => {
+  const reply = formatSecretRequestReply(
+    sampleSecretPayload({ telegram_button: undefined }),
+  );
+
+  assert.equal(reply.ok, false);
+  assert(!reply.channelData);
+  assert(!reply.presentation);
+  assert.match(reply.text, /Retry from Telegram or open Manage Computer/);
+  assertNoRawSecretTransportInVisibleReply(reply);
+});
+
+test("formatSecretListReply lists metadata without exposing raw link fields", () => {
+  const reply = formatSecretListReply({
+    mini_app_url: MINI_APP_URL,
+    telegram_button: {
+      text: "Manage secrets",
+      web_app: { url: MINI_APP_URL },
+    },
+    secrets: [
+      {
+        name: "OPENAI_API_KEY",
+        description: "Used for model access",
+        has_value: true,
+        vps_status: "available",
+        secret_value: "sk-never-visible",
+      },
+    ],
+  });
+
+  assert.match(reply.text, /OPENAI_API_KEY: saved, available/);
+  assert.equal(reply.channelData.telegram.buttons[0][0].web_app.url, MINI_APP_URL);
+  assertNoRawSecretTransportInVisibleReply(reply);
+});
+
+test("formatButtonReply keeps Manage Computer URLs transport-only", () => {
+  const reply = formatButtonReply(
+    {
+      mini_app_url: MINI_APP_URL,
+      message: "Manage Computer is ready.",
+      telegram_button: {
+        text: "Manage computer",
+        web_app: { url: MINI_APP_URL },
+      },
+    },
+    "Manage computer",
+    "computer.open_manage",
+  );
+
+  assert.equal(reply.action, "computer.open_manage");
+  assert.equal(reply.text, "Manage Computer is ready.");
+  assert.equal(reply.channelData.telegram.buttons[0][0].web_app.url, MINI_APP_URL);
+  assertNoRawSecretTransportInVisibleReply(reply);
+});

--- a/test/presentation_helpers.test.mjs
+++ b/test/presentation_helpers.test.mjs
@@ -57,6 +57,7 @@ test("formatSecretRequestReply returns safe text plus Telegram transport button"
     kind: "telegram_web_app",
     transport_only: true,
   });
+  assert(!("unsupported_channel_text" in reply));
   assert.equal(reply.channelData.telegram.buttons[0][0].web_app.url, MINI_APP_URL);
   assertNoRawSecretTransportInVisibleReply(reply);
 });
@@ -106,7 +107,31 @@ test("formatSecretListReply lists metadata without exposing raw link fields", ()
   });
 
   assert.match(reply.text, /OPENAI_API_KEY: saved, available/);
+  assert(!("unsupported_channel_text" in reply));
   assert.equal(reply.channelData.telegram.buttons[0][0].web_app.url, MINI_APP_URL);
+  assertNoRawSecretTransportInVisibleReply(reply);
+});
+
+test("formatSecretListReply degrades without raw URL when no button exists", () => {
+  const reply = formatSecretListReply({
+    mini_app_url: MINI_APP_URL,
+    secrets: [
+      {
+        name: "OPENAI_API_KEY",
+        description: "Used for model access",
+        has_value: false,
+        vps_status: "missing",
+        secret_value: "sk-never-visible",
+      },
+    ],
+  });
+
+  assert.equal(reply.ok, true);
+  assert.equal(reply.action, "credentials.list_metadata");
+  assert.match(reply.text, /OPENAI_API_KEY: not saved, not available/);
+  assert(!reply.channelData);
+  assert(!reply.presentation);
+  assert.match(reply.unsupported_channel_text, /Telegram Mini App button/);
   assertNoRawSecretTransportInVisibleReply(reply);
 });
 
@@ -126,6 +151,7 @@ test("formatButtonReply keeps Manage Computer URLs transport-only", () => {
 
   assert.equal(reply.action, "computer.open_manage");
   assert.equal(reply.text, "Manage Computer is ready.");
+  assert(!("unsupported_channel_text" in reply));
   assert.equal(reply.channelData.telegram.buttons[0][0].web_app.url, MINI_APP_URL);
   assertNoRawSecretTransportInVisibleReply(reply);
 });

--- a/test/presentation_helpers.test.mjs
+++ b/test/presentation_helpers.test.mjs
@@ -62,17 +62,10 @@ test("formatSecretRequestReply returns safe text plus Telegram transport button"
   assertNoRawSecretTransportInVisibleReply(reply);
 });
 
-test("formatSecretRequestReply does not put URLs in presentation fallback", () => {
+test("formatSecretRequestReply keeps button replies on the Telegram-native path", () => {
   const reply = formatSecretRequestReply(sampleSecretPayload());
 
-  assert.deepEqual(reply.presentation, {
-    blocks: [
-      {
-        type: "text",
-        text: "Add OPENAI_API_KEY is attached as a Telegram Mini App button.",
-      },
-    ],
-  });
+  assert(!reply.presentation);
   assertNoRawSecretTransportInVisibleReply(reply);
 });
 

--- a/test/telegram_delivery.test.mjs
+++ b/test/telegram_delivery.test.mjs
@@ -1,0 +1,129 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  markTelegramDelivered,
+  sendTelegramMiniAppButton,
+  telegramBotTokenFromConfig,
+  telegramChatIdFromDeliveryContext,
+} from "../src/telegram_delivery.js";
+
+const MINI_APP_URL = "https://tinyhat.example/miniapp/secret";
+
+function replyWithButton() {
+  return {
+    ok: true,
+    text: "Open the Telegram Mini App button to add OPENROUTER_API_KEY.",
+    channelData: {
+      telegram: {
+        buttons: [
+          [
+            {
+              text: "Add OPENROUTER_API_KEY",
+              web_app: { url: MINI_APP_URL },
+            },
+          ],
+        ],
+      },
+    },
+    agent_instructions: ["Do not print the Mini App URL."],
+  };
+}
+
+test("sendTelegramMiniAppButton posts native Telegram web_app markup", async () => {
+  const calls = [];
+  const result = await sendTelegramMiniAppButton({
+    api: {},
+    toolContext: {
+      deliveryContext: {
+        channel: "telegram",
+        to: "telegram:101216939",
+        accountId: "default",
+      },
+      config: { channels: { telegram: { botToken: "123:token" } } },
+    },
+    reply: replyWithButton(),
+    text: "Tap the button.",
+    fetchImpl: async (url, init) => {
+      calls.push({ url, init });
+      return {
+        ok: true,
+        status: 200,
+        json: async () => ({
+          ok: true,
+          result: { message_id: 42, chat: { id: 101216939 } },
+        }),
+      };
+    },
+  });
+
+  assert.deepEqual(result, {
+    sent: true,
+    channel: "telegram",
+    chat_id: "101216939",
+    message_id: "42",
+  });
+  assert.equal(calls.length, 1);
+  assert.equal(calls[0].url, "https://api.telegram.org/bot123:token/sendMessage");
+  assert.deepEqual(JSON.parse(calls[0].init.body), {
+    chat_id: "101216939",
+    text: "Tap the button.",
+    reply_markup: {
+      inline_keyboard: replyWithButton().channelData.telegram.buttons,
+    },
+  });
+});
+
+test("markTelegramDelivered removes transport URL from tool result", () => {
+  const marked = markTelegramDelivered(replyWithButton(), {
+    sent: true,
+    channel: "telegram",
+    chat_id: "101216939",
+    message_id: "42",
+  });
+
+  assert.equal(marked.delivered, true);
+  assert(!marked.channelData);
+  assert(!JSON.stringify(marked).includes(MINI_APP_URL));
+  assert.match(marked.agent_instructions.at(-1), /already been sent directly/);
+});
+
+test("telegram delivery helper ignores non-telegram contexts", async () => {
+  const result = await sendTelegramMiniAppButton({
+    toolContext: {
+      deliveryContext: { channel: "slack", to: "telegram:101216939" },
+      config: { channels: { telegram: { botToken: "123:token" } } },
+    },
+    reply: replyWithButton(),
+    text: "Tap the button.",
+    fetchImpl: async () => {
+      throw new Error("should not send");
+    },
+  });
+
+  assert.deepEqual(result, {
+    sent: false,
+    reason: "not_telegram_delivery_context",
+  });
+});
+
+test("telegram config helpers support default and account tokens", () => {
+  assert.equal(
+    telegramChatIdFromDeliveryContext({ to: "telegram:101216939" }, {}),
+    "101216939",
+  );
+  assert.equal(
+    telegramBotTokenFromConfig(
+      {
+        channels: {
+          telegram: {
+            botToken: "default-token",
+            accounts: { work: { botToken: "work-token" } },
+          },
+        },
+      },
+      "work",
+    ),
+    "work-token",
+  );
+});


### PR DESCRIPTION
## Summary

Format Tinyhat secret, Manage Computer, and terminal button responses before they reach agent-facing tools so user-visible text and fallback presentation never include raw Mini App URLs. For Telegram secret entry, `tinyhat_request_runtime_secret` now direct-sends the native Telegram `web_app` button from tool context when the current delivery context is Telegram, then returns a safe `delivered: true` tool result without `channelData`.

The Telegram `web_app` URL remains transport-only. The skill guidance also teaches agents to infer conventional secret names/descriptions from plain English, so a request like “use OpenRouter for models” becomes `OPENROUTER_API_KEY` without asking the user to know the exact key name.

## Linked Issue

Refs tinyloophub/tinyloop#506

## Type Of Change

- [ ] `feat` - new feature
- [x] `fix` - bug fix
- [x] `docs` - documentation only
- [ ] `refactor` - no behavior change
- [x] `test` - tests only
- [ ] `chore` / `ci` / `build` - tooling
- [ ] Breaking change

## Testing Performed

- [x] `git diff --check`
- [x] `python3 scripts/check_dev_skills.py`
- [x] `bash .github/scripts/check_packaging.sh`
- [x] `python3 scripts/validate_openclaw_package.py`
- [x] `python3 -m compileall -q scripts`
- [x] `node --check src/index.js`
- [x] `node --test` (15 tests passed)
- [x] `ruff check .` and `ruff format --check .`
- [x] Manual OpenClaw plugin smoke test via Tinyloop PR #512 local Docker Computer

## Screenshots Or Logs

Redacted `node --test` summary:

```text
# tests 15
# pass 15
# fail 0
```

Live E2E from Tinyloop PR #512:

- Docker Computer `5029` installed this plugin at `14ae4108c391e50bb0b659a881f191ed75d2b721`.
- Plain-English Telegram request: “Use OpenRouter for models. Please set up whatever secret is needed.”
- Agent inferred `OPENROUTER_API_KEY` plus a non-secret OpenRouter description.
- `tinyhat_request_runtime_secret` direct-sent Telegram message id `352` with native button `Add OPENROUTER_API_KEY`.
- Tool result returned `delivered: true`, no raw Mini App URL in agent-facing text, and no `channelData` after direct delivery.
- Mini App opened with name/description prefilled; save completed with Telegram Mini App auth for the same user/bot; the secret later listed as `set` / `available` without revealing the value.

## Checklist

- [x] PR title is a Conventional Commit.
- [x] Linked to an issue or this PR is the canonical spec.
- [x] Docs updated where behavior changed.
- [x] Packaged skill changes follow `docs/skill-authoring.md`.
- [x] CI is green.
- [x] No tenant secrets, signed Mini App URLs, private backend URLs, local-only paths, or internal docs are included.
- [x] I will not self-merge.

<details>
<summary>Agent checklist</summary>

- [x] Commits follow the repo bot-identity/signing rules in `AGENTS.md`.
- [x] Branch named with an agent or contributor prefix.

</details>
