### PR TITLE
fix(subscriptions): return JSON tool results

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,9 @@ The first package exposes these named Tinyhat operations:
 | `computer.open_terminal` | `tinyhat_open_terminal_link` | Telegram Mini App button with optional admin-reviewed command. |
 | `computer.status` | `tinyhat_get_platform_status` | Secret-free runtime/platform status. |
 | `packages.list_installed` | `tinyhat_list_installed_packages` | Public refs/SHAs and Tinyhat-vs-user package split when available. |
+| `subscriptions.open_prerequisite_help` | `tinyhat_open_chatgpt_subscription_prerequisite_help` | Telegram photo plus walkthrough text. |
+| `subscriptions.open_link` | `tinyhat_open_chatgpt_subscription_link` | Telegram URL button plus bare device-code bubble. |
+| `subscriptions.revert_to_platform_credits` | `tinyhat_revert_to_platform_credits` | Metadata-only tool result. |
 | `support.report_problem` | `tinyhat_report_problem` | Redacted support context. |
 
 Secret values, signed Mini App intent tokens, raw backend URLs, and

--- a/docs/local-development.md
+++ b/docs/local-development.md
@@ -47,6 +47,55 @@ pipx run ruff format --check .
 | `node --test` | Runs pure JavaScript safety tests for redaction and command parsing. |
 | `ruff` | Lints and format-checks Python helper scripts. |
 
+## ChatGPT Subscription Link Regression Loop
+
+The ChatGPT/Codex subscription link is a cross-repo contract between:
+
+- this plugin (`tinyhat-ai/tinyhat`) for chat routing, Telegram button/code
+  delivery, and OpenClaw tool-result shape;
+- the runtime (`tinyloophub/tinyhat--runtimes--openclaw`) for provider-plugin
+  install/verification and the `openclaw models auth login --provider openai
+  --device-code` worker;
+- the platform (`tinyloophub/tinyloop`) for
+  `/hapi/v1/computers/me/subscription-link/*` state and Telegram Mini App
+  surfaces.
+
+Before merging plugin changes that touch
+`tinyhat_open_chatgpt_subscription_link`,
+`tinyhat_open_chatgpt_subscription_prerequisite_help`,
+`src/subscriptions.js`, `src/subscription_builders.js`, or Telegram button
+delivery, run at least:
+
+```bash
+node --test test/subscription_flow.test.mjs test/telegram_delivery.test.mjs
+```
+
+That targeted suite must prove:
+
+- subscription factory tools return MCP/OpenClaw-style results with
+  `content[]`; raw objects can reproduce OpenClaw wrapper failures such as
+  `Cannot read properties of undefined (reading 'reduce')`;
+- the serialized tool result never exposes the raw OpenAI verification URL
+  after Telegram button delivery handling;
+- the URL button and bare-code bubble success/failure states produce accurate
+  recovery instructions.
+
+For release-gate work, pair the plugin suite with the runtime retry smoke:
+
+```bash
+cd ../tinyhat--runtimes--openclaw
+python3 scripts/smoke_start_chatgpt_link_retry.py
+```
+
+Then run the Tinyloop E2E scenario:
+
+```text
+docs/e2e-scenarios/tinyhat/20-chatgpt-byo-subscription.md
+```
+
+The live pass condition is Telegram showing a native **Sign in to ChatGPT**
+button plus a separate bare device-code message for a real assigned Computer.
+
 ## Manual OpenClaw Smoke Test
 
 Use an OpenClaw development instance when available:

--- a/docs/local-development.md
+++ b/docs/local-development.md
@@ -80,6 +80,8 @@ That targeted suite must prove:
 - the chat-side polling budget covers supervisor heartbeat skew plus runtime
   pre-code retry, so a valid URL/code that arrives after the old 15s window is
   not surfaced to the user as a timeout;
+- the 90s plugin-side polling ceiling remains bounded by OpenClaw's tool-call
+  abort signal; if the runtime cancels sooner, the `signal` path wins;
 - the URL button and bare-code bubble success/failure states produce accurate
   recovery instructions.
 
@@ -90,7 +92,8 @@ cd ../tinyhat--runtimes--openclaw
 python3 scripts/smoke_start_chatgpt_link_retry.py
 ```
 
-Then run the Tinyloop E2E scenario:
+Then run the Tinyloop monorepo E2E scenario (this file lives in
+`tinyloophub/tinyloop`, not in this public plugin repo):
 
 ```text
 docs/e2e-scenarios/tinyhat/20-chatgpt-byo-subscription.md

--- a/docs/local-development.md
+++ b/docs/local-development.md
@@ -77,6 +77,9 @@ That targeted suite must prove:
   `Cannot read properties of undefined (reading 'reduce')`;
 - the serialized tool result never exposes the raw OpenAI verification URL
   after Telegram button delivery handling;
+- the chat-side polling budget covers supervisor heartbeat skew plus runtime
+  pre-code retry, so a valid URL/code that arrives after the old 15s window is
+  not surfaced to the user as a timeout;
 - the URL button and bare-code bubble success/failure states produce accurate
   recovery instructions.
 

--- a/src/index.js
+++ b/src/index.js
@@ -330,7 +330,9 @@ const plugin = defineToolPlugin({
           });
           // The finalizer is the only place delivery-state claims are
           // made: success → "already sent"; failure → recovery guidance.
-          return finalizeSubscriptionPrerequisiteHelpReply(reply, photoDelivery);
+          return jsonToolResult(
+            finalizeSubscriptionPrerequisiteHelpReply(reply, photoDelivery),
+          );
         },
       }),
     }),
@@ -364,7 +366,7 @@ const plugin = defineToolPlugin({
               signal: runtime.signal,
             });
           } catch (err) {
-            return buildSubscriptionLinkFailureReply(err);
+            return jsonToolResult(buildSubscriptionLinkFailureReply(err));
           }
           const reply = buildSubscriptionLinkReply(session);
           // Send the URL-button intro first so the user sees the
@@ -394,10 +396,12 @@ const plugin = defineToolPlugin({
               signal: runtime.signal,
             });
           }
-          return finalizeSubscriptionLinkReply(reply, {
-            buttonDelivery,
-            codeDelivery,
-          });
+          return jsonToolResult(
+            finalizeSubscriptionLinkReply(reply, {
+              buttonDelivery,
+              codeDelivery,
+            }),
+          );
         },
       }),
     }),
@@ -541,9 +545,10 @@ function resolveExecutionRuntime(configArg, contextArg) {
 }
 
 function jsonToolResult(payload) {
+  const safePayload = payload ?? {};
   return {
-    content: [{ type: "text", text: JSON.stringify(payload, null, 2) }],
-    details: payload,
+    content: [{ type: "text", text: JSON.stringify(safePayload, null, 2) }],
+    details: safePayload,
   };
 }
 

--- a/src/index.js
+++ b/src/index.js
@@ -26,6 +26,7 @@ import {
   sendTelegramPhoto,
   sendTelegramText,
 } from "./telegram_delivery.js";
+import { jsonToolResult } from "./tool_results.js";
 
 const METADATA_BASE_URL_KEY = "tinyhat-platform-base-url";
 const METADATA_AUDIENCE_KEY = "tinyhat-backend-audience";
@@ -541,14 +542,6 @@ function resolveExecutionRuntime(configArg, contextArg) {
   return {
     config: configCandidate,
     signal: contextArg?.signal ?? configArg?.signal,
-  };
-}
-
-function jsonToolResult(payload) {
-  const safePayload = payload ?? {};
-  return {
-    content: [{ type: "text", text: JSON.stringify(safePayload, null, 2) }],
-    details: safePayload,
   };
 }
 

--- a/src/subscription_builders.js
+++ b/src/subscription_builders.js
@@ -184,13 +184,17 @@ export function finalizeSubscriptionLinkReply(
     : [];
   // Never surface the transport button payload / verification URL button
   // to the agent, regardless of outcome.
-  const { channelData: _channelData, ...withoutChannelData } = base;
+  const {
+    channelData: _channelData,
+    verification_url: _verificationUrl,
+    ...withoutTransportData
+  } = base;
   const buttonSent = !!buttonDelivery?.sent;
   const codeSent = !!codeDelivery?.sent;
 
   if (!buttonSent) {
     return {
-      ...withoutChannelData,
+      ...withoutTransportData,
       delivered: false,
       code_delivered: codeSent,
       telegram_delivery: buttonDelivery || { sent: false },
@@ -204,7 +208,7 @@ export function finalizeSubscriptionLinkReply(
 
   if (codeSent) {
     return {
-      ...withoutChannelData,
+      ...withoutTransportData,
       delivered: true,
       code_delivered: true,
       telegram_delivery: buttonDelivery,
@@ -222,7 +226,7 @@ export function finalizeSubscriptionLinkReply(
   // supply it. The device code is the one paste-able non-secret value in
   // this flow, so re-pasting it here is allowed.
   return {
-    ...withoutChannelData,
+    ...withoutTransportData,
     delivered: true,
     code_delivered: false,
     telegram_delivery: buttonDelivery,

--- a/src/subscriptions.js
+++ b/src/subscriptions.js
@@ -18,8 +18,12 @@
 // in by the tool body) so they reuse the Computer-bearer-token auth +
 // platform base URL resolution that every other Tinyhat tool uses.
 
-const POLL_INTERVAL_MS = 1_500;
-const POLL_TIMEOUT_MS = 15_000;
+export const CHATGPT_LINK_POLL_INTERVAL_MS = 1_500;
+// The chat tool starts a platform row, then waits for the supervisor's next
+// heartbeat to receive the command, spawn the OpenClaw device-code CLI, retry
+// transient pre-code failures, and POST URL+code back. A 15s budget raced real
+// local Computers where the code arrived just after the tool returned failure.
+export const CHATGPT_LINK_POLL_TIMEOUT_MS = 90_000;
 
 /**
  * Start (or retrieve, if already in flight) a ChatGPT BYO device-code
@@ -36,8 +40,8 @@ const POLL_TIMEOUT_MS = 15_000;
 export async function startChatgptSubscriptionLink({
   callTinyhat,
   signal,
-  pollIntervalMs = POLL_INTERVAL_MS,
-  pollTimeoutMs = POLL_TIMEOUT_MS,
+  pollIntervalMs = CHATGPT_LINK_POLL_INTERVAL_MS,
+  pollTimeoutMs = CHATGPT_LINK_POLL_TIMEOUT_MS,
 }) {
   // Kick off (or retrieve) the link session. The backend bumps the
   // row to pending + signals the supervisor via the heartbeat command;

--- a/src/subscriptions.js
+++ b/src/subscriptions.js
@@ -23,6 +23,8 @@ export const CHATGPT_LINK_POLL_INTERVAL_MS = 1_500;
 // heartbeat to receive the command, spawn the OpenClaw device-code CLI, retry
 // transient pre-code failures, and POST URL+code back. A 15s budget raced real
 // local Computers where the code arrived just after the tool returned failure.
+// This is only the plugin-side ceiling: OpenClaw's tool-call abort signal still
+// wins first because the loop checks `signal` and passes it into `callTinyhat`.
 export const CHATGPT_LINK_POLL_TIMEOUT_MS = 90_000;
 
 /**

--- a/src/tool_results.js
+++ b/src/tool_results.js
@@ -1,0 +1,12 @@
+// OpenClaw tool wrappers consume MCP-style tool results with a `content[]`
+// array. Factory-style tools that return raw objects can trip wrapper code
+// that reduces over `result.content`, so keep the shape centralized and
+// executable in pure unit tests.
+
+export function jsonToolResult(payload) {
+  const safePayload = payload ?? {};
+  return {
+    content: [{ type: "text", text: JSON.stringify(safePayload, null, 2) }],
+    details: safePayload,
+  };
+}

--- a/test/subscription_flow.test.mjs
+++ b/test/subscription_flow.test.mjs
@@ -21,6 +21,7 @@ import {
   finalizeSubscriptionLinkReply,
   finalizeSubscriptionPrerequisiteHelpReply,
 } from "../src/subscription_builders.js";
+import { jsonToolResult } from "../src/tool_results.js";
 
 const REPO_ROOT = path.resolve(
   path.dirname(fileURLToPath(import.meta.url)),
@@ -28,6 +29,15 @@ const REPO_ROOT = path.resolve(
 );
 
 const ALREADY_SENT = /already (been )?sent/i;
+
+function collectOpenClawTextContent(result) {
+  return result.content.reduce((chunks, item) => {
+    if (item?.type === "text" && typeof item.text === "string") {
+      chunks.push(item.text);
+    }
+    return chunks;
+  }, []).join("\n");
+}
 
 // ── Base builders are NEUTRAL — they must never claim delivery ─────────
 // (Codex P1, #109: a `{ sent: false }` result must never leave a stale
@@ -272,6 +282,43 @@ test("link finalizer always strips the transport verification URL button from th
       "verification URL must never appear in agent_instructions",
     );
   }
+});
+
+test("subscription link final result is safe for OpenClaw content reducers", () => {
+  const reply = buildSubscriptionLinkReply({
+    verificationUrl: "https://auth.openai.com/codex/device",
+    userCode: "6JTR-X8OS4",
+  });
+  const final = finalizeSubscriptionLinkReply(reply, {
+    buttonDelivery: { sent: true, message_id: "10" },
+    codeDelivery: { sent: true, message_id: "11" },
+  });
+
+  assert.throws(
+    () => collectOpenClawTextContent(final),
+    /Cannot read properties of undefined \(reading 'reduce'\)|reduce/,
+    "raw finalized replies reproduce the OpenClaw wrapper failure",
+  );
+
+  const wrapped = jsonToolResult(final);
+  assert.deepEqual(Object.keys(wrapped).sort(), ["content", "details"]);
+  assert.equal(wrapped.content[0].type, "text");
+
+  const text = collectOpenClawTextContent(wrapped);
+  const parsed = JSON.parse(text);
+  assert.equal(parsed.action, "subscriptions.open_link");
+  assert.equal(parsed.delivered, true);
+  assert.equal(parsed.code_delivered, true);
+  assert.equal(parsed.user_code, "6JTR-X8OS4");
+  assert.equal(parsed.verification_url, undefined);
+  assert.equal(parsed.channelData, undefined);
+  assert.deepEqual(wrapped.details, final);
+});
+
+test("jsonToolResult normalizes nullish payloads to an object payload", () => {
+  const wrapped = jsonToolResult(undefined);
+  assert.deepEqual(wrapped.details, {});
+  assert.deepEqual(JSON.parse(collectOpenClawTextContent(wrapped)), {});
 });
 
 test("ChatGPT subscription factory tools return OpenClaw JSON tool results", () => {

--- a/test/subscription_flow.test.mjs
+++ b/test/subscription_flow.test.mjs
@@ -34,7 +34,10 @@ const REPO_ROOT = path.resolve(
 
 const ALREADY_SENT = /already (been )?sent/i;
 
-function collectOpenClawTextContent(result) {
+// Local proxy for OpenClaw's wrapper behavior: factory-tool results are reduced
+// over `content[]`, so a raw finalized reply reproduces the crash shape without
+// importing OpenClaw internals into this plugin's unit tests.
+function collectOpenClawTextContentProxy(result) {
   return result.content.reduce((chunks, item) => {
     if (item?.type === "text" && typeof item.text === "string") {
       chunks.push(item.text);
@@ -340,7 +343,7 @@ test("link finalizer always strips the transport verification URL button from th
   }
 });
 
-test("subscription link final result is safe for OpenClaw content reducers", () => {
+test("subscription link final result is safe for the local OpenClaw reducer proxy", () => {
   const reply = buildSubscriptionLinkReply({
     verificationUrl: "https://auth.openai.com/codex/device",
     userCode: "6JTR-X8OS4",
@@ -351,7 +354,7 @@ test("subscription link final result is safe for OpenClaw content reducers", () 
   });
 
   assert.throws(
-    () => collectOpenClawTextContent(final),
+    () => collectOpenClawTextContentProxy(final),
     /Cannot read properties of undefined \(reading 'reduce'\)|reduce/,
     "raw finalized replies reproduce the OpenClaw wrapper failure",
   );
@@ -360,7 +363,7 @@ test("subscription link final result is safe for OpenClaw content reducers", () 
   assert.deepEqual(Object.keys(wrapped).sort(), ["content", "details"]);
   assert.equal(wrapped.content[0].type, "text");
 
-  const text = collectOpenClawTextContent(wrapped);
+  const text = collectOpenClawTextContentProxy(wrapped);
   const parsed = JSON.parse(text);
   assert.equal(parsed.action, "subscriptions.open_link");
   assert.equal(parsed.delivered, true);
@@ -374,7 +377,7 @@ test("subscription link final result is safe for OpenClaw content reducers", () 
 test("jsonToolResult normalizes nullish payloads to an object payload", () => {
   const wrapped = jsonToolResult(undefined);
   assert.deepEqual(wrapped.details, {});
-  assert.deepEqual(JSON.parse(collectOpenClawTextContent(wrapped)), {});
+  assert.deepEqual(JSON.parse(collectOpenClawTextContentProxy(wrapped)), {});
 });
 
 test("ChatGPT subscription factory tools return OpenClaw JSON tool results", () => {

--- a/test/subscription_flow.test.mjs
+++ b/test/subscription_flow.test.mjs
@@ -261,12 +261,37 @@ test("link finalizer always strips the transport verification URL button from th
   ]) {
     const final = finalizeSubscriptionLinkReply(reply, outcome);
     assert.equal(final.channelData, undefined);
+    assert.equal(final.verification_url, undefined);
+    assert.ok(
+      !JSON.stringify(final).includes("UNIQUE-MARKER"),
+      "finalized tool payload must be safe to JSON-serialize for OpenClaw",
+    );
     // The raw URL must not appear in any agent_instructions line.
     assert.ok(
       !final.agent_instructions.some((l) => l.includes("UNIQUE-MARKER")),
       "verification URL must never appear in agent_instructions",
     );
   }
+});
+
+test("ChatGPT subscription factory tools return OpenClaw JSON tool results", () => {
+  const entrypoint = readFileSync(path.join(REPO_ROOT, "src/index.js"), "utf8");
+
+  assert.match(
+    entrypoint,
+    /return jsonToolResult\(\s*finalizeSubscriptionPrerequisiteHelpReply/s,
+    "prerequisite-help factory tool must not return a raw object",
+  );
+  assert.match(
+    entrypoint,
+    /return jsonToolResult\(buildSubscriptionLinkFailureReply\(err\)\)/,
+    "subscription-link failure path must include content[]",
+  );
+  assert.match(
+    entrypoint,
+    /return jsonToolResult\(\s*finalizeSubscriptionLinkReply/s,
+    "subscription-link success path must include content[]",
+  );
 });
 
 // ── Failure + revert builders ─────────────────────────────────────────

--- a/test/subscription_flow.test.mjs
+++ b/test/subscription_flow.test.mjs
@@ -21,6 +21,10 @@ import {
   finalizeSubscriptionLinkReply,
   finalizeSubscriptionPrerequisiteHelpReply,
 } from "../src/subscription_builders.js";
+import {
+  CHATGPT_LINK_POLL_TIMEOUT_MS,
+  startChatgptSubscriptionLink,
+} from "../src/subscriptions.js";
 import { jsonToolResult } from "../src/tool_results.js";
 
 const REPO_ROOT = path.resolve(
@@ -38,6 +42,58 @@ function collectOpenClawTextContent(result) {
     return chunks;
   }, []).join("\n");
 }
+
+// ── Platform/runtime polling budget ──────────────────────────────────
+
+test("chatgpt link default polling budget covers heartbeat plus retry latency", () => {
+  assert.ok(
+    CHATGPT_LINK_POLL_TIMEOUT_MS >= 90_000,
+    "chat-triggered link must wait through supervisor heartbeat skew and runtime retry",
+  );
+  assert.ok(
+    CHATGPT_LINK_POLL_TIMEOUT_MS > 15_000,
+    "regression guard: 15s timed out before real local Computers posted URL+code",
+  );
+});
+
+test("chatgpt link helper keeps polling until the supervisor posts URL and code", async () => {
+  const paths = [];
+  let statusCalls = 0;
+
+  const result = await startChatgptSubscriptionLink({
+    pollIntervalMs: 1,
+    pollTimeoutMs: 200,
+    callTinyhat: async (path) => {
+      paths.push(path);
+      if (path.endsWith("/subscription-link/start")) {
+        return { status: "pending", session_id: "session-1" };
+      }
+      assert.ok(path.endsWith("/subscription-link/status"));
+      statusCalls += 1;
+      if (statusCalls < 8) {
+        return {
+          status: "pending",
+          pending_session: { session_id: "session-1" },
+        };
+      }
+      return {
+        status: "pending",
+        pending_session: {
+          session_id: "session-1",
+          verification_url: "https://auth.openai.com/verify",
+          user_code: "ABCD-EFGHI",
+        },
+      };
+    },
+  });
+
+  assert.deepEqual(result, {
+    verificationUrl: "https://auth.openai.com/verify",
+    userCode: "ABCD-EFGHI",
+  });
+  assert.equal(paths[0], "/hapi/v1/computers/me/subscription-link/start");
+  assert.equal(statusCalls, 8);
+});
 
 // ── Base builders are NEUTRAL — they must never claim delivery ─────────
 // (Codex P1, #109: a `{ sent: false }` result must never leave a stale


### PR DESCRIPTION
## Summary

Fix `tinyhat_open_chatgpt_subscription_link` returning a raw object from factory-style OpenClaw tool handlers. The factory subscription tools now return MCP-style JSON tool results with `content[]`, preventing OpenClaw render/wrapper code from hitting `Cannot read properties of undefined (reading 'reduce')` when processing the ChatGPT subscription-link result.

The link finalizer also strips the raw `verification_url` before the result is serialized, keeping the OpenAI URL on the Telegram button transport path only.

## Linked Issue

N/A. This PR is the canonical fix for the reported live `tinyhat_open_chatgpt_subscription_link` failure.

## Type Of Change

- [ ] `feat` - new feature
- [x] `fix` - bug fix
- [ ] `docs` - documentation only
- [ ] `refactor` - no behavior change
- [ ] `test` - tests only
- [ ] `chore` / `ci` / `build` - tooling
- [ ] Breaking change

## Testing Performed

- [x] `git diff --check`
- [x] `python3 scripts/check_dev_skills.py`
- [x] `bash .github/scripts/check_packaging.sh`
- [x] `python3 scripts/validate_openclaw_package.py`
- [x] `python3 -m compileall -q scripts`
- [x] `node --check src/index.js`
- [x] `node --test test/*.test.mjs`
- [ ] `ruff check .` and `ruff format --check .`
- [ ] Manual OpenClaw plugin smoke test, if applicable

## Screenshots Or Logs

Focused regression check:

```text
node --test test/subscription_flow.test.mjs test/telegram_delivery.test.mjs
# tests 25
# pass 25
```

Full JS suite:

```text
node --test test/*.test.mjs
# tests 40
# pass 40
```

Package validation:

```text
python3 scripts/check_dev_skills.py
# dev-skills: ok (parent skill root not mounted; standalone mode)

python3 scripts/validate_openclaw_package.py
# openclaw-package: ok

bash .github/scripts/check_packaging.sh
# packaging-guard: ok
```

## Checklist

- [x] PR title is a Conventional Commit.
- [x] Linked to an issue or this PR is the canonical spec.
- [x] Docs updated where behavior changed.
- [x] Packaged skill changes follow `docs/skill-authoring.md`.
- [ ] CI is green.
- [x] No tenant secrets, signed Mini App URLs, private backend URLs, local-only paths, or internal docs are included.
- [x] I will not self-merge.

<details>
<summary>Agent checklist</summary>

- [x] Commits follow the repo bot-identity/signing rules in `AGENTS.md`.
- [x] Branch named with an agent or contributor prefix.

</details>
