### PR TITLE
fix(hermes): simplify secret entry flow

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "__init__.py",
     "platform.py",
     "secret_handoff.py",
+    "secret_handoff_worker.py",
     "schemas.py",
     "tools.py",
     "skills",

--- a/schemas.py
+++ b/schemas.py
@@ -32,12 +32,6 @@ TINYHAT_PRIVATE_SECRET_HANDOFF_SCHEMA = {
             "type": "string",
             "description": "Short human reminder for what this secret is used for.",
         },
-        "expires_in_seconds": {
-            "type": "integer",
-            "description": "Optional handoff timeout. Defaults to 300 seconds.",
-            "minimum": 60,
-            "maximum": 600,
-        },
     },
     "required": ["name"],
     "additionalProperties": False,

--- a/scripts/validate_framework_package.py
+++ b/scripts/validate_framework_package.py
@@ -125,6 +125,7 @@ def validate_hermes_adapter(root: Path) -> None:
         "tools.py",
         "platform.py",
         "secret_handoff.py",
+        "secret_handoff_worker.py",
     ):
         require((root / rel).is_file(), f"{rel} is missing")
 
@@ -201,6 +202,7 @@ def validate_fresh_surface(root: Path) -> None:
         root / "__init__.py",
         root / "platform.py",
         root / "secret_handoff.py",
+        root / "secret_handoff_worker.py",
         root / "schemas.py",
         root / "tools.py",
     ]

--- a/secret_handoff.py
+++ b/secret_handoff.py
@@ -3,11 +3,12 @@
 from __future__ import annotations
 
 import base64
+import os
 import re
 import shutil
 import subprocess
+import sys
 import tempfile
-import threading
 import time
 from datetime import datetime, timezone
 from pathlib import Path
@@ -18,7 +19,7 @@ from .platform import PlatformClient, build_platform_client, computer_api_path
 KEY_ALGORITHM = "RSA-OAEP-256"
 DEFAULT_EXPIRES_IN_SECONDS = 300
 SECRET_NAME_RE = re.compile(r"^[A-Z_][A-Z0-9_]{0,126}$")
-_WORKERS: set[threading.Thread] = set()
+STATE_DIR = Path.home() / ".tinyhat" / "private-secret-handoffs"
 GENERIC_SECRET_NAMES = {
     "TINYHAT_SECRET",
     "SECRET",
@@ -56,7 +57,7 @@ class SecretHandoffError(RuntimeError):
 
     def __init__(self, message: str, *, public_message: str | None = None) -> None:
         super().__init__(message)
-        self.public_message = public_message or "Private secret handoff failed."
+        self.public_message = public_message or "Could not start secure secret entry."
 
 
 def start_private_secret_handoff(
@@ -67,9 +68,7 @@ def start_private_secret_handoff(
     payload = args or {}
     description = _clean_description(payload.get("description"))
     secret_name = _resolve_secret_name(payload.get("name"), description)
-    expires_in_seconds = int(
-        payload.get("expires_in_seconds") or DEFAULT_EXPIRES_IN_SECONDS
-    )
+    expires_in_seconds = DEFAULT_EXPIRES_IN_SECONDS
 
     private_key_pem, public_key_pem = _generate_key_pair()
     client, platform_auth = build_platform_client()
@@ -83,24 +82,65 @@ def start_private_secret_handoff(
             "expires_in_seconds": expires_in_seconds,
         },
     )
-    worker = threading.Thread(
-        target=_poll_and_install_secret,
-        kwargs={
-            "client": client,
-            "platform_auth": platform_auth,
-            "handoff": handoff,
-            "private_key_pem": private_key_pem,
-        },
-        name=f"tinyhat-secret-handoff-{handoff.get('handoff_id', 'unknown')}",
-        daemon=True,
-    )
-    _WORKERS.add(worker)
-    worker.start()
+    if not handoff.get("existing_handoff"):
+        _start_worker_process(handoff, private_key_pem)
     shown_name = str(handoff.get("secret_name") or secret_name)
     return (
-        f"Tap Enter secret and paste the `{shown_name}` value within about "
-        "5 minutes. Tinyhat never sees the plaintext."
+        f"I sent the secure Enter secret button for `{shown_name}`. Tap it "
+        "within about 5 minutes and paste the value there. Tinyhat never sees "
+        "the plaintext."
     )
+
+
+def _start_worker_process(handoff: dict[str, Any], private_key_pem: str) -> None:
+    handoff_id = str(handoff.get("handoff_id") or "").strip()
+    if not handoff_id:
+        raise SecretHandoffError("Platform did not return a handoff id.")
+    key_path = _write_private_key_file(handoff_id, private_key_pem)
+    package_dir = Path(__file__).resolve().parent
+    env = os.environ.copy()
+    pythonpath = str(package_dir.parent)
+    if env.get("PYTHONPATH"):
+        pythonpath = f"{pythonpath}{os.pathsep}{env['PYTHONPATH']}"
+    env["PYTHONPATH"] = pythonpath
+    try:
+        subprocess.Popen(
+            [
+                sys.executable,
+                str(package_dir / "secret_handoff_worker.py"),
+                "--handoff-id",
+                handoff_id,
+                "--key-path",
+                str(key_path),
+            ],
+            cwd=str(package_dir.parent),
+            env=env,
+            stdin=subprocess.DEVNULL,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            start_new_session=True,
+            close_fds=True,
+        )
+    except Exception as exc:
+        try:
+            key_path.unlink()
+        except OSError:
+            pass
+        raise SecretHandoffError(
+            "Could not start the local secret handoff worker.",
+            public_message="I could not start the secure secret saver on this Computer.",
+        ) from exc
+
+
+def _write_private_key_file(handoff_id: str, private_key_pem: str) -> Path:
+    safe_id = re.sub(r"[^A-Za-z0-9_.-]", "_", handoff_id)
+    directory = STATE_DIR / safe_id
+    directory.mkdir(parents=True, exist_ok=True)
+    directory.chmod(0o700)
+    key_path = directory / "private.pem"
+    key_path.write_text(private_key_pem, encoding="utf-8")
+    key_path.chmod(0o600)
+    return key_path
 
 
 def _poll_and_install_secret(
@@ -140,7 +180,7 @@ def _poll_and_install_secret(
             platform_auth,
             handoff_id,
             installed=False,
-            message="Secret handoff expired before a value was submitted.",
+            message="Secret entry expired before a value was submitted.",
         )
     except Exception as exc:  # pragma: no cover - worker safety net
         try:
@@ -153,9 +193,6 @@ def _poll_and_install_secret(
             )
         except Exception:
             pass
-    finally:
-        current = threading.current_thread()
-        _WORKERS.discard(current)
 
 
 def _install_submitted_secret(
@@ -294,7 +331,7 @@ def _public_failure_message(exc: BaseException) -> str:
         return exc.public_message[:500]
     if isinstance(exc, UnicodeDecodeError):
         return "The encrypted secret could not be decoded."
-    return "Private secret handoff failed."
+    return "Could not complete secure secret entry."
 
 
 def _parse_expires_at(value: Any) -> float | None:

--- a/secret_handoff_worker.py
+++ b/secret_handoff_worker.py
@@ -1,0 +1,121 @@
+"""Detached worker for Tinyhat private secret handoffs.
+
+Hermes may execute tools in a short-lived process. The handoff must keep
+polling after the tool returns, so this worker owns the one-time private key
+until the user submits, the Computer saves the secret, or the handoff expires.
+"""
+
+from __future__ import annotations
+
+import argparse
+import shutil
+import sys
+import time
+import types
+from pathlib import Path
+
+if __package__ in {None, ""}:
+    package_dir = Path(__file__).resolve().parent
+    parent_dir = package_dir.parent
+    if str(parent_dir) not in sys.path:
+        sys.path.insert(0, str(parent_dir))
+    package = sys.modules.get("tinyhat")
+    if package is None:
+        package = types.ModuleType("tinyhat")
+        package.__file__ = str(package_dir / "__init__.py")
+        package.__path__ = [str(package_dir)]  # type: ignore[attr-defined]
+        sys.modules["tinyhat"] = package
+    __package__ = "tinyhat"
+
+from .platform import build_platform_client
+from .platform import computer_api_path
+from .secret_handoff import (
+    DEFAULT_EXPIRES_IN_SECONDS,
+    SecretHandoffError,
+    _claim_handoff,
+    _install_submitted_secret,
+    _parse_expires_at,
+    _public_failure_message,
+)
+
+
+def run_worker(*, handoff_id: str, key_path: Path) -> None:
+    client, platform_auth = build_platform_client()
+    try:
+        private_key_pem = key_path.read_text(encoding="utf-8")
+        deadline = time.time() + DEFAULT_EXPIRES_IN_SECONDS
+        while time.time() < deadline:
+            state = client.get_json(
+                computer_api_path(
+                    platform_auth,
+                    f"private-secret-handoffs/v1/{handoff_id}",
+                )
+            )
+            parsed_deadline = _parse_expires_at(state.get("expires_at"))
+            if parsed_deadline is not None:
+                deadline = parsed_deadline
+            status = str(state.get("status") or "").strip()
+            if status == "submitted":
+                _install_submitted_secret(
+                    client=client,
+                    platform_auth=platform_auth,
+                    handoff_id=handoff_id,
+                    private_key_pem=private_key_pem,
+                    state=state,
+                )
+                return
+            if status in {"claimed", "expired", "failed"}:
+                return
+            poll_after = max(1.0, float(state.get("poll_after_ms") or 2000) / 1000)
+            time.sleep(poll_after)
+        _claim_handoff(
+            client,
+            platform_auth,
+            handoff_id,
+            installed=False,
+            message="Secret entry expired before a value was submitted.",
+        )
+    except Exception as exc:
+        try:
+            _claim_handoff(
+                client,
+                platform_auth,
+                handoff_id,
+                installed=False,
+                message=_public_failure_message(exc),
+            )
+        except Exception:
+            pass
+        if isinstance(exc, SecretHandoffError):
+            raise SystemExit(1) from exc
+        raise
+    finally:
+        _cleanup_key_path(key_path)
+
+
+def _cleanup_key_path(key_path: Path) -> None:
+    try:
+        key_path.unlink()
+    except OSError:
+        pass
+    try:
+        shutil.rmtree(key_path.parent)
+    except OSError:
+        pass
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--handoff-id", required=True)
+    parser.add_argument("--key-path", required=True)
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    run_worker(handoff_id=args.handoff_id, key_path=Path(args.key_path))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/skills/tinyhat-private-secret/SKILL.md
+++ b/skills/tinyhat-private-secret/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: tinyhat-private-secret
-description: Start a private Tinyhat secret handoff. Use when the user asks to add, save, create, update, or connect an API key, token, password, credential, webhook secret, or other secret for this agent.
+description: Start a secure Tinyhat secret entry flow. Use when the user asks to add, save, create, update, or connect an API key, token, password, credential, webhook secret, or other secret for this agent.
 ---
 
 # Tinyhat Private Secret
@@ -8,8 +8,8 @@ description: Start a private Tinyhat secret handoff. Use when the user asks to a
 Use this when the user wants to add a secret or credential to the
 current Tinyhat-managed Computer.
 
-Never ask the user to paste the secret value in chat. Start a private
-handoff instead:
+Never ask the user to paste the secret value in chat. Start a secure
+secret entry instead:
 
 1. Pick a specific env-style name from the user's request. If the user
    says "my Exa API key", use `EXA_API_KEY`. If they say GitHub token,
@@ -18,13 +18,13 @@ handoff instead:
 2. Add a short plain-English description that helps the user remember
    why the secret exists.
 3. Call `tinyhat_private_secret_handoff` with `name` and `description`.
-4. Let the returned message stand. Tinyhat already sends the secure
-   button.
+4. Call the tool once. Let the returned message stand. Tinyhat already
+   sends the secure button.
 
 Do not use generic names such as `TINYHAT_SECRET`, `SECRET`, `API_KEY`,
 `TOKEN`, `PASSWORD`, or `CREDENTIAL`. If the provider or purpose is not
 clear enough to choose a meaningful name, ask one short clarification
-question before starting the handoff.
+question before starting secret entry.
 
 Use these common names when they match the user request:
 
@@ -41,14 +41,16 @@ Use these common names when they match the user request:
 | Telegram bot token | `TELEGRAM_BOT_TOKEN` |
 | Slack bot token | `SLACK_BOT_TOKEN` |
 
-The handoff works like a device flow. This Computer creates a one-time
+The secure entry flow works like a device flow. This Computer creates a one-time
 key pair. The Tinyhat page encrypts the secret in the user's browser
 with the public key, and this Computer decrypts it with the temporary
-private key. Tinyhat stores only encrypted ciphertext during the handoff.
+private key. Tinyhat stores only encrypted ciphertext during the short
+entry window.
 
 If the entry window expires, ask the user whether to create a new secure
 link. Do not reuse old links.
 
-Keep the chat response short. Do not render a table, exact expiration
-timestamp, status field, raw URL, JSON payload, or extra explanation. The
-button is the main action.
+Keep the chat response short. Do not render a second message with a
+button, a table, exact expiration timestamp, status field, raw URL, JSON
+payload, or extra explanation. The button that Tinyhat already sent is
+the main action.

--- a/test/test_hermes_adapter.py
+++ b/test/test_hermes_adapter.py
@@ -4,7 +4,9 @@ from __future__ import annotations
 
 import json
 import importlib.util
+import subprocess
 import sys
+import tempfile
 import unittest
 from pathlib import Path
 
@@ -28,6 +30,7 @@ else:
     import tinyhat  # noqa: E402
 
 from tinyhat import secret_handoff, tools  # noqa: E402
+from tinyhat import secret_handoff_worker  # noqa: E402
 
 
 class FakeHermesContext:
@@ -116,32 +119,39 @@ class HermesAdapterTests(unittest.TestCase):
         fake_client = FakeClient()
         original_build = secret_handoff.build_platform_client
         original_generate = secret_handoff._generate_key_pair
-        original_worker = secret_handoff._poll_and_install_secret
+        worker_calls: list[dict] = []
+        original_worker = secret_handoff._start_worker_process
         try:
             secret_handoff.build_platform_client = lambda: (fake_client, "local_dev")
             secret_handoff._generate_key_pair = lambda: ("PRIVATE", "PUBLIC")
-            secret_handoff._poll_and_install_secret = lambda **_: None
+            secret_handoff._start_worker_process = lambda handoff, private_key_pem: worker_calls.append(
+                {"handoff": handoff, "private_key_pem": private_key_pem}
+            )
 
             reply = tools.private_secret_handoff(
                 {
                     "name": "github_token",
                     "description": "GitHub access for repository tasks",
+                    "expires_in_seconds": 600,
                 }
             )
         finally:
             secret_handoff.build_platform_client = original_build
             secret_handoff._generate_key_pair = original_generate
-            secret_handoff._poll_and_install_secret = original_worker
+            secret_handoff._start_worker_process = original_worker
 
         self.assertEqual(
             fake_client.path,
             "/hapi/v1/computers/local-dev/private-secret-handoffs/v1",
         )
         self.assertEqual(fake_client.payload["name"], "GITHUB_TOKEN")
-        self.assertIn("Tap Enter secret", reply)
+        self.assertEqual(fake_client.payload["expires_in_seconds"], 300)
+        self.assertEqual(worker_calls[0]["private_key_pem"], "PRIVATE")
+        self.assertIn("I sent the secure Enter secret button", reply)
         self.assertIn("GITHUB_TOKEN", reply)
         self.assertIn("within about 5 minutes", reply)
         self.assertIn("never sees the plaintext", reply)
+        self.assertNotIn("handoff", reply.lower())
         self.assertNotIn("Expires", reply)
         self.assertNotIn("waiting_for_user", reply)
         self.assertFalse(reply.strip().startswith("{"))
@@ -163,11 +173,11 @@ class HermesAdapterTests(unittest.TestCase):
         fake_client = FakeClient()
         original_build = secret_handoff.build_platform_client
         original_generate = secret_handoff._generate_key_pair
-        original_worker = secret_handoff._poll_and_install_secret
+        original_worker = secret_handoff._start_worker_process
         try:
             secret_handoff.build_platform_client = lambda: (fake_client, "local_dev")
             secret_handoff._generate_key_pair = lambda: ("PRIVATE", "PUBLIC")
-            secret_handoff._poll_and_install_secret = lambda **_: None
+            secret_handoff._start_worker_process = lambda *_: None
 
             reply = tools.private_secret_handoff(
                 {
@@ -178,9 +188,52 @@ class HermesAdapterTests(unittest.TestCase):
         finally:
             secret_handoff.build_platform_client = original_build
             secret_handoff._generate_key_pair = original_generate
-            secret_handoff._poll_and_install_secret = original_worker
+            secret_handoff._start_worker_process = original_worker
 
         self.assertEqual(fake_client.payload["name"], "EXA_API_KEY")
+        self.assertIn("EXA_API_KEY", reply)
+
+    def test_private_secret_handoff_does_not_start_second_worker_for_existing_pending(
+        self,
+    ) -> None:
+        class FakeClient:
+            def post_json(self, path: str, payload: dict) -> dict:
+                self.path = path
+                self.payload = payload
+                return {
+                    "handoff_id": "sh_existing",
+                    "existing_handoff": True,
+                    "status": "pending",
+                    "secret_name": payload["name"],
+                    "description": payload["description"],
+                    "expires_at": "2026-06-29T12:00:00Z",
+                    "poll_after_ms": 2000,
+                }
+
+        fake_client = FakeClient()
+        worker_calls: list[dict] = []
+        original_build = secret_handoff.build_platform_client
+        original_generate = secret_handoff._generate_key_pair
+        original_worker = secret_handoff._start_worker_process
+        try:
+            secret_handoff.build_platform_client = lambda: (fake_client, "local_dev")
+            secret_handoff._generate_key_pair = lambda: ("PRIVATE", "PUBLIC")
+            secret_handoff._start_worker_process = lambda handoff, private_key_pem: worker_calls.append(
+                {"handoff": handoff, "private_key_pem": private_key_pem}
+            )
+
+            reply = tools.private_secret_handoff(
+                {
+                    "name": "EXA_API_KEY",
+                    "description": "Exa API key for search",
+                }
+            )
+        finally:
+            secret_handoff.build_platform_client = original_build
+            secret_handoff._generate_key_pair = original_generate
+            secret_handoff._start_worker_process = original_worker
+
+        self.assertEqual(worker_calls, [])
         self.assertIn("EXA_API_KEY", reply)
 
     def test_private_secret_handoff_rejects_generic_unknown_name(self) -> None:
@@ -235,6 +288,75 @@ class HermesAdapterTests(unittest.TestCase):
         finally:
             secret_handoff._decrypt_ciphertext = original_decrypt
             secret_handoff._set_hermes_secret = original_set
+
+        self.assertEqual(fake_client.claim_payloads[-1]["installed"], False)
+        self.assertEqual(
+            fake_client.claim_payloads[-1]["message"],
+            "Hermes could not save this secret.",
+        )
+        self.assertNotIn("super-secret-value", json.dumps(fake_client.claim_payloads))
+
+    def test_worker_script_bootstraps_from_non_package_checkout(self) -> None:
+        result = subprocess.run(
+            [
+                sys.executable,
+                str(REPO_ROOT / "secret_handoff_worker.py"),
+                "--help",
+            ],
+            cwd="/tmp",
+            capture_output=True,
+            text=True,
+            timeout=10,
+            check=False,
+        )
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("--handoff-id", result.stdout)
+
+    def test_live_worker_failure_message_is_sanitized(self) -> None:
+        class FakeClient:
+            def __init__(self) -> None:
+                self.claim_payloads: list[dict] = []
+
+            def get_json(self, path: str) -> dict:
+                return {
+                    "status": "submitted",
+                    "secret_name": "PRIVATE_TOKEN",
+                    "ciphertext_payload": {"algorithm": "RSA-OAEP-256"},
+                }
+
+            def post_json(self, path: str, payload: dict) -> dict:
+                self.claim_payloads.append(payload)
+                return {"status": "failed"}
+
+        fake_client = FakeClient()
+        original_build = secret_handoff_worker.build_platform_client
+        original_install = secret_handoff_worker._install_submitted_secret
+        try:
+            secret_handoff_worker.build_platform_client = lambda: (
+                fake_client,
+                "local_dev",
+            )
+            secret_handoff_worker._install_submitted_secret = lambda **_: (
+                _ for _ in ()
+            ).throw(
+                secret_handoff.SecretHandoffError(
+                    "worker echoed super-secret-value",
+                    public_message="Hermes could not save this secret.",
+                )
+            )
+            with tempfile.TemporaryDirectory(prefix="tinyhat-worker-test-") as temp_dir:
+                key_path = Path(temp_dir) / "private.pem"
+                key_path.write_text("PRIVATE", encoding="utf-8")
+
+                with self.assertRaises(SystemExit):
+                    secret_handoff_worker.run_worker(
+                        handoff_id="sh_test",
+                        key_path=key_path,
+                    )
+        finally:
+            secret_handoff_worker.build_platform_client = original_build
+            secret_handoff_worker._install_submitted_secret = original_install
 
         self.assertEqual(fake_client.claim_payloads[-1]["installed"], False)
         self.assertEqual(


### PR DESCRIPTION
## Summary

This PR makes the Tinyhat private-secret skill behave cleanly in chat:

- starts the secret-entry watcher in a detached worker so Hermes can keep running after the tool call returns
- removes timeout control from the public tool schema so the platform owns the short entry window
- makes the tool and skill copy simpler: no raw Mini App link, no exact UTC expiry, no internal “handoff” wording in the chat-facing response
- keeps duplicate pending requests from starting a second local watcher

## Scope

- Hermes plugin package files for the Tinyhat private-secret skill and tool.
- Package validation now requires the detached worker file.
- Unit tests cover readable confirmation text, meaningful secret names, duplicate pending request behavior, and secret install failure safety.

## Non-scope

- No platform API changes in this repo.
- No runtime installer changes.
- No legacy OpenClaw plugin files are added to the v0.20 branch.

## How to test

```bash
python3 scripts/validate_framework_package.py
python3 -m unittest discover -s test -p "*.py"
python3 -m compileall -q .
```

A live Hermes Computer should send the secure Telegram button itself. The assistant should not send a second raw link or repeat the button.

## Verified

```bash
python3 scripts/validate_framework_package.py && python3 -m unittest discover -s test -p "*.py" && python3 -m compileall -q .
# framework-package: ok (version 0.20.4)
# Ran 10 tests
# OK
```
