### PR TITLE
feat(hermes): add private secret handoff

### DIFF
--- a/.agents/skills/tinyhat-plugin-skill-authoring/SKILL.md
+++ b/.agents/skills/tinyhat-plugin-skill-authoring/SKILL.md
@@ -1,0 +1,63 @@
+---
+name: tinyhat-plugin-skill-authoring
+description: Create, modify, or review Tinyhat plugin skills. Use when adding a Tinyhat capability, changing a SKILL.md file, changing plugin tool schemas, updating Hermes adapter metadata, or modifying secret/credential handoff behavior in the tinyhat-ai/tinyhat plugin repo.
+---
+
+# Tinyhat Plugin Skill Authoring
+
+Use this skill before changing any file under `skills/`, any plugin tool
+schema, or any Hermes adapter registration.
+
+## Standard
+
+- Keep the runtime boring. New user-facing capabilities belong in this
+  plugin plus versioned Tinyhat platform APIs, not in runtime code.
+- Make one skill do one clear user-visible job.
+- Put the exact trigger in frontmatter `description`; keep the body for
+  operational instructions.
+- Keep `SKILL.md` short. Move long references into `docs/` and link them.
+- Register framework-specific details in `plugin.yaml`, `hermes.plugin.json`,
+  and `__init__.py`; do not make skill text depend on Hermes-only internals.
+- Keep examples concrete and safe to copy.
+
+## Skill Change Checklist
+
+1. Add or update `skills/<skill-name>/SKILL.md`.
+2. Update tool schemas in `schemas.py` when the skill calls a tool.
+3. Update tool implementation in `tools.py` or a small focused module.
+4. Update `hermes.plugin.json`, `plugin.yaml`, and `__init__.py` when a
+   new tool, command, or skill becomes part of the public surface.
+5. Update `docs/skill-authoring.md`, `docs/capabilities.md`, and
+   `README.md` when behavior changes.
+6. Add or update unit tests in `test/`.
+7. Run:
+
+```bash
+python3 scripts/validate_framework_package.py
+python3 -m unittest discover -s test -p "*.py"
+python3 -m compileall -q .
+```
+
+## Secret Skills
+
+Secret and credential skills have stricter requirements:
+
+- Never ask the user to paste secret values in chat.
+- Never print, log, snapshot, or include secret values in test fixtures.
+- Use the browser-encrypted Mini App handoff for values.
+- Choose a meaningful env-style name from the user's wording:
+  `EXA_API_KEY`, `OPENROUTER_API_KEY`, `GITHUB_TOKEN`,
+  `STRIPE_SECRET_KEY`.
+- Reject or clarify generic names such as `TINYHAT_SECRET`, `SECRET`,
+  `API_KEY`, `TOKEN`, `PASSWORD`, or `CREDENTIAL`.
+- Keep the success message short and explicit that Tinyhat did not store
+  the plaintext.
+
+## Review Questions
+
+- Can a user understand what the skill does by reading its name and first
+  paragraph?
+- Can an agent choose the right tool inputs without guessing?
+- Does the tool reject unsafe or ambiguous inputs?
+- Are security claims true for both local and GCloud Computers?
+- Did tests cover the failure mode that caused this change?

--- a/.agents/skills/tinyhat-plugin-skill-authoring/agents/openai.yaml
+++ b/.agents/skills/tinyhat-plugin-skill-authoring/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Tinyhat Plugin Skill Authoring"
+  short_description: "Create and review Tinyhat plugin skills."
+  default_prompt: "Use this when adding or changing a Tinyhat plugin skill, tool schema, or Hermes adapter registration."

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,9 +20,10 @@ a fresh Hermes-only start.
 - `plugin.yaml`: Hermes manifest.
 - `__init__.py`: Hermes registration entrypoint.
 - `hermes.plugin.json`: Tinyhat adapter metadata.
-- `tools.py` and `schemas.py`: tiny public tool surface.
+- `tools.py`, `schemas.py`, `platform.py`, and `secret_handoff.py`: tiny public tool surface.
 - `skills/tinyhat-tell-joke/SKILL.md`: deterministic joke proof.
 - `skills/tinyhat-plugin-version/SKILL.md`: live plugin version proof.
+- `skills/tinyhat-private-secret/SKILL.md`: private Mini App secret handoff.
 
 ## Checks
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,6 +24,8 @@ a fresh Hermes-only start.
 - `skills/tinyhat-tell-joke/SKILL.md`: deterministic joke proof.
 - `skills/tinyhat-plugin-version/SKILL.md`: live plugin version proof.
 - `skills/tinyhat-private-secret/SKILL.md`: private Mini App secret handoff.
+- `.agents/skills/tinyhat-plugin-skill-authoring/SKILL.md`: maintainer
+  workflow for adding or changing plugin skills.
 
 ## Checks
 
@@ -34,6 +36,9 @@ python3 scripts/validate_framework_package.py
 python3 -m unittest discover -s test -p "*.py"
 python3 -m compileall -q .
 ```
+
+When adding or changing plugin skills, read
+`.agents/skills/tinyhat-plugin-skill-authoring/SKILL.md` first.
 
 ## Writing
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ All notable changes to the Tinyhat plugin are documented here.
 
 ### Changed
 
+- Teach the private secret skill and tool to use meaningful env-style names
+  such as `EXA_API_KEY` instead of generic placeholders like
+  `TINYHAT_SECRET`.
+- Add a repo-local Tinyhat plugin skill-authoring skill and expand the
+  public skill standard for future plugin capabilities.
 - Bump the fresh Hermes plugin package to `0.20.3` so managed Computers can
   verify the Tinyhat plugin update flow from `0.20.2`.
 - Start the v0.20 Tinyhat plugin branch as a fresh Hermes-only package.

--- a/README.md
+++ b/README.md
@@ -9,11 +9,11 @@ the part that can evolve faster. It adds the agent-facing skills and tools
 that explain how to use Tinyhat platform capabilities without exposing
 private platform URLs, machine credentials, bot tokens, or tenant data.
 
-For the first v0.20 version, this repo is deliberately tiny. It supports
-Hermes only, and it ships two proof skills: a small joke command used to
-prove that the plugin is installed and discoverable from a real agent
-chat, and a version command used to prove which plugin code Hermes is
-actually running.
+For the first v0.20 version, this repo is deliberately small. It supports
+Hermes only, ships two proof skills, and now includes the first real
+Tinyhat platform capability: a private secret handoff that lets the user
+enter a secret in a Telegram Mini App without sending the plaintext to
+Tinyhat's servers.
 
 ## What This Plugin Does
 
@@ -22,9 +22,10 @@ actually running.
 | `plugin.yaml` | Hermes plugin manifest. |
 | `__init__.py` | Hermes registration entrypoint. |
 | `hermes.plugin.json` | Tinyhat metadata for the Hermes adapter, skill, command, and release channels. |
-| `tools.py` / `schemas.py` | The first tiny tools: `tinyhat_tell_joke` and `tinyhat_plugin_version`. |
+| `tools.py` / `schemas.py` | Tinyhat tools: plugin version, joke proof, and private secret handoff. |
 | `skills/tinyhat-tell-joke/SKILL.md` | Deterministic joke proof. |
 | `skills/tinyhat-plugin-version/SKILL.md` | Live plugin version proof. |
+| `skills/tinyhat-private-secret/SKILL.md` | Browser-encrypted secret handoff guidance. |
 | `docs/skill-authoring.md` | The standard for future Tinyhat skills. |
 | `RELEASING.md` | How releases and `channels/lts` / `channels/latest` work. |
 
@@ -50,7 +51,7 @@ That separation matters:
 - Users can inspect which skills and tools are being installed.
 - Privileged actions can stay behind platform APIs and Telegram buttons.
 
-## Current Skill
+## Current Skills
 
 `tinyhat-tell-joke` is a wiring proof. When the user asks whether the
 Tinyhat plugin is available, or asks for a joke, the agent can call
@@ -61,6 +62,14 @@ whole installation path before adding real platform capabilities.
 Tinyhat plugin version is running, the agent can call
 `tinyhat_plugin_version`. The answer comes from the plugin code loaded by
 Hermes, not from admin metadata or a GitHub branch name.
+
+`tinyhat-private-secret` is the first real capability. When the user asks
+to save an API key, token, password, or credential, the agent calls
+`tinyhat_private_secret_handoff`. The Computer creates a one-time key
+pair, the user enters the value in a Telegram Mini App, the browser
+encrypts the value with the public key, and the Computer decrypts it with
+the temporary private key. Tinyhat stores only short-lived ciphertext for
+the handoff and wipes it after completion, expiration, or failure.
 
 ## Installing
 
@@ -82,7 +91,7 @@ For development or manual testing, use `channels/latest` or an exact tag:
 
 ```bash
 TINYHAT_PLUGIN_REF=channels/latest
-TINYHAT_PLUGIN_REF=v0.20.3
+TINYHAT_PLUGIN_REF=v0.20.4
 ```
 
 ## Channels
@@ -107,9 +116,6 @@ python3 -m compileall -q .
 
 ## Roadmap
 
-The next skills will teach agents how to use Tinyhat platform
-capabilities through attested APIs. Examples include opening safe
-Telegram buttons for secrets, showing Computer status, and reporting
-support diagnostics. Those will be added one skill at a time, with the
-same goal as this first branch: small, inspectable files that make the
-agent more capable without hiding what is happening.
+The next skills will continue this pattern: small, inspectable plugin
+tools that call versioned Tinyhat platform APIs through the Computer's
+attested identity. Runtime code should stay boring and stable.

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ Tinyhat's servers.
 | `skills/tinyhat-plugin-version/SKILL.md` | Live plugin version proof. |
 | `skills/tinyhat-private-secret/SKILL.md` | Browser-encrypted secret handoff guidance. |
 | `docs/skill-authoring.md` | The standard for future Tinyhat skills. |
+| `.agents/skills/tinyhat-plugin-skill-authoring/SKILL.md` | Maintainer workflow for adding or changing plugin skills. |
 | `RELEASING.md` | How releases and `channels/lts` / `channels/latest` work. |
 
 There is no legacy framework adapter in this branch. Additional framework

--- a/__init__.py
+++ b/__init__.py
@@ -59,18 +59,21 @@ def register(ctx: Any) -> None:
         schema=schemas.TINYHAT_PRIVATE_SECRET_HANDOFF_SCHEMA,
         handler=tools.private_secret_handoff,
     )
+    # Hermes registers plugin slash commands by their canonical names, then
+    # Telegram shows them with underscores and maps inbound underscores back to
+    # hyphens before dispatch.
     ctx.register_command(
-        "tinyhat_joke",
+        "tinyhat-joke",
         _joke_command_handler,
         description="Tell a short Tinyhat plugin wiring-test joke.",
     )
     ctx.register_command(
-        "tinyhat_plugin_version",
+        "tinyhat-plugin-version",
         _plugin_version_command_handler,
         description="Show the Tinyhat plugin version currently loaded in Hermes.",
     )
     ctx.register_command(
-        "tinyhat_secret",
+        "tinyhat-secret",
         _private_secret_command_handler,
         description="Start a secure Tinyhat Mini App handoff for a secret.",
     )

--- a/__init__.py
+++ b/__init__.py
@@ -60,21 +60,18 @@ def register(ctx: Any) -> None:
         handler=tools.private_secret_handoff,
     )
     ctx.register_command(
-        name="tinyhat_joke",
-        handler=_joke_command_handler,
+        "tinyhat_joke",
+        _joke_command_handler,
         description="Tell a short Tinyhat plugin wiring-test joke.",
-        args_hint="[topic]",
     )
     ctx.register_command(
-        name="tinyhat_plugin_version",
-        handler=_plugin_version_command_handler,
+        "tinyhat_plugin_version",
+        _plugin_version_command_handler,
         description="Show the Tinyhat plugin version currently loaded in Hermes.",
-        args_hint="",
     )
     ctx.register_command(
-        name="tinyhat_secret",
-        handler=_private_secret_command_handler,
+        "tinyhat_secret",
+        _private_secret_command_handler,
         description="Start a secure Tinyhat Mini App handoff for a secret.",
-        args_hint="SECRET_NAME [description]",
     )
     _register_skills(ctx)

--- a/__init__.py
+++ b/__init__.py
@@ -19,6 +19,15 @@ def _plugin_version_command_handler(raw_args: str = "") -> str:
     return f"Tinyhat plugin {payload['version']} is loaded in Hermes."
 
 
+def _private_secret_command_handler(raw_args: str = "") -> str:
+    parts = raw_args.strip().split(maxsplit=1)
+    name = parts[0].strip() if parts else "TINYHAT_SECRET"
+    description = parts[1].strip() if len(parts) > 1 else None
+    return tools.private_secret_handoff(
+        {"name": name, "description": description},
+    )
+
+
 def _register_skills(ctx: Any) -> list[str]:
     skills_dir = Path(__file__).parent / "skills"
     registered: list[str] = []
@@ -44,6 +53,12 @@ def register(ctx: Any) -> None:
         schema=schemas.TINYHAT_TELL_JOKE_SCHEMA,
         handler=tools.tell_joke,
     )
+    ctx.register_tool(
+        name="tinyhat_private_secret_handoff",
+        toolset="tinyhat",
+        schema=schemas.TINYHAT_PRIVATE_SECRET_HANDOFF_SCHEMA,
+        handler=tools.private_secret_handoff,
+    )
     ctx.register_command(
         name="tinyhat_joke",
         handler=_joke_command_handler,
@@ -55,5 +70,11 @@ def register(ctx: Any) -> None:
         handler=_plugin_version_command_handler,
         description="Show the Tinyhat plugin version currently loaded in Hermes.",
         args_hint="",
+    )
+    ctx.register_command(
+        name="tinyhat_secret",
+        handler=_private_secret_command_handler,
+        description="Start a secure Tinyhat Mini App handoff for a secret.",
+        args_hint="SECRET_NAME [description]",
     )
     _register_skills(ctx)

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -45,3 +45,17 @@ become the platform or the runtime.
 Future skills will call named platform capabilities through the
 Computer's attested identity. They should not paste raw backend URLs or
 ask users for secrets in chat.
+
+## Secret Handoff Pattern
+
+The plugin can start a private secret handoff without expanding the
+runtime. The platform exposes a versioned handoff API. The Computer calls
+that API with its attested identity, the plugin skill gives the user a
+Telegram Mini App button, and the browser encrypts the secret value before
+it reaches Tinyhat.
+
+This pattern keeps responsibilities narrow:
+
+- the platform owns authorization and stores short-lived ciphertext;
+- the plugin owns the agent-facing instruction and tool;
+- the runtime stays focused on identity, heartbeat, and installation.

--- a/docs/capabilities.md
+++ b/docs/capabilities.md
@@ -6,10 +6,21 @@ The current capability list is intentionally small.
 | --- | --- | --- |
 | `tinyhat_plugin_version` | Available now | Proves which Tinyhat plugin version Hermes has loaded for the live agent. |
 | `tinyhat_tell_joke` | Available now | Proves Hermes loaded the Tinyhat plugin and can call a plugin tool. |
+| `tinyhat_private_secret_handoff` | Available now | Lets a user enter a secret in a Telegram Mini App while Tinyhat stores only short-lived ciphertext. |
 
-The next capabilities will be added one at a time. Each one should be
-visible in this document, represented by a small tool or skill, and
-covered by validation.
+Each capability should be visible in this document, represented by a small
+tool or skill, and covered by validation.
+
+## Private Secret Handoff
+
+This capability is used when the user wants to save an API key, token,
+password, or credential for their agent.
+
+The agent must not ask for the secret in chat. Instead, it calls
+`tinyhat_private_secret_handoff`. The Computer creates a temporary key
+pair, the Mini App encrypts the entered value with the public key, and the
+Computer decrypts the submitted ciphertext with the temporary private key.
+Tinyhat stores only ciphertext during the short handoff window.
 
 ## Capability Rules
 
@@ -19,3 +30,5 @@ covered by validation.
   Computer identity provided by the runtime.
 - Secrets, signed URLs, and private platform endpoints must not be
   printed into chat.
+- Secret values must be entered in dedicated user-facing flows, not chat
+  messages or skill instructions.

--- a/docs/skill-authoring.md
+++ b/docs/skill-authoring.md
@@ -23,12 +23,48 @@ description: Tell a short Tinyhat wiring-test joke when the user asks for proof 
 ## Rules
 
 - One skill should do one clear job.
-- Use names that describe the user intent.
-- Keep the body short and operational.
+- Use names that describe the user intent and the capability outcome.
+- Keep the body short and operational. Put long examples or references in
+  linked docs instead of loading them into every agent run.
+- Make the frontmatter `description` specific enough to trigger only for
+  the intended user request.
+- Define any tool inputs with strict schemas and examples that match real
+  user wording.
 - Put framework-specific loading in adapter files, not in skill text.
 - Do not include private platform URLs, tenant data, tokens, or local
   machine paths.
 - Do not ask the user to paste secret values in chat.
+- For credentials, require meaningful env-style names. Use
+  `EXA_API_KEY`, `GITHUB_TOKEN`, or `STRIPE_SECRET_KEY`; never use
+  `TINYHAT_SECRET`, `SECRET`, `API_KEY`, or `TOKEN`.
+- Add or update tests when changing a skill's tool contract, naming
+  behavior, security wording, or framework adapter registration.
+
+## Skill Checklist
+
+- The skill has one user-visible job.
+- The trigger description names the exact user intent that should load it.
+- The first steps tell the agent what to do, not why skills exist.
+- Examples are concrete and safe to copy.
+- Tool schemas reject dangerous or generic inputs.
+- User-facing messages are short and put the main action first.
+- Security claims match the real platform and runtime behavior.
+- README, capabilities docs, tests, and adapter metadata stay in sync.
+
+## Secret Naming Standard
+
+When a skill creates or asks for a credential, choose a name that the
+user can recognize later without seeing the value.
+
+| Request | Correct name | Avoid |
+| --- | --- | --- |
+| "Save my Exa API key" | `EXA_API_KEY` | `TINYHAT_SECRET` |
+| "Connect my GitHub token" | `GITHUB_TOKEN` | `TOKEN` |
+| "Add a Stripe secret key" | `STRIPE_SECRET_KEY` | `API_KEY` |
+| "Save the OpenRouter key" | `OPENROUTER_API_KEY` | `SECRET` |
+
+If the provider or purpose is ambiguous, ask one short clarification
+question before creating the handoff.
 
 ## Current Skills
 

--- a/hermes.plugin.json
+++ b/hermes.plugin.json
@@ -1,6 +1,6 @@
 {
   "schema": "tinyhat.framework-adapter.v1",
-  "version": "0.20.3",
+  "version": "0.20.4",
   "framework": {
     "name": "hermes",
     "minimum": "0.0.0"
@@ -20,6 +20,11 @@
       "name": "tinyhat-tell-joke",
       "path": "skills/tinyhat-tell-joke/SKILL.md",
       "purpose": "Simple wiring proof that a Hermes agent can discover Tinyhat plugin skills."
+    },
+    {
+      "name": "tinyhat-private-secret",
+      "path": "skills/tinyhat-private-secret/SKILL.md",
+      "purpose": "Starts a private browser-encrypted secret handoff to the assigned Computer."
     }
   ],
   "tools": [
@@ -32,6 +37,11 @@
       "name": "tinyhat_tell_joke",
       "handler": "tools.tell_joke",
       "skill": "tinyhat-tell-joke"
+    },
+    {
+      "name": "tinyhat_private_secret_handoff",
+      "handler": "tools.private_secret_handoff",
+      "skill": "tinyhat-private-secret"
     }
   ],
   "commands": [
@@ -44,6 +54,11 @@
       "name": "tinyhat_plugin_version",
       "tool": "tinyhat_plugin_version",
       "purpose": "Human-visible proof of the Tinyhat plugin version loaded by Hermes."
+    },
+    {
+      "name": "tinyhat_secret",
+      "tool": "tinyhat_private_secret_handoff",
+      "purpose": "Human-visible test path for creating a private secret handoff."
     }
   ],
   "release": {

--- a/hermes.plugin.json
+++ b/hermes.plugin.json
@@ -46,17 +46,17 @@
   ],
   "commands": [
     {
-      "name": "tinyhat_joke",
+      "name": "tinyhat-joke",
       "tool": "tinyhat_tell_joke",
       "purpose": "Human-visible slash-command smoke test for plugin loading."
     },
     {
-      "name": "tinyhat_plugin_version",
+      "name": "tinyhat-plugin-version",
       "tool": "tinyhat_plugin_version",
       "purpose": "Human-visible proof of the Tinyhat plugin version loaded by Hermes."
     },
     {
-      "name": "tinyhat_secret",
+      "name": "tinyhat-secret",
       "tool": "tinyhat_private_secret_handoff",
       "purpose": "Human-visible test path for creating a private secret handoff."
     }

--- a/package.json
+++ b/package.json
@@ -1,12 +1,14 @@
 {
   "name": "tinyhat",
-  "version": "0.20.3",
+  "version": "0.20.4",
   "description": "Hermes plugin that teaches agents how to use Tinyhat platform capabilities.",
   "private": true,
   "files": [
     "plugin.yaml",
     "hermes.plugin.json",
     "__init__.py",
+    "platform.py",
+    "secret_handoff.py",
     "schemas.py",
     "tools.py",
     "skills",

--- a/platform.py
+++ b/platform.py
@@ -1,0 +1,195 @@
+"""Tinyhat platform client for plugin capabilities.
+
+The runtime provides the Computer identity and environment. Plugin tools use
+that identity to call versioned platform APIs, but they do not mint tokens or
+carry private platform URLs in skills.
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+import os
+import shlex
+import time
+from pathlib import Path
+from typing import Any
+from urllib import error, parse, request
+
+DEFAULT_ENV_FILES = (
+    Path("/opt/tinyhat-hermes-runtime/env/runtime.env"),
+    Path("/etc/tinyhat/hermes-runtime.env"),
+)
+
+
+class PlatformError(RuntimeError):
+    """The Tinyhat platform request failed."""
+
+
+class CachedGoogleIdentityToken:
+    """Fetch and cache the VM identity token used for platform calls."""
+
+    def __init__(self, *, audience: str, timeout_seconds: int = 5) -> None:
+        self.audience = audience.rstrip("/")
+        self.timeout_seconds = timeout_seconds
+        self._token: str | None = None
+        self._expires_at = 0
+
+    def __call__(self) -> str:
+        now = int(time.time())
+        if self._token and self._expires_at - 60 > now:
+            return self._token
+        token = self._fetch()
+        self._token = token
+        self._expires_at = _jwt_exp(token) or (now + 300)
+        return token
+
+    def _fetch(self) -> str:
+        query = parse.urlencode({"audience": self.audience, "format": "full"})
+        req = request.Request(
+            "http://metadata.google.internal/computeMetadata/v1/instance/"
+            f"service-accounts/default/identity?{query}",
+            headers={"Metadata-Flavor": "Google"},
+            method="GET",
+        )
+        try:
+            with request.urlopen(req, timeout=self.timeout_seconds) as response:
+                return response.read().decode("utf-8").strip()
+        except error.URLError as exc:
+            raise PlatformError(
+                f"failed to fetch Google identity token: {exc.reason}"
+            ) from exc
+
+
+class PlatformClient:
+    def __init__(
+        self,
+        *,
+        base_url: str,
+        token: str | None = None,
+        token_provider: Any | None = None,
+        timeout_seconds: int = 20,
+    ) -> None:
+        self.base_url = base_url.rstrip("/")
+        self.token = token
+        self.token_provider = token_provider
+        self.timeout_seconds = timeout_seconds
+
+    def get_json(self, path: str) -> dict[str, Any]:
+        return self._request_json("GET", path, None)
+
+    def post_json(self, path: str, payload: dict[str, Any]) -> dict[str, Any]:
+        return self._request_json("POST", path, payload)
+
+    def _request_json(
+        self,
+        method: str,
+        path: str,
+        payload: dict[str, Any] | None,
+    ) -> dict[str, Any]:
+        token = self.token_provider() if self.token_provider else self.token
+        if not token:
+            raise PlatformError("missing platform authentication token")
+        headers = {
+            "Accept": "application/json",
+            "Authorization": f"Bearer {token}",
+            "Content-Type": "application/json",
+            "User-Agent": "tinyhat-plugin/0.20",
+        }
+        body = (
+            json.dumps(payload, separators=(",", ":")).encode("utf-8")
+            if payload is not None
+            else None
+        )
+        req = request.Request(
+            f"{self.base_url}{path}",
+            data=body,
+            headers=headers,
+            method=method,
+        )
+        try:
+            with request.urlopen(req, timeout=self.timeout_seconds) as response:
+                raw = response.read()
+        except error.HTTPError as exc:
+            detail = exc.read().decode("utf-8", errors="replace")
+            raise PlatformError(
+                f"{method} {path} failed with HTTP {exc.code}: {detail}"
+            ) from exc
+        except error.URLError as exc:
+            raise PlatformError(f"{method} {path} failed: {exc.reason}") from exc
+        if not raw:
+            return {}
+        try:
+            decoded = json.loads(raw.decode("utf-8"))
+        except json.JSONDecodeError as exc:
+            raise PlatformError(f"{method} {path} returned invalid JSON") from exc
+        if not isinstance(decoded, dict):
+            raise PlatformError(f"{method} {path} returned non-object JSON")
+        return decoded
+
+
+def build_platform_client(env: dict[str, str] | None = None) -> tuple[PlatformClient, str]:
+    values = runtime_env(env)
+    base_url = values.get("TINYHAT_PLATFORM_URL", "").strip()
+    if not base_url:
+        raise PlatformError("TINYHAT_PLATFORM_URL is not configured")
+    local_token = values.get("TINYHAT_LOCAL_DEV_TOKEN", "").strip()
+    if local_token:
+        return PlatformClient(base_url=base_url, token=local_token), "local_dev"
+    audience = values.get("TINYHAT_COMPUTER_TOKEN_AUDIENCE", "").strip() or base_url
+    return (
+        PlatformClient(
+            base_url=base_url,
+            token_provider=CachedGoogleIdentityToken(audience=audience),
+        ),
+        "gcloud",
+    )
+
+
+def computer_api_path(platform_auth: str, suffix: str) -> str:
+    clean_suffix = suffix.lstrip("/")
+    if platform_auth == "gcloud":
+        return f"/hapi/v1/computers/me/{clean_suffix}"
+    return f"/hapi/v1/computers/local-dev/{clean_suffix}"
+
+
+def runtime_env(env: dict[str, str] | None = None) -> dict[str, str]:
+    values: dict[str, str] = {}
+    for path in DEFAULT_ENV_FILES:
+        values.update(_read_env_file(path))
+    values.update(os.environ if env is None else env)
+    return values
+
+
+def _read_env_file(path: Path) -> dict[str, str]:
+    if not path.is_file():
+        return {}
+    values: dict[str, str] = {}
+    for raw_line in path.read_text(encoding="utf-8", errors="replace").splitlines():
+        line = raw_line.strip()
+        if not line or line.startswith("#") or "=" not in line:
+            continue
+        key, _, raw_value = line.partition("=")
+        key = key.strip()
+        if not key:
+            continue
+        try:
+            parts = shlex.split(raw_value, posix=True)
+            value = parts[0] if parts else ""
+        except ValueError:
+            value = raw_value.strip().strip("'\"")
+        values[key] = value
+    return values
+
+
+def _jwt_exp(token: str) -> int | None:
+    parts = token.split(".")
+    if len(parts) < 2:
+        return None
+    payload = parts[1] + "=" * (-len(parts[1]) % 4)
+    try:
+        decoded = json.loads(base64.urlsafe_b64decode(payload.encode("ascii")))
+    except (ValueError, json.JSONDecodeError):
+        return None
+    exp = decoded.get("exp") if isinstance(decoded, dict) else None
+    return int(exp) if isinstance(exp, int) else None

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -1,8 +1,9 @@
 name: tinyhat
-version: 0.20.3
+version: 0.20.4
 description: Framework-neutral Tinyhat platform skills and tools.
 kind: plugin
 author: Tinyloop
 provides_tools:
   - tinyhat_plugin_version
   - tinyhat_tell_joke
+  - tinyhat_private_secret_handoff

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -1,7 +1,7 @@
 name: tinyhat
 version: 0.20.4
 description: Framework-neutral Tinyhat platform skills and tools.
-kind: plugin
+kind: standalone
 author: Tinyloop
 provides_tools:
   - tinyhat_plugin_version

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "tinyhat"
-version = "0.20.3"
+version = "0.20.4"
 description = "Hermes plugin that teaches agents how to use Tinyhat platform capabilities."
 readme = "README.md"
 requires-python = ">=3.9"

--- a/schemas.py
+++ b/schemas.py
@@ -22,7 +22,11 @@ TINYHAT_PRIVATE_SECRET_HANDOFF_SCHEMA = {
     "properties": {
         "name": {
             "type": "string",
-            "description": "Env-style secret name, for example OPENROUTER_API_KEY.",
+            "description": (
+                "Specific env-style secret name chosen from the user request, "
+                "for example EXA_API_KEY for an Exa API key. Never use "
+                "generic placeholders such as TINYHAT_SECRET, SECRET, API_KEY, or TOKEN."
+            ),
         },
         "description": {
             "type": "string",

--- a/schemas.py
+++ b/schemas.py
@@ -16,3 +16,25 @@ TINYHAT_TELL_JOKE_SCHEMA = {
     },
     "additionalProperties": False,
 }
+
+TINYHAT_PRIVATE_SECRET_HANDOFF_SCHEMA = {
+    "type": "object",
+    "properties": {
+        "name": {
+            "type": "string",
+            "description": "Env-style secret name, for example OPENROUTER_API_KEY.",
+        },
+        "description": {
+            "type": "string",
+            "description": "Short human reminder for what this secret is used for.",
+        },
+        "expires_in_seconds": {
+            "type": "integer",
+            "description": "Optional handoff timeout. Defaults to 300 seconds.",
+            "minimum": 60,
+            "maximum": 600,
+        },
+    },
+    "required": ["name"],
+    "additionalProperties": False,
+}

--- a/scripts/validate_framework_package.py
+++ b/scripts/validate_framework_package.py
@@ -10,9 +10,21 @@ from pathlib import Path
 
 
 VERSION_SHAPE = re.compile(r"^\d+\.\d+\.\d+$")
-REQUIRED_TOOLS = ["tinyhat_plugin_version", "tinyhat_tell_joke"]
-REQUIRED_COMMANDS = ["tinyhat_joke", "tinyhat_plugin_version"]
-REQUIRED_SKILLS = ["tinyhat-plugin-version", "tinyhat-tell-joke"]
+REQUIRED_TOOLS = [
+    "tinyhat_plugin_version",
+    "tinyhat_tell_joke",
+    "tinyhat_private_secret_handoff",
+]
+REQUIRED_COMMANDS = [
+    "tinyhat_joke",
+    "tinyhat_plugin_version",
+    "tinyhat_secret",
+]
+REQUIRED_SKILLS = [
+    "tinyhat-plugin-version",
+    "tinyhat-tell-joke",
+    "tinyhat-private-secret",
+]
 FORBIDDEN_PATHS = (
     "openclaw.plugin.json",
     "src",
@@ -23,7 +35,6 @@ FORBIDDEN_PATHS = (
 FORBIDDEN_TEXT = (
     "CLAUDE_PLUGIN_DATA",
     "ChatGPT subscription",
-    "Mini App URL",
 )
 
 
@@ -103,7 +114,15 @@ def validate_hermes_adapter(root: Path) -> None:
     require(isinstance(framework, dict), "framework must be an object")
     require(framework.get("name") == "hermes", "framework.name must be hermes")
 
-    for rel in ("plugin.yaml", "hermes.plugin.json", "__init__.py", "schemas.py", "tools.py"):
+    for rel in (
+        "plugin.yaml",
+        "hermes.plugin.json",
+        "__init__.py",
+        "schemas.py",
+        "tools.py",
+        "platform.py",
+        "secret_handoff.py",
+    ):
         require((root / rel).is_file(), f"{rel} is missing")
 
     entrypoint = hermes.get("entrypoint")
@@ -116,7 +135,7 @@ def validate_hermes_adapter(root: Path) -> None:
     require(isinstance(provided_tools, list), "plugin.yaml provides_tools must be a list")
     require(
         provided_tools == REQUIRED_TOOLS,
-        "plugin.yaml must provide only the Tinyhat proof tools",
+        "plugin.yaml provided tools drift",
     )
 
     source = (root / "__init__.py").read_text(encoding="utf-8")
@@ -130,6 +149,7 @@ def validate_hermes_adapter(root: Path) -> None:
     expected_skill_paths = {
         "tinyhat-plugin-version": "skills/tinyhat-plugin-version/SKILL.md",
         "tinyhat-tell-joke": "skills/tinyhat-tell-joke/SKILL.md",
+        "tinyhat-private-secret": "skills/tinyhat-private-secret/SKILL.md",
     }
     for skill in skills:
         require(isinstance(skill, dict), "skill declaration must be an object")
@@ -159,7 +179,10 @@ def validate_fresh_surface(root: Path) -> None:
         require(not (root / rel).exists(), f"{rel} must not exist in this fresh Hermes branch")
 
     skill_dirs = sorted(path.name for path in (root / "skills").iterdir() if path.is_dir())
-    require(skill_dirs == REQUIRED_SKILLS, "only Tinyhat proof skills may exist under skills/")
+    require(
+        skill_dirs == sorted(REQUIRED_SKILLS),
+        "skills directory does not match the Tinyhat public capability set",
+    )
 
     checked_roots = [
         root / "README.md",
@@ -172,6 +195,8 @@ def validate_fresh_surface(root: Path) -> None:
         root / "plugin.yaml",
         root / "hermes.plugin.json",
         root / "__init__.py",
+        root / "platform.py",
+        root / "secret_handoff.py",
         root / "schemas.py",
         root / "tools.py",
     ]
@@ -195,6 +220,7 @@ def validate_docs(root: Path) -> None:
             "Hermes only",
             "tinyhat-tell-joke",
             "tinyhat-plugin-version",
+            "tinyhat-private-secret",
             "channels/lts",
             "channels/latest",
         ),

--- a/scripts/validate_framework_package.py
+++ b/scripts/validate_framework_package.py
@@ -94,6 +94,10 @@ def validate_versions(root: Path) -> str:
     package = read_json(root / "package.json")
     hermes = read_json(root / "hermes.plugin.json")
     yaml_data = read_plugin_yaml(root)
+    require(
+        yaml_data.get("kind") == "standalone",
+        "plugin.yaml kind must be standalone for Hermes",
+    )
     version = package.get("version")
     require(isinstance(version, str), "package.json version must be a string")
     require(VERSION_SHAPE.fullmatch(version) is not None, "version must be shaped X.Y.Z")

--- a/scripts/validate_framework_package.py
+++ b/scripts/validate_framework_package.py
@@ -16,9 +16,9 @@ REQUIRED_TOOLS = [
     "tinyhat_private_secret_handoff",
 ]
 REQUIRED_COMMANDS = [
-    "tinyhat_joke",
-    "tinyhat_plugin_version",
-    "tinyhat_secret",
+    "tinyhat-joke",
+    "tinyhat-plugin-version",
+    "tinyhat-secret",
 ]
 REQUIRED_SKILLS = [
     "tinyhat-plugin-version",

--- a/scripts/validate_framework_package.py
+++ b/scripts/validate_framework_package.py
@@ -28,7 +28,6 @@ REQUIRED_SKILLS = [
 FORBIDDEN_PATHS = (
     "openclaw.plugin.json",
     "src",
-    ".agents",
     ".claude",
     "roadmap",
 )
@@ -194,6 +193,7 @@ def validate_fresh_surface(root: Path) -> None:
         root / "CONTRIBUTING.md",
         root / "RELEASING.md",
         root / "docs",
+        root / ".agents",
         root / "skills",
         root / "test",
         root / "plugin.yaml",
@@ -231,6 +231,11 @@ def validate_docs(root: Path) -> None:
         "docs/skill-authoring.md": (
             "Tinyhat skills are public instructions",
             "Do not ask the user to paste secret values in chat.",
+            "Secret Naming Standard",
+        ),
+        ".agents/skills/tinyhat-plugin-skill-authoring/SKILL.md": (
+            "Create, modify, or review Tinyhat plugin skills.",
+            "Reject or clarify generic names",
         ),
         "RELEASING.md": (
             "channels/lts",

--- a/secret_handoff.py
+++ b/secret_handoff.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import base64
-import json
 import re
 import shutil
 import subprocess
@@ -20,6 +19,36 @@ KEY_ALGORITHM = "RSA-OAEP-256"
 DEFAULT_EXPIRES_IN_SECONDS = 300
 SECRET_NAME_RE = re.compile(r"^[A-Z_][A-Z0-9_]{0,126}$")
 _WORKERS: set[threading.Thread] = set()
+GENERIC_SECRET_NAMES = {
+    "TINYHAT_SECRET",
+    "SECRET",
+    "API_KEY",
+    "TOKEN",
+    "PASSWORD",
+    "CREDENTIAL",
+    "WEBHOOK_SECRET",
+}
+SECRET_NAME_HINTS: tuple[tuple[tuple[str, ...], str], ...] = (
+    (("exa", "exa.ai"), "EXA_API_KEY"),
+    (("openrouter", "open router"), "OPENROUTER_API_KEY"),
+    (("openai", "chatgpt"), "OPENAI_API_KEY"),
+    (("anthropic", "claude"), "ANTHROPIC_API_KEY"),
+    (("github", "git hub"), "GITHUB_TOKEN"),
+    (("stripe",), "STRIPE_SECRET_KEY"),
+    (("tavily",), "TAVILY_API_KEY"),
+    (("firecrawl", "fire crawl"), "FIRECRAWL_API_KEY"),
+    (("perplexity",), "PERPLEXITY_API_KEY"),
+    (("serper",), "SERPER_API_KEY"),
+    (("deepseek", "deep seek"), "DEEPSEEK_API_KEY"),
+    (("gemini", "google ai", "google/gemini"), "GEMINI_API_KEY"),
+    (("xai", "grok"), "XAI_API_KEY"),
+    (("slack",), "SLACK_BOT_TOKEN"),
+    (("telegram",), "TELEGRAM_BOT_TOKEN"),
+    (("resend",), "RESEND_API_KEY"),
+    (("elevenlabs", "eleven labs"), "ELEVENLABS_API_KEY"),
+    (("browserbase", "browser base"), "BROWSERBASE_API_KEY"),
+    (("fal", "fal.ai"), "FAL_API_KEY"),
+)
 
 
 class SecretHandoffError(RuntimeError):
@@ -36,8 +65,8 @@ def start_private_secret_handoff(
 ) -> str:
     """Hermes tool handler that starts one private secret handoff."""
     payload = args or {}
-    secret_name = _normalize_secret_name(str(payload.get("name") or "TINYHAT_SECRET"))
     description = _clean_description(payload.get("description"))
+    secret_name = _resolve_secret_name(payload.get("name"), description)
     expires_in_seconds = int(
         payload.get("expires_in_seconds") or DEFAULT_EXPIRES_IN_SECONDS
     )
@@ -67,24 +96,10 @@ def start_private_secret_handoff(
     )
     _WORKERS.add(worker)
     worker.start()
-    return json.dumps(
-        {
-            "schema": "tinyhat_private_secret_handoff_v1",
-            "status": "waiting_for_user",
-            "secret_name": handoff.get("secret_name", secret_name),
-            "description": handoff.get("description") or description,
-            "mini_app_url": handoff.get("mini_app_url"),
-            "button_text": handoff.get("button_text", "Enter secret"),
-            "telegram_button": handoff.get("telegram_button"),
-            "telegram_message_sent": bool(handoff.get("telegram_message_sent")),
-            "expires_at": handoff.get("expires_at"),
-            "message": (
-                "Open the secure Tinyhat page to enter this value. Tinyhat "
-                "stores only encrypted ciphertext; the temporary private key "
-                "stays on this Computer."
-            ),
-        },
-        sort_keys=True,
+    shown_name = str(handoff.get("secret_name") or secret_name)
+    return (
+        f"I sent the secure entry button for `{shown_name}`. "
+        "Paste the value there; Tinyhat will not receive or store the plaintext."
     )
 
 
@@ -299,6 +314,45 @@ def _normalize_secret_name(value: str) -> str:
     if not SECRET_NAME_RE.fullmatch(name):
         raise SecretHandoffError("Secret names must look like OPENROUTER_API_KEY.")
     return name
+
+
+def _resolve_secret_name(value: Any, description: str | None) -> str:
+    raw = str(value or "").strip()
+    inferred = _infer_secret_name(
+        " ".join(part for part in (raw, description or "") if part)
+    )
+    if not raw:
+        if inferred:
+            return inferred
+        raise SecretHandoffError(
+            "Choose a specific secret name like EXA_API_KEY or GITHUB_TOKEN."
+        )
+
+    try:
+        name = _normalize_secret_name(raw)
+    except SecretHandoffError:
+        if inferred:
+            return inferred
+        raise
+
+    if name in GENERIC_SECRET_NAMES:
+        if inferred and inferred not in GENERIC_SECRET_NAMES:
+            return inferred
+        raise SecretHandoffError(
+            "Secret names must be specific, for example EXA_API_KEY instead of TINYHAT_SECRET."
+        )
+    return name
+
+
+def _infer_secret_name(text: str) -> str | None:
+    normalized = re.sub(r"[^a-z0-9]+", " ", str(text or "").lower()).strip()
+    if not normalized:
+        return None
+    padded = f" {normalized} "
+    for hints, name in SECRET_NAME_HINTS:
+        if any(f" {hint} " in padded for hint in hints):
+            return name
+    return None
 
 
 def _clean_description(value: Any) -> str | None:

--- a/secret_handoff.py
+++ b/secret_handoff.py
@@ -98,8 +98,8 @@ def start_private_secret_handoff(
     worker.start()
     shown_name = str(handoff.get("secret_name") or secret_name)
     return (
-        f"I sent the secure entry button for `{shown_name}`. "
-        "Paste the value there; Tinyhat will not receive or store the plaintext."
+        f"Tap Enter secret and paste the `{shown_name}` value within about "
+        "5 minutes. Tinyhat never sees the plaintext."
     )
 
 

--- a/secret_handoff.py
+++ b/secret_handoff.py
@@ -1,0 +1,292 @@
+"""Private secret handoff tool implementation."""
+
+from __future__ import annotations
+
+import base64
+import json
+import re
+import shutil
+import subprocess
+import tempfile
+import threading
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from .platform import PlatformClient, PlatformError, build_platform_client, computer_api_path
+
+KEY_ALGORITHM = "RSA-OAEP-256"
+DEFAULT_EXPIRES_IN_SECONDS = 300
+SECRET_NAME_RE = re.compile(r"^[A-Z_][A-Z0-9_]{0,126}$")
+_WORKERS: set[threading.Thread] = set()
+
+
+class SecretHandoffError(RuntimeError):
+    """The private secret handoff could not start or finish."""
+
+
+def start_private_secret_handoff(
+    args: dict[str, Any] | None = None,
+    **_: Any,
+) -> str:
+    """Hermes tool handler that starts one private secret handoff."""
+    payload = args or {}
+    secret_name = _normalize_secret_name(str(payload.get("name") or "TINYHAT_SECRET"))
+    description = _clean_description(payload.get("description"))
+    expires_in_seconds = int(
+        payload.get("expires_in_seconds") or DEFAULT_EXPIRES_IN_SECONDS
+    )
+
+    private_key_pem, public_key_pem = _generate_key_pair()
+    client, platform_auth = build_platform_client()
+    handoff = client.post_json(
+        computer_api_path(platform_auth, "private-secret-handoffs/v1"),
+        {
+            "name": secret_name,
+            "description": description,
+            "public_key_pem": public_key_pem,
+            "key_algorithm": KEY_ALGORITHM,
+            "expires_in_seconds": expires_in_seconds,
+        },
+    )
+    worker = threading.Thread(
+        target=_poll_and_install_secret,
+        kwargs={
+            "client": client,
+            "platform_auth": platform_auth,
+            "handoff": handoff,
+            "private_key_pem": private_key_pem,
+        },
+        name=f"tinyhat-secret-handoff-{handoff.get('handoff_id', 'unknown')}",
+        daemon=True,
+    )
+    _WORKERS.add(worker)
+    worker.start()
+    return json.dumps(
+        {
+            "schema": "tinyhat_private_secret_handoff_v1",
+            "status": "waiting_for_user",
+            "secret_name": handoff.get("secret_name", secret_name),
+            "description": handoff.get("description") or description,
+            "mini_app_url": handoff.get("mini_app_url"),
+            "button_text": handoff.get("button_text", "Enter secret"),
+            "telegram_button": handoff.get("telegram_button"),
+            "telegram_message_sent": bool(handoff.get("telegram_message_sent")),
+            "expires_at": handoff.get("expires_at"),
+            "message": (
+                "Open the secure Tinyhat page to enter this value. Tinyhat "
+                "stores only encrypted ciphertext; the temporary private key "
+                "stays on this Computer."
+            ),
+        },
+        sort_keys=True,
+    )
+
+
+def _poll_and_install_secret(
+    *,
+    client: PlatformClient,
+    platform_auth: str,
+    handoff: dict[str, Any],
+    private_key_pem: str,
+) -> None:
+    handoff_id = str(handoff.get("handoff_id") or "").strip()
+    if not handoff_id:
+        return
+    try:
+        deadline = _parse_expires_at(handoff.get("expires_at")) or (
+            time.time() + DEFAULT_EXPIRES_IN_SECONDS
+        )
+        poll_after = max(1.0, float(handoff.get("poll_after_ms") or 2000) / 1000)
+        while time.time() < deadline:
+            state = client.get_json(
+                computer_api_path(platform_auth, f"private-secret-handoffs/v1/{handoff_id}")
+            )
+            status = str(state.get("status") or "").strip()
+            if status == "submitted":
+                _install_submitted_secret(
+                    client=client,
+                    platform_auth=platform_auth,
+                    handoff_id=handoff_id,
+                    private_key_pem=private_key_pem,
+                    state=state,
+                )
+                return
+            if status in {"claimed", "expired", "failed"}:
+                return
+            time.sleep(poll_after)
+        _claim_handoff(
+            client,
+            platform_auth,
+            handoff_id,
+            installed=False,
+            message="Secret handoff expired before a value was submitted.",
+        )
+    except Exception as exc:  # pragma: no cover - worker safety net
+        try:
+            _claim_handoff(
+                client,
+                platform_auth,
+                handoff_id,
+                installed=False,
+                message=str(exc)[:500],
+            )
+        except Exception:
+            pass
+    finally:
+        current = threading.current_thread()
+        _WORKERS.discard(current)
+
+
+def _install_submitted_secret(
+    *,
+    client: PlatformClient,
+    platform_auth: str,
+    handoff_id: str,
+    private_key_pem: str,
+    state: dict[str, Any],
+) -> None:
+    ciphertext_payload = state.get("ciphertext_payload")
+    if not isinstance(ciphertext_payload, dict):
+        raise SecretHandoffError("Platform did not return ciphertext.")
+    secret_name = _normalize_secret_name(str(state.get("secret_name") or ""))
+    plaintext = _decrypt_ciphertext(private_key_pem, ciphertext_payload)
+    try:
+        _set_hermes_secret(secret_name, plaintext)
+    finally:
+        plaintext = ""
+    _claim_handoff(client, platform_auth, handoff_id, installed=True)
+
+
+def _claim_handoff(
+    client: PlatformClient,
+    platform_auth: str,
+    handoff_id: str,
+    *,
+    installed: bool,
+    message: str | None = None,
+) -> None:
+    client.post_json(
+        computer_api_path(
+            platform_auth,
+            f"private-secret-handoffs/v1/{handoff_id}/claim",
+        ),
+        {"installed": installed, "message": message},
+    )
+
+
+def _generate_key_pair() -> tuple[str, str]:
+    openssl = shutil.which("openssl")
+    if not openssl:
+        raise SecretHandoffError("openssl is required for private secret handoffs.")
+    with tempfile.TemporaryDirectory(prefix="tinyhat-secret-") as temp_dir:
+        private_key = Path(temp_dir) / "private.pem"
+        public_key = Path(temp_dir) / "public.pem"
+        _run([openssl, "genpkey", "-algorithm", "RSA", "-pkeyopt", "rsa_keygen_bits:3072", "-out", str(private_key)])
+        _run([openssl, "rsa", "-pubout", "-in", str(private_key), "-out", str(public_key)])
+        return (
+            private_key.read_text(encoding="utf-8"),
+            public_key.read_text(encoding="utf-8"),
+        )
+
+
+def _decrypt_ciphertext(private_key_pem: str, payload: dict[str, Any]) -> str:
+    if payload.get("algorithm") != KEY_ALGORITHM:
+        raise SecretHandoffError("Unsupported ciphertext algorithm.")
+    chunks = payload.get("ciphertext_chunks_b64")
+    if isinstance(chunks, list) and chunks:
+        plaintext_parts = [
+            _decrypt_one_chunk(private_key_pem, str(chunk or "").strip())
+            for chunk in chunks
+        ]
+        return b"".join(plaintext_parts).decode("utf-8")
+    ciphertext_b64 = str(payload.get("ciphertext_b64") or "").strip()
+    if not ciphertext_b64:
+        raise SecretHandoffError("Ciphertext payload is empty.")
+    return _decrypt_one_chunk(private_key_pem, ciphertext_b64).decode("utf-8")
+
+
+def _decrypt_one_chunk(private_key_pem: str, ciphertext_b64: str) -> bytes:
+    if not ciphertext_b64:
+        raise SecretHandoffError("Ciphertext chunk is empty.")
+    openssl = shutil.which("openssl")
+    if not openssl:
+        raise SecretHandoffError("openssl is required for private secret handoffs.")
+    with tempfile.TemporaryDirectory(prefix="tinyhat-secret-") as temp_dir:
+        private_key = Path(temp_dir) / "private.pem"
+        ciphertext_path = Path(temp_dir) / "secret.bin"
+        private_key.write_text(private_key_pem, encoding="utf-8")
+        private_key.chmod(0o600)
+        ciphertext_path.write_bytes(base64.b64decode(ciphertext_b64))
+        result = _run(
+            [
+                openssl,
+                "pkeyutl",
+                "-decrypt",
+                "-inkey",
+                str(private_key),
+                "-in",
+                str(ciphertext_path),
+                "-pkeyopt",
+                "rsa_padding_mode:oaep",
+                "-pkeyopt",
+                "rsa_oaep_md:sha256",
+            ],
+            text=False,
+        )
+        return result
+
+
+def _set_hermes_secret(secret_name: str, value: str) -> None:
+    hermes = shutil.which("hermes")
+    if not hermes:
+        raise SecretHandoffError("Hermes CLI was not found.")
+    result = subprocess.run(
+        [hermes, "config", "set", secret_name, value],
+        capture_output=True,
+        text=True,
+        timeout=45,
+        check=False,
+    )
+    if result.returncode != 0:
+        detail = (result.stderr or result.stdout or "Hermes config set failed").strip()
+        raise SecretHandoffError(detail[:500])
+
+
+def _run(command: list[str], *, text: bool = True) -> str | bytes:
+    result = subprocess.run(
+        command,
+        capture_output=True,
+        text=text,
+        timeout=45,
+        check=False,
+    )
+    if result.returncode != 0:
+        stderr = result.stderr if text else result.stderr.decode("utf-8", "replace")
+        raise SecretHandoffError((stderr or "command failed").strip()[:500])
+    return result.stdout if text else result.stdout
+
+
+def _parse_expires_at(value: Any) -> float | None:
+    text = str(value or "").strip()
+    if not text:
+        return None
+    try:
+        return datetime.fromisoformat(text.replace("Z", "+00:00")).astimezone(
+            timezone.utc
+        ).timestamp()
+    except ValueError:
+        return None
+
+
+def _normalize_secret_name(value: str) -> str:
+    name = str(value or "").strip().upper()
+    if not SECRET_NAME_RE.fullmatch(name):
+        raise SecretHandoffError("Secret names must look like OPENROUTER_API_KEY.")
+    return name
+
+
+def _clean_description(value: Any) -> str | None:
+    text = str(value or "").strip()
+    return text[:500] if text else None

--- a/secret_handoff.py
+++ b/secret_handoff.py
@@ -14,7 +14,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
-from .platform import PlatformClient, PlatformError, build_platform_client, computer_api_path
+from .platform import PlatformClient, build_platform_client, computer_api_path
 
 KEY_ALGORITHM = "RSA-OAEP-256"
 DEFAULT_EXPIRES_IN_SECONDS = 300
@@ -24,6 +24,10 @@ _WORKERS: set[threading.Thread] = set()
 
 class SecretHandoffError(RuntimeError):
     """The private secret handoff could not start or finish."""
+
+    def __init__(self, message: str, *, public_message: str | None = None) -> None:
+        super().__init__(message)
+        self.public_message = public_message or "Private secret handoff failed."
 
 
 def start_private_secret_handoff(
@@ -130,7 +134,7 @@ def _poll_and_install_secret(
                 platform_auth,
                 handoff_id,
                 installed=False,
-                message=str(exc)[:500],
+                message=_public_failure_message(exc),
             )
         except Exception:
             pass
@@ -250,8 +254,10 @@ def _set_hermes_secret(secret_name: str, value: str) -> None:
         check=False,
     )
     if result.returncode != 0:
-        detail = (result.stderr or result.stdout or "Hermes config set failed").strip()
-        raise SecretHandoffError(detail[:500])
+        raise SecretHandoffError(
+            "Hermes config set failed.",
+            public_message="Hermes could not save this secret.",
+        )
 
 
 def _run(command: list[str], *, text: bool = True) -> str | bytes:
@@ -266,6 +272,14 @@ def _run(command: list[str], *, text: bool = True) -> str | bytes:
         stderr = result.stderr if text else result.stderr.decode("utf-8", "replace")
         raise SecretHandoffError((stderr or "command failed").strip()[:500])
     return result.stdout if text else result.stdout
+
+
+def _public_failure_message(exc: BaseException) -> str:
+    if isinstance(exc, SecretHandoffError):
+        return exc.public_message[:500]
+    if isinstance(exc, UnicodeDecodeError):
+        return "The encrypted secret could not be decoded."
+    return "Private secret handoff failed."
 
 
 def _parse_expires_at(value: Any) -> float | None:

--- a/skills/tinyhat-private-secret/SKILL.md
+++ b/skills/tinyhat-private-secret/SKILL.md
@@ -1,0 +1,30 @@
+---
+name: tinyhat-private-secret
+description: Start a private Tinyhat secret handoff. Use when the user asks to add, save, create, update, or connect an API key, token, password, credential, webhook secret, or other secret for this agent.
+---
+
+# Tinyhat Private Secret
+
+Use this when the user wants to add a secret or credential to the
+current Tinyhat-managed Computer.
+
+Never ask the user to paste the secret value in chat. Start a private
+handoff instead:
+
+1. Pick an env-style name such as `OPENROUTER_API_KEY`, `GITHUB_TOKEN`,
+   or `STRIPE_SECRET_KEY`.
+2. Add a short plain-English description that helps the user remember
+   why the secret exists.
+3. Call `tinyhat_private_secret_handoff` with `name` and `description`.
+4. Show the returned secure Mini App button/link and explain that the
+   user has about five minutes to enter the value.
+
+The handoff works like a device flow. This Computer creates a one-time
+key pair. The Tinyhat page encrypts the secret in the user's browser
+with the public key, and this Computer decrypts it with the temporary
+private key. Tinyhat stores only encrypted ciphertext during the handoff.
+
+If the handoff expires, ask the user whether to create a new secure
+link. Do not reuse old links.
+
+Keep the chat response short. The button is the main action.

--- a/skills/tinyhat-private-secret/SKILL.md
+++ b/skills/tinyhat-private-secret/SKILL.md
@@ -18,8 +18,8 @@ handoff instead:
 2. Add a short plain-English description that helps the user remember
    why the secret exists.
 3. Call `tinyhat_private_secret_handoff` with `name` and `description`.
-4. Show the returned secure Mini App button/link and explain that the
-   user has about five minutes to enter the value.
+4. Let the returned message stand. Tinyhat already sends the secure
+   button.
 
 Do not use generic names such as `TINYHAT_SECRET`, `SECRET`, `API_KEY`,
 `TOKEN`, `PASSWORD`, or `CREDENTIAL`. If the provider or purpose is not
@@ -46,7 +46,9 @@ key pair. The Tinyhat page encrypts the secret in the user's browser
 with the public key, and this Computer decrypts it with the temporary
 private key. Tinyhat stores only encrypted ciphertext during the handoff.
 
-If the handoff expires, ask the user whether to create a new secure
+If the entry window expires, ask the user whether to create a new secure
 link. Do not reuse old links.
 
-Keep the chat response short. The button is the main action.
+Keep the chat response short. Do not render a table, exact expiration
+timestamp, status field, raw URL, JSON payload, or extra explanation. The
+button is the main action.

--- a/skills/tinyhat-private-secret/SKILL.md
+++ b/skills/tinyhat-private-secret/SKILL.md
@@ -11,13 +11,35 @@ current Tinyhat-managed Computer.
 Never ask the user to paste the secret value in chat. Start a private
 handoff instead:
 
-1. Pick an env-style name such as `OPENROUTER_API_KEY`, `GITHUB_TOKEN`,
-   or `STRIPE_SECRET_KEY`.
+1. Pick a specific env-style name from the user's request. If the user
+   says "my Exa API key", use `EXA_API_KEY`. If they say GitHub token,
+   use `GITHUB_TOKEN`. If they say Stripe secret key, use
+   `STRIPE_SECRET_KEY`.
 2. Add a short plain-English description that helps the user remember
    why the secret exists.
 3. Call `tinyhat_private_secret_handoff` with `name` and `description`.
 4. Show the returned secure Mini App button/link and explain that the
    user has about five minutes to enter the value.
+
+Do not use generic names such as `TINYHAT_SECRET`, `SECRET`, `API_KEY`,
+`TOKEN`, `PASSWORD`, or `CREDENTIAL`. If the provider or purpose is not
+clear enough to choose a meaningful name, ask one short clarification
+question before starting the handoff.
+
+Use these common names when they match the user request:
+
+| User wording | Secret name |
+| --- | --- |
+| Exa API key | `EXA_API_KEY` |
+| OpenRouter API key | `OPENROUTER_API_KEY` |
+| OpenAI API key | `OPENAI_API_KEY` |
+| Anthropic API key | `ANTHROPIC_API_KEY` |
+| GitHub token | `GITHUB_TOKEN` |
+| Stripe secret key | `STRIPE_SECRET_KEY` |
+| Tavily API key | `TAVILY_API_KEY` |
+| Firecrawl API key | `FIRECRAWL_API_KEY` |
+| Telegram bot token | `TELEGRAM_BOT_TOKEN` |
+| Slack bot token | `SLACK_BOT_TOKEN` |
 
 The handoff works like a device flow. This Computer creates a one-time
 key pair. The Tinyhat page encrypts the secret in the user's browser

--- a/test/test_hermes_adapter.py
+++ b/test/test_hermes_adapter.py
@@ -39,8 +39,8 @@ class FakeHermesContext:
     def register_tool(self, **kwargs) -> None:
         self.tools[kwargs["name"]] = kwargs
 
-    def register_command(self, **kwargs) -> None:
-        self.commands[kwargs["name"]] = kwargs
+    def register_command(self, name: str, handler, **kwargs) -> None:
+        self.commands[name] = {"name": name, "handler": handler, **kwargs}
 
     def register_skill(self, name: str, skill_md: Path) -> None:
         self.skills[name] = skill_md

--- a/test/test_hermes_adapter.py
+++ b/test/test_hermes_adapter.py
@@ -91,7 +91,7 @@ class HermesAdapterTests(unittest.TestCase):
         self.assertEqual(payload["schema"], "tinyhat_tell_joke_v1")
         self.assertIn("Hermes", payload["joke"])
 
-    def test_private_secret_handoff_returns_secure_button_payload(self) -> None:
+    def test_private_secret_handoff_returns_readable_confirmation(self) -> None:
         class FakeClient:
             def post_json(self, path: str, payload: dict) -> dict:
                 self.path = path
@@ -122,13 +122,11 @@ class HermesAdapterTests(unittest.TestCase):
             secret_handoff._generate_key_pair = lambda: ("PRIVATE", "PUBLIC")
             secret_handoff._poll_and_install_secret = lambda **_: None
 
-            payload = json.loads(
-                tools.private_secret_handoff(
-                    {
-                        "name": "github_token",
-                        "description": "GitHub access for repository tasks",
-                    }
-                )
+            reply = tools.private_secret_handoff(
+                {
+                    "name": "github_token",
+                    "description": "GitHub access for repository tasks",
+                }
             )
         finally:
             secret_handoff.build_platform_client = original_build
@@ -140,10 +138,58 @@ class HermesAdapterTests(unittest.TestCase):
             "/hapi/v1/computers/local-dev/private-secret-handoffs/v1",
         )
         self.assertEqual(fake_client.payload["name"], "GITHUB_TOKEN")
-        self.assertEqual(payload["schema"], "tinyhat_private_secret_handoff_v1")
-        self.assertEqual(payload["status"], "waiting_for_user")
-        self.assertEqual(payload["button_text"], "Enter secret")
-        self.assertIn("web_app", payload["telegram_button"])
+        self.assertIn("secure entry button", reply)
+        self.assertIn("GITHUB_TOKEN", reply)
+        self.assertIn("will not receive or store the plaintext", reply)
+        self.assertFalse(reply.strip().startswith("{"))
+
+    def test_private_secret_handoff_infers_name_from_user_wording(self) -> None:
+        class FakeClient:
+            def post_json(self, path: str, payload: dict) -> dict:
+                self.path = path
+                self.payload = payload
+                return {
+                    "handoff_id": "sh_exa",
+                    "status": "pending",
+                    "secret_name": payload["name"],
+                    "description": payload["description"],
+                    "expires_at": "2026-06-29T12:00:00Z",
+                    "poll_after_ms": 2000,
+                }
+
+        fake_client = FakeClient()
+        original_build = secret_handoff.build_platform_client
+        original_generate = secret_handoff._generate_key_pair
+        original_worker = secret_handoff._poll_and_install_secret
+        try:
+            secret_handoff.build_platform_client = lambda: (fake_client, "local_dev")
+            secret_handoff._generate_key_pair = lambda: ("PRIVATE", "PUBLIC")
+            secret_handoff._poll_and_install_secret = lambda **_: None
+
+            reply = tools.private_secret_handoff(
+                {
+                    "name": "TINYHAT_SECRET",
+                    "description": "Exa API key for search research",
+                }
+            )
+        finally:
+            secret_handoff.build_platform_client = original_build
+            secret_handoff._generate_key_pair = original_generate
+            secret_handoff._poll_and_install_secret = original_worker
+
+        self.assertEqual(fake_client.payload["name"], "EXA_API_KEY")
+        self.assertIn("EXA_API_KEY", reply)
+
+    def test_private_secret_handoff_rejects_generic_unknown_name(self) -> None:
+        with self.assertRaises(secret_handoff.SecretHandoffError) as exc:
+            tools.private_secret_handoff(
+                {
+                    "name": "TINYHAT_SECRET",
+                    "description": "generic credential",
+                }
+            )
+
+        self.assertIn("specific", str(exc.exception))
 
     def test_worker_claim_failure_message_is_sanitized(self) -> None:
         class FakeClient:

--- a/test/test_hermes_adapter.py
+++ b/test/test_hermes_adapter.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import importlib.util
 import sys
 import unittest
 from pathlib import Path
@@ -12,7 +13,20 @@ REPO_ROOT = Path(__file__).resolve().parents[1]
 PARENT = REPO_ROOT.parent
 sys.path.insert(0, str(PARENT))
 
-import tinyhat  # noqa: E402
+if REPO_ROOT.name != "tinyhat":
+    spec = importlib.util.spec_from_file_location(
+        "tinyhat",
+        REPO_ROOT / "__init__.py",
+        submodule_search_locations=[str(REPO_ROOT)],
+    )
+    if spec is None or spec.loader is None:
+        raise RuntimeError("Could not load local tinyhat package for tests.")
+    tinyhat = importlib.util.module_from_spec(spec)
+    sys.modules["tinyhat"] = tinyhat
+    spec.loader.exec_module(tinyhat)
+else:
+    import tinyhat  # noqa: E402
+
 from tinyhat import secret_handoff, tools  # noqa: E402
 
 
@@ -117,6 +131,55 @@ class HermesAdapterTests(unittest.TestCase):
         self.assertEqual(payload["status"], "waiting_for_user")
         self.assertEqual(payload["button_text"], "Enter secret")
         self.assertIn("web_app", payload["telegram_button"])
+
+    def test_worker_claim_failure_message_is_sanitized(self) -> None:
+        class FakeClient:
+            def __init__(self) -> None:
+                self.claim_payloads: list[dict] = []
+
+            def get_json(self, path: str) -> dict:
+                return {
+                    "status": "submitted",
+                    "secret_name": "PRIVATE_TOKEN",
+                    "ciphertext_payload": {"algorithm": "RSA-OAEP-256"},
+                }
+
+            def post_json(self, path: str, payload: dict) -> dict:
+                self.claim_payloads.append(payload)
+                return {"status": "failed"}
+
+        fake_client = FakeClient()
+        original_decrypt = secret_handoff._decrypt_ciphertext
+        original_set = secret_handoff._set_hermes_secret
+        try:
+            secret_handoff._decrypt_ciphertext = lambda *_: "super-secret-value"
+            secret_handoff._set_hermes_secret = lambda *_: (_ for _ in ()).throw(
+                secret_handoff.SecretHandoffError(
+                    "hermes echoed super-secret-value",
+                    public_message="Hermes could not save this secret.",
+                )
+            )
+
+            secret_handoff._poll_and_install_secret(
+                client=fake_client,
+                platform_auth="local_dev",
+                handoff={
+                    "handoff_id": "sh_test",
+                    "expires_at": "2999-01-01T00:00:00Z",
+                    "poll_after_ms": 1,
+                },
+                private_key_pem="PRIVATE",
+            )
+        finally:
+            secret_handoff._decrypt_ciphertext = original_decrypt
+            secret_handoff._set_hermes_secret = original_set
+
+        self.assertEqual(fake_client.claim_payloads[-1]["installed"], False)
+        self.assertEqual(
+            fake_client.claim_payloads[-1]["message"],
+            "Hermes could not save this secret.",
+        )
+        self.assertNotIn("super-secret-value", json.dumps(fake_client.claim_payloads))
 
     def test_tell_joke_ignores_hermes_runtime_metadata(self) -> None:
         payload = json.loads(

--- a/test/test_hermes_adapter.py
+++ b/test/test_hermes_adapter.py
@@ -13,7 +13,7 @@ PARENT = REPO_ROOT.parent
 sys.path.insert(0, str(PARENT))
 
 import tinyhat  # noqa: E402
-from tinyhat import tools  # noqa: E402
+from tinyhat import secret_handoff, tools  # noqa: E402
 
 
 class FakeHermesContext:
@@ -40,25 +40,83 @@ class HermesAdapterTests(unittest.TestCase):
 
         self.assertIn("tinyhat_plugin_version", ctx.tools)
         self.assertIn("tinyhat_tell_joke", ctx.tools)
+        self.assertIn("tinyhat_private_secret_handoff", ctx.tools)
         self.assertIn("tinyhat_plugin_version", ctx.commands)
         self.assertIn("tinyhat_joke", ctx.commands)
+        self.assertIn("tinyhat_secret", ctx.commands)
         self.assertIn("tinyhat-plugin-version", ctx.skills)
         self.assertIn("tinyhat-tell-joke", ctx.skills)
+        self.assertIn("tinyhat-private-secret", ctx.skills)
         self.assertTrue(ctx.skills["tinyhat-plugin-version"].is_file())
         self.assertTrue(ctx.skills["tinyhat-tell-joke"].is_file())
+        self.assertTrue(ctx.skills["tinyhat-private-secret"].is_file())
 
     def test_plugin_version_returns_live_manifest_version(self) -> None:
         payload = json.loads(tools.plugin_version())
 
         self.assertEqual(payload["schema"], "tinyhat_plugin_version_v1")
         self.assertEqual(payload["name"], "tinyhat")
-        self.assertEqual(payload["version"], "0.20.3")
+        self.assertEqual(payload["version"], "0.20.4")
 
     def test_tell_joke_returns_stable_json(self) -> None:
         payload = json.loads(tools.tell_joke({"topic": "Hermes"}))
 
         self.assertEqual(payload["schema"], "tinyhat_tell_joke_v1")
         self.assertIn("Hermes", payload["joke"])
+
+    def test_private_secret_handoff_returns_secure_button_payload(self) -> None:
+        class FakeClient:
+            def post_json(self, path: str, payload: dict) -> dict:
+                self.path = path
+                self.payload = payload
+                return {
+                    "handoff_id": "sh_test",
+                    "status": "pending",
+                    "secret_name": payload["name"],
+                    "description": payload["description"],
+                    "mini_app_url": "https://example.test/tinyhat/miniapp/private-secrets/sh_test",
+                    "button_text": "Enter secret",
+                    "telegram_button": {
+                        "text": "Enter secret",
+                        "web_app": {
+                            "url": "https://example.test/tinyhat/miniapp/private-secrets/sh_test"
+                        },
+                    },
+                    "expires_at": "2026-06-29T12:00:00Z",
+                    "poll_after_ms": 2000,
+                }
+
+        fake_client = FakeClient()
+        original_build = secret_handoff.build_platform_client
+        original_generate = secret_handoff._generate_key_pair
+        original_worker = secret_handoff._poll_and_install_secret
+        try:
+            secret_handoff.build_platform_client = lambda: (fake_client, "local_dev")
+            secret_handoff._generate_key_pair = lambda: ("PRIVATE", "PUBLIC")
+            secret_handoff._poll_and_install_secret = lambda **_: None
+
+            payload = json.loads(
+                tools.private_secret_handoff(
+                    {
+                        "name": "github_token",
+                        "description": "GitHub access for repository tasks",
+                    }
+                )
+            )
+        finally:
+            secret_handoff.build_platform_client = original_build
+            secret_handoff._generate_key_pair = original_generate
+            secret_handoff._poll_and_install_secret = original_worker
+
+        self.assertEqual(
+            fake_client.path,
+            "/hapi/v1/computers/local-dev/private-secret-handoffs/v1",
+        )
+        self.assertEqual(fake_client.payload["name"], "GITHUB_TOKEN")
+        self.assertEqual(payload["schema"], "tinyhat_private_secret_handoff_v1")
+        self.assertEqual(payload["status"], "waiting_for_user")
+        self.assertEqual(payload["button_text"], "Enter secret")
+        self.assertIn("web_app", payload["telegram_button"])
 
     def test_tell_joke_ignores_hermes_runtime_metadata(self) -> None:
         payload = json.loads(

--- a/test/test_hermes_adapter.py
+++ b/test/test_hermes_adapter.py
@@ -138,9 +138,12 @@ class HermesAdapterTests(unittest.TestCase):
             "/hapi/v1/computers/local-dev/private-secret-handoffs/v1",
         )
         self.assertEqual(fake_client.payload["name"], "GITHUB_TOKEN")
-        self.assertIn("secure entry button", reply)
+        self.assertIn("Tap Enter secret", reply)
         self.assertIn("GITHUB_TOKEN", reply)
-        self.assertIn("will not receive or store the plaintext", reply)
+        self.assertIn("within about 5 minutes", reply)
+        self.assertIn("never sees the plaintext", reply)
+        self.assertNotIn("Expires", reply)
+        self.assertNotIn("waiting_for_user", reply)
         self.assertFalse(reply.strip().startswith("{"))
 
     def test_private_secret_handoff_infers_name_from_user_wording(self) -> None:

--- a/test/test_hermes_adapter.py
+++ b/test/test_hermes_adapter.py
@@ -55,15 +55,28 @@ class HermesAdapterTests(unittest.TestCase):
         self.assertIn("tinyhat_plugin_version", ctx.tools)
         self.assertIn("tinyhat_tell_joke", ctx.tools)
         self.assertIn("tinyhat_private_secret_handoff", ctx.tools)
-        self.assertIn("tinyhat_plugin_version", ctx.commands)
-        self.assertIn("tinyhat_joke", ctx.commands)
-        self.assertIn("tinyhat_secret", ctx.commands)
+        self.assertIn("tinyhat-plugin-version", ctx.commands)
+        self.assertIn("tinyhat-joke", ctx.commands)
+        self.assertIn("tinyhat-secret", ctx.commands)
         self.assertIn("tinyhat-plugin-version", ctx.skills)
         self.assertIn("tinyhat-tell-joke", ctx.skills)
         self.assertIn("tinyhat-private-secret", ctx.skills)
         self.assertTrue(ctx.skills["tinyhat-plugin-version"].is_file())
         self.assertTrue(ctx.skills["tinyhat-tell-joke"].is_file())
         self.assertTrue(ctx.skills["tinyhat-private-secret"].is_file())
+
+    def test_registered_commands_match_telegram_dispatch_names(self) -> None:
+        ctx = FakeHermesContext()
+
+        tinyhat.register(ctx)
+
+        for telegram_name in (
+            "tinyhat_joke",
+            "tinyhat_plugin_version",
+            "tinyhat_secret",
+        ):
+            hermes_dispatch_name = telegram_name.replace("_", "-")
+            self.assertIn(hermes_dispatch_name, ctx.commands)
 
     def test_plugin_version_returns_live_manifest_version(self) -> None:
         payload = json.loads(tools.plugin_version())

--- a/tools.py
+++ b/tools.py
@@ -6,6 +6,8 @@ import json
 from pathlib import Path
 from typing import Any
 
+from .secret_handoff import start_private_secret_handoff
+
 
 def plugin_version_payload() -> dict[str, str]:
     """Return the version of the Tinyhat plugin code currently loaded."""
@@ -49,3 +51,8 @@ def tell_joke(args: dict[str, Any] | None = None, **_: Any) -> str:
         },
         sort_keys=True,
     )
+
+
+def private_secret_handoff(args: dict[str, Any] | None = None, **kwargs: Any) -> str:
+    """Start a blind private-secret handoff through the Tinyhat platform."""
+    return start_private_secret_handoff(args, **kwargs)


### PR DESCRIPTION
## TL;DR for the reviewer

Adds the first real Tinyhat plugin capability for Hermes: a private secret handoff. The plugin starts a short-lived platform handoff, shows the user a Telegram Mini App button, polls for browser-encrypted ciphertext, decrypts it on the Computer with a one-time private key, and saves the result through the public Hermes CLI.

## Reviewer context

- Base branch: `codex/v0.20-hermes-plugin`.
- Companion platform PR: https://github.com/tinyloophub/tinyloop/pull/901
- Runtime repo changes: none. This feature is plugin + versioned platform APIs only.

## Scope — what this PR changes

Plugin capability:
- Adds `tinyhat_private_secret_handoff`.
- Adds `/tinyhat_secret SECRET_NAME [description]` as a manual test command.
- Adds `skills/tinyhat-private-secret/SKILL.md` so agents do not ask users to paste secrets in chat.

Platform client:
- Adds a small stdlib-only client that calls the assigned Computer APIs using local-dev bearer auth or GCloud identity-token auth.

Docs and manifests:
- Updates plugin manifests to version `0.20.4`.
- Documents the secret handoff pattern and capability list.
- Extends package validation to require the new skill, tool, and command.

## Non-scope — what this PR deliberately does NOT change

- No runtime repo changes.
- No platform API implementation here; that is in the companion platform PR.
- No plaintext secret storage in Tinyhat.
- No framework besides Hermes yet.

## How to test

### Plugin package contract

**What to do:**
```bash
python3 scripts/validate_framework_package.py
```
**Before this PR:** the validator only knew about joke/version proof skills.
**After this PR:** it also requires the private-secret skill, tool, command, and docs.
**Why this matters:** keeps the public package self-describing and prevents shipping a half-registered capability.

### Unit tests

**What to do:**
```bash
python3 -m unittest discover -s test -p "*.py"
```
**Before this PR:** no secret handoff tool existed.
**After this PR:** tests verify the tool returns a Mini App button payload and starts the polling worker without exposing plaintext.
**Why this matters:** proves the agent-visible entrypoint is wired before trying a live Computer.

### Compile smoke

**What to do:**
```bash
python3 -m compileall -q .
```
**Why this matters:** catches syntax/import errors in the stdlib-only platform client and handoff worker.

## Implementation summary

```mermaid
sequenceDiagram
  participant Agent as Hermes Agent
  participant Tool as Tinyhat Plugin Tool
  participant API as Tinyhat Platform API
  participant Mini as Telegram Mini App
  Agent->>Tool: User asks to save a secret
  Tool->>Tool: Generate one-time RSA keypair
  Tool->>API: Create handoff with public key
  API-->>Tool: Mini App button + handoff id
  Tool-->>Agent: Show button / waiting status
  Mini->>API: Submit ciphertext encrypted in browser
  Tool->>API: Poll for ciphertext
  Tool->>Tool: Decrypt locally and run `hermes config set`
  Tool->>API: Claim completion
```

## Verified

```bash
python3 scripts/validate_framework_package.py
# framework-package: ok (version 0.20.4)

python3 -m unittest discover -s test -p "*.py"
# Ran 5 tests: OK

python3 -m compileall -q .
# passed
```

Live Telegram handoff requires the companion platform PR and a Computer with this plugin branch installed.
