### PR TITLE
fix(subscriptions): track current OpenAI provider

### DIFF
--- a/skills/tinyhat-subscriptions/SKILL.md
+++ b/skills/tinyhat-subscriptions/SKILL.md
@@ -97,7 +97,7 @@ error text.
 5. The Computer's supervisor detects the new auth-profile on its
    next tick and rewrites `openclaw.json` so subsequent agent turns
    select the `openai` OAuth profile and route through
-   `openai/gpt-5.5` via the native Codex runtime. The first agent
+   `openai/gpt-5.5` via OpenClaw's native model route. The first agent
    reply after that switch confirms it — no polling,
    no separate notification flow.
 

--- a/skills/tinyhat-subscriptions/SKILL.md
+++ b/skills/tinyhat-subscriptions/SKILL.md
@@ -72,7 +72,7 @@ error text.
 2. Call `tinyhat_open_chatgpt_subscription_link`. The tool asks the
    platform to start a device-code session for this Computer; the
    Computer's runtime supervisor runs
-   `openclaw models auth login --provider openai-codex --device-code`
+   `openclaw models auth login --provider openai --device-code`
    (the supervisor owns the subprocess so this plugin stays
    subprocess-free per OpenClaw's plugin-install policy) and reports
    the verification URL + 9-character user code back to the platform.
@@ -96,8 +96,9 @@ error text.
    signed in to. The code expires in about 15 minutes."*
 5. The Computer's supervisor detects the new auth-profile on its
    next tick and rewrites `openclaw.json` so subsequent agent turns
-   route through `openai/gpt-5.5` via the native Codex runtime. The
-   first agent reply after that switch confirms it — no polling,
+   select the `openai` OAuth profile and route through
+   `openai/gpt-5.5` via the native Codex runtime. The first agent
+   reply after that switch confirms it — no polling,
    no separate notification flow.
 
 ## Subscription Button Contract

--- a/src/subscriptions.js
+++ b/src/subscriptions.js
@@ -7,7 +7,7 @@
 //   3. POST /hapi/v1/computers/me/subscription-link/revert (back to platform_credits)
 //
 // The runtime supervisor is the layer that actually spawns the
-// `openclaw models auth login --provider openai-codex --device-code`
+// `openclaw models auth login --provider openai --device-code`
 // CLI in a PTY — see the sibling runtime repo for the heartbeat-command
 // handler. This plugin must not import `node:child_process` or
 // `node:fs` for OAuth state because OpenClaw's plugin installer

--- a/test/subscription_flow.test.mjs
+++ b/test/subscription_flow.test.mjs
@@ -356,3 +356,21 @@ test("subscription SKILL.md routes the prerequisite-help tool and documents the 
   assert.match(skill, /photo_delivered/);
   assert.match(skill, /long-press.*Copy|bare.*bubble/i);
 });
+
+test("subscription guidance tracks the current OpenAI provider", () => {
+  const skill = readFileSync(
+    path.join(REPO_ROOT, "skills/tinyhat-subscriptions/SKILL.md"),
+    "utf8",
+  );
+  const helper = readFileSync(
+    path.join(REPO_ROOT, "src/subscriptions.js"),
+    "utf8",
+  );
+  const combined = `${skill}\n${helper}`;
+
+  assert.match(
+    combined,
+    /openclaw models auth login --provider openai --device-code/,
+  );
+  assert.doesNotMatch(combined, /openai-codex/);
+});


### PR DESCRIPTION
## Summary

Updates the shipped Tinyhat subscription guidance to match the current OpenClaw runtime: device-code linking now uses the `openai` provider/profile path, not the legacy `openai-codex` wording. Adds a regression test so packaged subscription guidance stays aligned with the current provider route.

## Linked Issue

This PR is the compatibility follow-up for the current runtime subscription-linking fix.

## Type Of Change

- [x] `fix` - bug fix
- [x] `docs` - documentation only
- [x] `test` - tests only

## Testing Performed

- [x] `git diff --check`
- [x] `python3 scripts/check_dev_skills.py`
- [x] `bash .github/scripts/check_packaging.sh`
- [x] `python3 scripts/validate_openclaw_package.py`
- [x] `python3 -m compileall -q scripts`
- [x] `node --check src/index.js`
- [x] `node --test test/*.test.mjs`
- [ ] `ruff check .` and `ruff format --check .` (not run: `ruff` is not installed in this shell)
- [x] Manual OpenClaw plugin smoke test, if applicable

## Screenshots Or Logs

Manual OpenClaw plugin smoke test used an isolated OpenClaw state dir and installed this checkout successfully:

```text
Installed plugin: tinyhat
{"id":"tinyhat","name":"Tinyhat","version":"0.4.3","enabled":true}
```

## Checklist

- [x] PR title is a Conventional Commit.
- [x] Linked to an issue or this PR is the canonical spec.
- [x] Docs updated where behavior changed.
- [x] Packaged skill changes follow `docs/skill-authoring.md`.
- [x] CI is green.
- [x] No tenant secrets, signed Mini App URLs, private backend URLs, local-only paths, or internal docs are included.
- [x] I will not self-merge.

<details>
<summary>Agent checklist</summary>

- [x] Commits follow the repo bot-identity/signing rules in `AGENTS.md`.
- [x] Branch named with an agent or contributor prefix.

</details>
