### PR TITLE
fix(plugin): restore subscription command contract

### DIFF
--- a/scripts/validate_openclaw_package.py
+++ b/scripts/validate_openclaw_package.py
@@ -380,6 +380,7 @@ def validate_source(root: Path) -> None:
         "tinyhat_secrets_manage",
         "tinyhat_computer",
         "tinyhat_software",
+        "tinyhat_subscriptions",
         "tinyhat_terminal",
     ):
         require(f'name: "{command}"' in source, f"src/index.js missing command {command}")

--- a/src/index.js
+++ b/src/index.js
@@ -9,18 +9,11 @@ import {
   formatSoftwareUpdatesReply,
 } from "./presentation_helpers.js";
 import {
-  buildSubscriptionLinkFailureReply,
-  buildSubscriptionLinkReply,
-  buildSubscriptionPrerequisiteHelpReply,
-  buildSubscriptionRevertFailureReply,
-  buildSubscriptionRevertReply,
-  finalizeSubscriptionLinkReply,
-  finalizeSubscriptionPrerequisiteHelpReply,
-} from "./subscription_builders.js";
-import {
-  revertChatgptSubscriptionAuth,
-  startChatgptSubscriptionLink,
-} from "./subscriptions.js";
+  buildSubscriptionRevertCommandReply,
+  handleSubscriptionCommand,
+  sendSubscriptionPrerequisiteHelpReply,
+  startAndSendSubscriptionLinkReply,
+} from "./subscription_commands.js";
 import {
   buildComputerAuthFailureSupportGuidance,
   isMalformedComputerAuthError,
@@ -29,8 +22,6 @@ import {
 import {
   markTelegramDelivered,
   sendTelegramMiniAppButton,
-  sendTelegramPhoto,
-  sendTelegramText,
 } from "./telegram_delivery.js";
 import { jsonToolResult } from "./tool_results.js";
 
@@ -352,18 +343,12 @@ const plugin = defineToolPlugin({
         execute: async (_toolCallId, _params, signal) => {
           const runtime = resolveExecutionRuntime(config, { signal });
           runtime.signal?.throwIfAborted?.();
-          const reply = buildSubscriptionPrerequisiteHelpReply();
-          const photoDelivery = await sendTelegramPhoto({
-            api,
-            toolContext,
-            photoUrl: reply.channelData.telegram.photo_url,
-            caption: reply.channelData.telegram.photo_caption,
-            signal: runtime.signal,
-          });
-          // The finalizer is the only place delivery-state claims are
-          // made: success → "already sent"; failure → recovery guidance.
           return jsonToolResult(
-            finalizeSubscriptionPrerequisiteHelpReply(reply, photoDelivery),
+            await sendSubscriptionPrerequisiteHelpReply({
+              api,
+              toolContext,
+              signal: runtime.signal,
+            }),
           );
         },
       }),
@@ -391,47 +376,12 @@ const plugin = defineToolPlugin({
           // poll the backend for the URL+code result.
           const boundCall = (path, init, sig) =>
             callTinyhat(runtime.config, path, init, sig);
-          let session;
-          try {
-            session = await startChatgptSubscriptionLink({
+          return jsonToolResult(
+            await startAndSendSubscriptionLinkReply({
               callTinyhat: boundCall,
-              signal: runtime.signal,
-            });
-          } catch (err) {
-            return jsonToolResult(buildSubscriptionLinkFailureReply(err));
-          }
-          const reply = buildSubscriptionLinkReply(session);
-          // Send the URL-button intro first so the user sees the
-          // "Sign in to ChatGPT" tap target right after the prerequisite
-          // walkthrough.
-          const buttonDelivery = await sendTelegramMiniAppButton({
-            api,
-            toolContext,
-            reply,
-            text: reply.text,
-            signal: runtime.signal,
-          });
-          // Only attempt the bare-code bubble when the button reached the
-          // user — a lone code bubble with no verification button would
-          // just confuse them. The finalizer turns each outcome into an
-          // accurate reply (success → "already sent"; code-fail → tell the
-          // agent to paste the code; button-fail → tell the user to retry).
-          let codeDelivery = { sent: false, reason: "skipped_button_not_sent" };
-          if (buttonDelivery?.sent) {
-            // The device code lands as its own bare bubble — long-press →
-            // Copy on mobile then captures only the 9 characters (#108).
-            codeDelivery = await sendTelegramText({
               api,
               toolContext,
-              text:
-                reply.channelData?.telegram?.followup_text || session.userCode,
               signal: runtime.signal,
-            });
-          }
-          return jsonToolResult(
-            finalizeSubscriptionLinkReply(reply, {
-              buttonDelivery,
-              codeDelivery,
             }),
           );
         },
@@ -449,15 +399,10 @@ const plugin = defineToolPlugin({
         runtime.signal?.throwIfAborted?.();
         const boundCall = (path, init, sig) =>
           callTinyhat(runtime.config, path, init, sig);
-        try {
-          const result = await revertChatgptSubscriptionAuth({
-            callTinyhat: boundCall,
-            signal: runtime.signal,
-          });
-          return buildSubscriptionRevertReply(result);
-        } catch (err) {
-          return buildSubscriptionRevertFailureReply(err);
-        }
+        return buildSubscriptionRevertCommandReply({
+          callTinyhat: boundCall,
+          signal: runtime.signal,
+        });
       },
     }),
   ],
@@ -546,6 +491,29 @@ plugin.register = (api) => {
     handler: async () => {
       const payload = await fetchManageComputerLink(platformConfig);
       return formatSoftwareUpdatesReply(payload);
+    },
+  });
+
+  api.registerCommand({
+    name: "tinyhat_subscriptions",
+    nativeNames: { default: "tinyhat_subscriptions" },
+    description: "Connect ChatGPT subscription or revert to Tinyhat credits.",
+    channels: ["telegram"],
+    acceptsArgs: true,
+    agentPromptGuidance: [
+      "Use /tinyhat_subscriptions help, prerequisite, link, or revert for ChatGPT subscription flows.",
+    ],
+    handler: async (ctx) => {
+      const runtime = resolveExecutionRuntime(platformConfig, ctx);
+      runtime.signal?.throwIfAborted?.();
+      const boundCall = (path, init, signal) =>
+        callTinyhat(runtime.config, path, init, signal);
+      return handleSubscriptionCommand({
+        api,
+        ctx,
+        callTinyhat: boundCall,
+        signal: runtime.signal,
+      });
     },
   });
 

--- a/src/subscription_commands.js
+++ b/src/subscription_commands.js
@@ -1,0 +1,213 @@
+import {
+  buildSubscriptionLinkFailureReply,
+  buildSubscriptionLinkReply,
+  buildSubscriptionPrerequisiteHelpReply,
+  buildSubscriptionRevertFailureReply,
+  buildSubscriptionRevertReply,
+  finalizeSubscriptionLinkReply,
+  finalizeSubscriptionPrerequisiteHelpReply,
+} from "./subscription_builders.js";
+import {
+  revertChatgptSubscriptionAuth,
+  startChatgptSubscriptionLink,
+} from "./subscriptions.js";
+import {
+  sendTelegramMiniAppButton,
+  sendTelegramPhoto,
+  sendTelegramText,
+} from "./telegram_delivery.js";
+
+export async function sendSubscriptionPrerequisiteHelpReply({
+  api,
+  toolContext,
+  signal,
+  fetchImpl,
+}) {
+  const reply = buildSubscriptionPrerequisiteHelpReply();
+  const photoDelivery = await sendTelegramPhoto({
+    api,
+    toolContext,
+    photoUrl: reply.channelData.telegram.photo_url,
+    caption: reply.channelData.telegram.photo_caption,
+    signal,
+    fetchImpl,
+  });
+  // The finalizer is the only place delivery-state claims are made:
+  // success -> "already sent"; failure -> recovery guidance.
+  return finalizeSubscriptionPrerequisiteHelpReply(reply, photoDelivery);
+}
+
+export async function sendSubscriptionLinkReply({
+  api,
+  toolContext,
+  session,
+  signal,
+  fetchImpl,
+}) {
+  const reply = buildSubscriptionLinkReply(session);
+  // Send the URL-button intro first so the user sees the "Sign in to
+  // ChatGPT" tap target right after the prerequisite walkthrough.
+  const buttonDelivery = await sendTelegramMiniAppButton({
+    api,
+    toolContext,
+    reply,
+    text: reply.text,
+    signal,
+    fetchImpl,
+  });
+  // Only attempt the bare-code bubble when the button reached the user; a
+  // lone code bubble with no verification button would just confuse them.
+  let codeDelivery = { sent: false, reason: "skipped_button_not_sent" };
+  if (buttonDelivery?.sent) {
+    codeDelivery = await sendTelegramText({
+      api,
+      toolContext,
+      text: reply.channelData?.telegram?.followup_text || session.userCode,
+      signal,
+      fetchImpl,
+    });
+  }
+  return finalizeSubscriptionLinkReply(reply, {
+    buttonDelivery,
+    codeDelivery,
+  });
+}
+
+export async function startAndSendSubscriptionLinkReply({
+  callTinyhat,
+  api,
+  toolContext,
+  signal,
+  fetchImpl,
+}) {
+  try {
+    const session = await startChatgptSubscriptionLink({
+      callTinyhat,
+      signal,
+    });
+    return sendSubscriptionLinkReply({
+      api,
+      toolContext,
+      session,
+      signal,
+      fetchImpl,
+    });
+  } catch (err) {
+    return buildSubscriptionLinkFailureReply(err);
+  }
+}
+
+export async function buildSubscriptionRevertCommandReply({
+  callTinyhat,
+  signal,
+}) {
+  try {
+    return buildSubscriptionRevertReply(
+      await revertChatgptSubscriptionAuth({ callTinyhat, signal }),
+    );
+  } catch (err) {
+    return buildSubscriptionRevertFailureReply(err);
+  }
+}
+
+export async function handleSubscriptionCommand({
+  api,
+  ctx = {},
+  callTinyhat,
+  signal,
+  fetchImpl,
+}) {
+  const parsed = parseSubscriptionCommand(ctx.args || "");
+  if (parsed.action === "help") {
+    return { text: subscriptionCommandUsage().usage.join("\n") };
+  }
+  if (parsed.action === "prerequisite") {
+    return sendSubscriptionPrerequisiteHelpReply({
+      api,
+      toolContext: ctx,
+      signal,
+      fetchImpl,
+    });
+  }
+  if (parsed.action === "revert") {
+    return buildSubscriptionRevertCommandReply({ callTinyhat, signal });
+  }
+  return startAndSendSubscriptionLinkReply({
+    callTinyhat,
+    api,
+    toolContext: ctx,
+    signal,
+    fetchImpl,
+  });
+}
+
+export function parseSubscriptionCommand(raw) {
+  const text = normalizeString(raw).toLowerCase();
+  if (!text || ["help", "-h", "--help"].includes(text)) {
+    return { action: "help" };
+  }
+  const verb = text.split(/\s+/)[0];
+  if (
+    [
+      "before",
+      "enable",
+      "help",
+      "prereq",
+      "prerequisite",
+      "security",
+      "settings",
+      "setup",
+    ].includes(verb)
+  ) {
+    return { action: "prerequisite" };
+  }
+  if (
+    [
+      "back",
+      "credits",
+      "disconnect",
+      "platform",
+      "platform-credits",
+      "revert",
+      "stop",
+      "unlink",
+    ].includes(verb)
+  ) {
+    return { action: "revert" };
+  }
+  if (
+    [
+      "chatgpt",
+      "codex",
+      "connect",
+      "link",
+      "login",
+      "openai",
+      "signin",
+      "sign-in",
+      "start",
+      "subscription",
+    ].includes(verb)
+  ) {
+    return { action: "link" };
+  }
+  return { action: "help" };
+}
+
+export function subscriptionCommandUsage() {
+  return {
+    ok: false,
+    usage: [
+      "Tinyhat ChatGPT subscription:",
+      "/tinyhat_subscriptions prerequisite",
+      "/tinyhat_subscriptions link",
+      "/tinyhat_subscriptions revert",
+      "",
+      "Never share your ChatGPT password or OAuth token in chat.",
+    ],
+  };
+}
+
+function normalizeString(value) {
+  return String(value || "").trim();
+}

--- a/test/subscription_flow.test.mjs
+++ b/test/subscription_flow.test.mjs
@@ -25,6 +25,7 @@ import {
   CHATGPT_LINK_POLL_TIMEOUT_MS,
   startChatgptSubscriptionLink,
 } from "../src/subscriptions.js";
+import { handleSubscriptionCommand } from "../src/subscription_commands.js";
 import { jsonToolResult } from "../src/tool_results.js";
 
 const REPO_ROOT = path.resolve(
@@ -385,17 +386,12 @@ test("ChatGPT subscription factory tools return OpenClaw JSON tool results", () 
 
   assert.match(
     entrypoint,
-    /return jsonToolResult\(\s*finalizeSubscriptionPrerequisiteHelpReply/s,
+    /return jsonToolResult\(\s*await sendSubscriptionPrerequisiteHelpReply/s,
     "prerequisite-help factory tool must not return a raw object",
   );
   assert.match(
     entrypoint,
-    /return jsonToolResult\(buildSubscriptionLinkFailureReply\(err\)\)/,
-    "subscription-link failure path must include content[]",
-  );
-  assert.match(
-    entrypoint,
-    /return jsonToolResult\(\s*finalizeSubscriptionLinkReply/s,
+    /return jsonToolResult\(\s*await startAndSendSubscriptionLinkReply/s,
     "subscription-link success path must include content[]",
   );
 });
@@ -475,6 +471,86 @@ test("openclaw.plugin.json registers the new prerequisite-help tool + operation"
   );
   assert.ok(linkOp);
   assert.equal(linkOp.userSurface, "telegram_url_button_plus_bare_code_bubble");
+});
+
+test("subscription slash command stays registered for the platform contract", () => {
+  const entrypoint = readFileSync(path.join(REPO_ROOT, "src/index.js"), "utf8");
+
+  assert.match(entrypoint, /api\.registerCommand\(\{\s*name: "tinyhat_subscriptions"/s);
+  assert.match(entrypoint, /handleSubscriptionCommand\(\{/);
+  assert.match(entrypoint, /callTinyhat\(runtime\.config, path, init, signal\)/);
+});
+
+test("subscription slash command sends button plus code before returning finalized reply", async () => {
+  const platformPaths = [];
+  const telegramCalls = [];
+  const reply = await handleSubscriptionCommand({
+    api: {},
+    ctx: {
+      args: "link",
+      deliveryContext: {
+        channel: "telegram",
+        to: "telegram:101216939",
+        accountId: "default",
+      },
+      config: { channels: { telegram: { botToken: "123:token" } } },
+    },
+    callTinyhat: async (path, init) => {
+      platformPaths.push({ path, method: init?.method });
+      if (path.endsWith("/subscription-link/start")) {
+        return { status: "pending", session_id: "session-1" };
+      }
+      assert.ok(path.endsWith("/subscription-link/status"));
+      return {
+        status: "pending",
+        pending_session: {
+          session_id: "session-1",
+          verification_url: "https://auth.openai.com/command-test",
+          user_code: "SZ85-LWNTP",
+        },
+      };
+    },
+    fetchImpl: async (url, init) => {
+      const body = JSON.parse(init.body);
+      telegramCalls.push({ url, body });
+      return {
+        ok: true,
+        status: 200,
+        json: async () => ({
+          ok: true,
+          result: {
+            message_id: telegramCalls.length,
+            chat: { id: 101216939 },
+          },
+        }),
+      };
+    },
+  });
+
+  assert.deepEqual(platformPaths, [
+    { path: "/hapi/v1/computers/me/subscription-link/start", method: "POST" },
+    { path: "/hapi/v1/computers/me/subscription-link/status", method: "GET" },
+  ]);
+  assert.equal(telegramCalls.length, 2);
+  assert.equal(
+    telegramCalls[0].url,
+    "https://api.telegram.org/bot123:token/sendMessage",
+  );
+  assert.deepEqual(telegramCalls[0].body.reply_markup.inline_keyboard, [
+    [{ text: "Sign in to ChatGPT", url: "https://auth.openai.com/command-test" }],
+  ]);
+  assert.equal(telegramCalls[1].body.text, "SZ85-LWNTP");
+  assert.equal(telegramCalls[1].body.reply_markup, undefined);
+
+  assert.equal(reply.delivered, true);
+  assert.equal(reply.code_delivered, true);
+  assert.equal(reply.user_code, "SZ85-LWNTP");
+  assert.equal(reply.verification_url, undefined);
+  assert.equal(reply.channelData, undefined);
+  assert.ok(
+    !JSON.stringify(reply).includes("https://auth.openai.com/command-test"),
+    "command reply must not expose the raw verification URL after delivery",
+  );
 });
 
 test("subscription SKILL.md routes the prerequisite-help tool and documents the delivery markers", () => {


### PR DESCRIPTION
## Summary

- Adds the `tinyhat_subscriptions` Telegram command that the platform capability contract already advertises for ChatGPT subscription link/revert flows.
- Routes the command through the existing safe subscription helpers and platform APIs; it does not add any OpenClaw lifecycle control or OAuth-state handling.
- Extends plugin validation/tests so the command cannot drift out of the packaged plugin again.

## Verification

```text
node --check src/index.js
node --test
python3 scripts/validate_openclaw_package.py
python3 -m compileall -q scripts
```

Result: 73 Node tests passed; `openclaw-package: ok`; script compile clean.

## Notes

This fixes a cross-repo contract drift: the backend advertised `command_name: tinyhat_subscriptions`, while the plugin did not register that command. The related monorepo PR will add a cross-repo guard that checks backend `tool_name` values against `openclaw.plugin.json` and backend `command_name` values against plugin `api.registerCommand(...)` entries.
