### PR TITLE
feat(plugin): add Tinyhat platform context

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,6 +24,8 @@ a fresh Hermes-only start.
 - `skills/tinyhat-tell-joke/SKILL.md`: deterministic joke proof.
 - `skills/tinyhat-plugin-version/SKILL.md`: live plugin version proof.
 - `skills/tinyhat-private-secret/SKILL.md`: private Mini App secret handoff.
+- `skills/tinyhat-platform/SKILL.md`: Tinyhat-managed Hermes operating context.
+- `context.py`: small keyword-gated Hermes `pre_llm_call` context hook.
 - `.agents/skills/tinyhat-plugin-skill-authoring/SKILL.md`: maintainer
   workflow for adding or changing plugin skills.
 

--- a/README.md
+++ b/README.md
@@ -10,10 +10,10 @@ that explain how to use Tinyhat platform capabilities without exposing
 private platform URLs, machine credentials, bot tokens, or tenant data.
 
 For the first v0.20 version, this repo is deliberately small. It supports
-Hermes only, ships two proof skills, and now includes the first real
-Tinyhat platform capability: a private secret handoff that lets the user
-enter a secret in a Telegram Mini App without sending the plaintext to
-Tinyhat's servers.
+Hermes only, ships two proof skills, a small Tinyhat context hook, and
+now includes the first real Tinyhat platform capability: a private secret
+handoff that lets the user enter a secret in a Telegram Mini App without
+sending the plaintext to Tinyhat's servers.
 
 ## What This Plugin Does
 
@@ -22,10 +22,12 @@ Tinyhat's servers.
 | `plugin.yaml` | Hermes plugin manifest. |
 | `__init__.py` | Hermes registration entrypoint. |
 | `hermes.plugin.json` | Tinyhat metadata for the Hermes adapter, skill, command, and release channels. |
+| `context.py` | Small Hermes `pre_llm_call` context hook for Tinyhat-sensitive turns. |
 | `tools.py` / `schemas.py` | Tinyhat tools: plugin version, joke proof, and private secret handoff. |
 | `skills/tinyhat-tell-joke/SKILL.md` | Deterministic joke proof. |
 | `skills/tinyhat-plugin-version/SKILL.md` | Live plugin version proof. |
 | `skills/tinyhat-private-secret/SKILL.md` | Browser-encrypted secret handoff guidance. |
+| `skills/tinyhat-platform/SKILL.md` | Platform context for Tinyhat-managed Hermes agents. |
 | `docs/skill-authoring.md` | The standard for future Tinyhat skills. |
 | `.agents/skills/tinyhat-plugin-skill-authoring/SKILL.md` | Maintainer workflow for adding or changing plugin skills. |
 | `RELEASING.md` | How releases and `channels/lts` / `channels/latest` work. |
@@ -71,6 +73,13 @@ pair, the user enters the value in a Telegram Mini App, the browser
 encrypts the value with the public key, and the Computer decrypts it with
 the temporary private key. Tinyhat stores only short-lived ciphertext for
 the handoff and wipes it after completion, expiration, or failure.
+
+`tinyhat-platform` is the operating context. It tells the agent that
+Tinyhat secrets are the default way to add credentials to Hermes and that
+Tinyhat's installed Codex auth commands should be used for OpenAI Codex
+auth and limit checks. A small `pre_llm_call` hook injects only the short
+version of that context on first turn or when the user mentions secrets,
+credentials, Tinyhat, Codex auth, or usage limits.
 
 ## Installing
 

--- a/__init__.py
+++ b/__init__.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Any
 
-from . import schemas, tools
+from . import context, schemas, tools
 
 
 def _joke_command_handler(raw_args: str = "") -> str:
@@ -21,7 +21,12 @@ def _plugin_version_command_handler(raw_args: str = "") -> str:
 
 def _private_secret_command_handler(raw_args: str = "") -> str:
     parts = raw_args.strip().split(maxsplit=1)
-    name = parts[0].strip() if parts else "TINYHAT_SECRET"
+    if not parts:
+        return (
+            "Tell me the specific secret name, for example "
+            "/tinyhat_secret EXA_API_KEY Exa API key for search."
+        )
+    name = parts[0].strip()
     description = parts[1].strip() if len(parts) > 1 else None
     return tools.private_secret_handoff(
         {"name": name, "description": description},
@@ -59,6 +64,7 @@ def register(ctx: Any) -> None:
         schema=schemas.TINYHAT_PRIVATE_SECRET_HANDOFF_SCHEMA,
         handler=tools.private_secret_handoff,
     )
+    ctx.register_hook("pre_llm_call", context.inject_tinyhat_context)
     # Hermes registers plugin slash commands by their canonical names, then
     # Telegram shows them with underscores and maps inbound underscores back to
     # hyphens before dispatch.

--- a/context.py
+++ b/context.py
@@ -1,0 +1,65 @@
+"""Tinyhat turn context for Hermes-managed Computers."""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+TINYHAT_CONTEXT = """Tinyhat context: this Hermes agent runs on a Tinyhat-managed Computer.
+- For API keys, tokens, passwords, webhook secrets, or credentials, use tinyhat_private_secret_handoff by default. Do not ask the user to paste secrets in chat and do not lead with manual .env editing unless the user explicitly asks for manual server operations.
+- Choose meaningful env-style names such as EXA_API_KEY, OPENROUTER_API_KEY, GITHUB_TOKEN, or STRIPE_SECRET_KEY. Never use TINYHAT_SECRET for a known provider.
+- For OpenAI Codex auth or usage limits, prefer the Tinyhat-installed /codex_auth, /codex_auth_status, /codex_auth_log, and /codex_limits flows. The auth flow sends the Telegram button and copyable device code; do not ask for auth.json, refresh tokens, passwords, or raw OAuth tokens.
+- Load tinyhat:tinyhat-platform, tinyhat:tinyhat-private-secret, or tinyhat:tinyhat-plugin-version when you need the longer Tinyhat playbook."""
+
+_CONTEXT_KEYWORDS = (
+    "api key",
+    "apikey",
+    "token",
+    "secret",
+    "credential",
+    "password",
+    "webhook secret",
+    "exa",
+    "openrouter",
+    "github token",
+    "stripe",
+    "tavily",
+    "firecrawl",
+    "codex",
+    "openai",
+    "chatgpt",
+    "usage limit",
+    "usage limits",
+    "quota",
+    "credits",
+    "subscription",
+    "auth",
+    "login",
+    "sign in",
+    "settings",
+    "tinyhat",
+)
+
+
+def should_inject_tinyhat_context(user_message: str, *, is_first_turn: bool = False) -> bool:
+    """Return whether this turn benefits from Tinyhat operating context."""
+    if is_first_turn:
+        return True
+    normalized = " ".join((user_message or "").lower().split())
+    return any(keyword in normalized for keyword in _CONTEXT_KEYWORDS)
+
+
+def inject_tinyhat_context(
+    session_id: str | None = None,
+    user_message: str = "",
+    conversation_history: list[Any] | None = None,
+    is_first_turn: bool = False,
+    model: str | None = None,
+    platform: str | None = None,
+    **_: Any,
+) -> dict[str, str] | None:
+    """Hermes pre_llm_call hook that adds compact Tinyhat context when useful."""
+    _ = (session_id, conversation_history, model, platform)
+    if not should_inject_tinyhat_context(user_message, is_first_turn=is_first_turn):
+        return None
+    return {"context": TINYHAT_CONTEXT}

--- a/context.py
+++ b/context.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import re
 from typing import Any
 
 
@@ -11,31 +12,42 @@ TINYHAT_CONTEXT = """Tinyhat context: this Hermes agent runs on a Tinyhat-manage
 - For OpenAI Codex auth or usage limits, prefer the Tinyhat-installed /codex_auth, /codex_auth_status, /codex_auth_log, and /codex_limits flows. The auth flow sends the Telegram button and copyable device code; do not ask for auth.json, refresh tokens, passwords, or raw OAuth tokens.
 - Load tinyhat:tinyhat-platform, tinyhat:tinyhat-private-secret, or tinyhat:tinyhat-plugin-version when you need the longer Tinyhat playbook."""
 
-_CONTEXT_KEYWORDS = (
+_CONTEXT_PHRASES = (
     "api key",
-    "apikey",
-    "token",
-    "secret",
-    "credential",
-    "password",
+    "api token",
+    "access token",
+    "auth token",
+    "bot token",
+    "github token",
+    "oauth token",
+    "refresh token",
     "webhook secret",
+    "usage limit",
+    "usage limits",
+    "sign in",
+)
+
+_CONTEXT_TERMS = (
+    "apikey",
+    "secret",
+    "secrets",
+    "credential",
+    "credentials",
+    "password",
+    "passwords",
     "exa",
     "openrouter",
-    "github token",
     "stripe",
     "tavily",
     "firecrawl",
     "codex",
     "openai",
     "chatgpt",
-    "usage limit",
-    "usage limits",
     "quota",
     "credits",
     "subscription",
     "auth",
     "login",
-    "sign in",
     "settings",
     "tinyhat",
 )
@@ -46,7 +58,10 @@ def should_inject_tinyhat_context(user_message: str, *, is_first_turn: bool = Fa
     if is_first_turn:
         return True
     normalized = " ".join((user_message or "").lower().split())
-    return any(keyword in normalized for keyword in _CONTEXT_KEYWORDS)
+    if any(phrase in normalized for phrase in _CONTEXT_PHRASES):
+        return True
+    terms = set(re.findall(r"[a-z0-9_]+", normalized))
+    return any(term in terms for term in _CONTEXT_TERMS)
 
 
 def inject_tinyhat_context(

--- a/context.py
+++ b/context.py
@@ -58,9 +58,13 @@ def should_inject_tinyhat_context(user_message: str, *, is_first_turn: bool = Fa
     if is_first_turn:
         return True
     normalized = " ".join((user_message or "").lower().split())
-    if any(phrase in normalized for phrase in _CONTEXT_PHRASES):
+    normalized_for_terms = re.sub(r"[_-]+", " ", normalized)
+    if any(
+        phrase in normalized or phrase in normalized_for_terms
+        for phrase in _CONTEXT_PHRASES
+    ):
         return True
-    terms = set(re.findall(r"[a-z0-9_]+", normalized))
+    terms = set(re.findall(r"[a-z0-9]+", normalized_for_terms))
     return any(term in terms for term in _CONTEXT_TERMS)
 
 

--- a/docs/capabilities.md
+++ b/docs/capabilities.md
@@ -7,6 +7,7 @@ The current capability list is intentionally small.
 | `tinyhat_plugin_version` | Available now | Proves which Tinyhat plugin version Hermes has loaded for the live agent. |
 | `tinyhat_tell_joke` | Available now | Proves Hermes loaded the Tinyhat plugin and can call a plugin tool. |
 | `tinyhat_private_secret_handoff` | Available now | Lets a user enter a secret in a Telegram Mini App while Tinyhat stores only short-lived ciphertext. |
+| `pre_llm_call` context | Available now | Gives Hermes a short Tinyhat operating reminder on first turn and Tinyhat-sensitive requests. |
 
 Each capability should be visible in this document, represented by a small
 tool or skill, and covered by validation.
@@ -21,6 +22,14 @@ The agent must not ask for the secret in chat. Instead, it calls
 pair, the Mini App encrypts the entered value with the public key, and the
 Computer decrypts the submitted ciphertext with the temporary private key.
 Tinyhat stores only ciphertext during the short handoff window.
+
+## Tinyhat Platform Context
+
+The plugin injects a short context note when the user asks about secrets,
+credentials, Tinyhat, Codex auth, usage limits, or on the first turn of a
+session. The context tells the agent to prefer Tinyhat private secret
+entry for credentials and Tinyhat's installed Codex commands for OpenAI
+Codex auth. The longer playbook lives in `skills/tinyhat-platform/SKILL.md`.
 
 ## Capability Rules
 

--- a/docs/skill-authoring.md
+++ b/docs/skill-authoring.md
@@ -37,6 +37,9 @@ description: Tell a short Tinyhat wiring-test joke when the user asks for proof 
 - For credentials, require meaningful env-style names. Use
   `EXA_API_KEY`, `GITHUB_TOKEN`, or `STRIPE_SECRET_KEY`; never use
   `TINYHAT_SECRET`, `SECRET`, `API_KEY`, or `TOKEN`.
+- For Tinyhat-managed Hermes behavior that should be visible before a
+  specific skill loads, use a short `pre_llm_call` context hook and keep
+  the longer playbook in a skill.
 - Add or update tests when changing a skill's tool contract, naming
   behavior, security wording, or framework adapter registration.
 
@@ -66,6 +69,12 @@ user can recognize later without seeing the value.
 If the provider or purpose is ambiguous, ask one short clarification
 question before creating the handoff.
 
+## Tinyhat Platform Context
+
+Use `pre_llm_call` only for short operating context that should be visible
+before a specific Tinyhat skill is loaded. Keep the detailed instructions
+inside skills so the plugin stays readable and token efficient.
+
 ## Current Skills
 
 `tinyhat-tell-joke` is intentionally small. It proves the plugin is
@@ -74,3 +83,11 @@ installed before we add real Tinyhat platform capabilities.
 `tinyhat-plugin-version` proves which plugin version Hermes is actually
 running. Use it for update tests so we do not confuse admin metadata with
 the live plugin code loaded in an agent session.
+
+`tinyhat-private-secret` is the default way to add credentials to Hermes.
+It should be triggered before generic `.env` advice whenever a user asks
+to add or save an API key, token, password, or credential.
+
+`tinyhat-platform` is the compact operating map for Tinyhat-managed
+Hermes agents. It explains secrets, Codex auth commands, usage limit
+commands, and the runtime/plugin/platform boundary.

--- a/hermes.plugin.json
+++ b/hermes.plugin.json
@@ -25,6 +25,11 @@
       "name": "tinyhat-private-secret",
       "path": "skills/tinyhat-private-secret/SKILL.md",
       "purpose": "Starts a private browser-encrypted secret handoff to the assigned Computer."
+    },
+    {
+      "name": "tinyhat-platform",
+      "path": "skills/tinyhat-platform/SKILL.md",
+      "purpose": "Explains Tinyhat-managed Hermes defaults for secrets, Codex auth, and platform boundaries."
     }
   ],
   "tools": [

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -7,3 +7,5 @@ provides_tools:
   - tinyhat_plugin_version
   - tinyhat_tell_joke
   - tinyhat_private_secret_handoff
+provides_hooks:
+  - pre_llm_call

--- a/schemas.py
+++ b/schemas.py
@@ -19,6 +19,11 @@ TINYHAT_TELL_JOKE_SCHEMA = {
 
 TINYHAT_PRIVATE_SECRET_HANDOFF_SCHEMA = {
     "type": "object",
+    "description": (
+        "Default Tinyhat way to add API keys, tokens, passwords, webhook secrets, "
+        "or other credentials to this Hermes Computer. Use this instead of telling "
+        "the user to edit .env files or paste secret values in chat."
+    ),
     "properties": {
         "name": {
             "type": "string",

--- a/scripts/validate_framework_package.py
+++ b/scripts/validate_framework_package.py
@@ -24,6 +24,7 @@ REQUIRED_SKILLS = [
     "tinyhat-plugin-version",
     "tinyhat-tell-joke",
     "tinyhat-private-secret",
+    "tinyhat-platform",
 ]
 FORBIDDEN_PATHS = (
     "openclaw.plugin.json",
@@ -154,6 +155,7 @@ def validate_hermes_adapter(root: Path) -> None:
         "tinyhat-plugin-version": "skills/tinyhat-plugin-version/SKILL.md",
         "tinyhat-tell-joke": "skills/tinyhat-tell-joke/SKILL.md",
         "tinyhat-private-secret": "skills/tinyhat-private-secret/SKILL.md",
+        "tinyhat-platform": "skills/tinyhat-platform/SKILL.md",
     }
     for skill in skills:
         require(isinstance(skill, dict), "skill declaration must be an object")
@@ -201,6 +203,7 @@ def validate_fresh_surface(root: Path) -> None:
         root / "hermes.plugin.json",
         root / "__init__.py",
         root / "platform.py",
+        root / "context.py",
         root / "secret_handoff.py",
         root / "secret_handoff_worker.py",
         root / "schemas.py",
@@ -227,6 +230,8 @@ def validate_docs(root: Path) -> None:
             "tinyhat-tell-joke",
             "tinyhat-plugin-version",
             "tinyhat-private-secret",
+            "tinyhat-platform",
+            "pre_llm_call",
             "channels/lts",
             "channels/latest",
         ),
@@ -234,6 +239,7 @@ def validate_docs(root: Path) -> None:
             "Tinyhat skills are public instructions",
             "Do not ask the user to paste secret values in chat.",
             "Secret Naming Standard",
+            "Tinyhat Platform Context",
         ),
         ".agents/skills/tinyhat-plugin-skill-authoring/SKILL.md": (
             "Create, modify, or review Tinyhat plugin skills.",

--- a/skills/tinyhat-platform/SKILL.md
+++ b/skills/tinyhat-platform/SKILL.md
@@ -1,0 +1,65 @@
+---
+name: tinyhat-platform
+description: Explain how this Hermes agent should use Tinyhat platform capabilities. Use for Tinyhat-managed Computers, secrets, API keys, credentials, Codex auth, usage limits, settings, or questions about where the agent is running.
+---
+
+# Tinyhat Platform
+
+You are running on a Tinyhat-managed Hermes Computer. Tinyhat provides
+the safe platform flows around Hermes; Hermes is still the agent
+framework.
+
+Use this as the default routing map:
+
+| User intent | Default Tinyhat route |
+| --- | --- |
+| Add or save an API key, token, password, webhook secret, or credential | Call `tinyhat_private_secret_handoff` once. |
+| Ask which Tinyhat plugin is running | Call `tinyhat_plugin_version`. |
+| Check that the Tinyhat plugin exists | Call `tinyhat_tell_joke` or `tinyhat_plugin_version`. |
+| Connect OpenAI Codex auth or use the user's OpenAI paid access | Use the installed `/codex_auth` flow. |
+| Check Codex auth | Use `/codex_auth_status`. |
+| Inspect recent Codex auth output | Use `/codex_auth_log`. |
+| Show Codex usage limits | Use `/codex_limits`. |
+
+## Secrets
+
+For secrets and credentials, Tinyhat private secret entry is the default.
+Do not lead with manual `.env` editing. Do not ask the user to paste a
+secret into chat.
+
+When the user says something like "add my Exa API key":
+
+1. Choose the specific env-style name, for example `EXA_API_KEY`.
+2. Call `tinyhat_private_secret_handoff` with `name` and a short
+   description.
+3. Let the Tinyhat-sent button stand.
+4. Keep the chat reply short.
+
+Load `tinyhat:tinyhat-private-secret` when you need the full naming and
+failure-handling rules.
+
+## Codex Auth
+
+Tinyhat installs Telegram commands for Codex auth during Computer setup.
+The important one is `/codex_auth`.
+
+When the user asks to connect OpenAI Codex or their OpenAI paid access:
+
+1. Prefer the Tinyhat `/codex_auth` flow. If your interface can run
+   slash commands, run `/codex_auth`. If it cannot, tell the user to
+   send `/codex_auth`.
+2. The command sends an OpenAI auth button and then a separate copyable
+   device code in Telegram.
+3. Do not paste raw auth URLs unless the Tinyhat command reports that
+   Telegram delivery failed.
+4. Do not ask for `auth.json`, passwords, refresh tokens, API keys, or
+   OAuth tokens.
+5. After the user signs in, use `/codex_auth_status` if you need proof,
+   and `/codex_limits` if they ask about remaining limits.
+
+## Boundary
+
+The runtime is the boring control plane: identity, heartbeat, install,
+updates, and a closed maintenance command set. Product behavior belongs
+in Tinyhat platform APIs plus this plugin's skills and tools. Do not
+invent runtime commands for product features.

--- a/skills/tinyhat-private-secret/SKILL.md
+++ b/skills/tinyhat-private-secret/SKILL.md
@@ -8,6 +8,11 @@ description: Start a secure Tinyhat secret entry flow. Use when the user asks to
 Use this when the user wants to add a secret or credential to the
 current Tinyhat-managed Computer.
 
+This is the default path for adding credentials to Hermes on Tinyhat.
+Do not answer first with manual `.env` file edits, `hermes config
+env-path`, or shell instructions unless the user explicitly asks for a
+manual server operation.
+
 Never ask the user to paste the secret value in chat. Start a secure
 secret entry instead:
 
@@ -19,7 +24,8 @@ secret entry instead:
    why the secret exists.
 3. Call `tinyhat_private_secret_handoff` with `name` and `description`.
 4. Call the tool once. Let the returned message stand. Tinyhat already
-   sends the secure button.
+   sends the secure button. Do not add a second link or duplicate
+   instructions.
 
 Do not use generic names such as `TINYHAT_SECRET`, `SECRET`, `API_KEY`,
 `TOKEN`, `PASSWORD`, or `CREDENTIAL`. If the provider or purpose is not
@@ -54,3 +60,7 @@ Keep the chat response short. Do not render a second message with a
 button, a table, exact expiration timestamp, status field, raw URL, JSON
 payload, or extra explanation. The button that Tinyhat already sent is
 the main action.
+
+If the user later asks you to test the secret, you may load the Hermes
+env in a shell command, but never print the secret value. Report only
+whether it is set and any non-secret test result.

--- a/test/test_hermes_adapter.py
+++ b/test/test_hermes_adapter.py
@@ -30,6 +30,7 @@ else:
     import tinyhat  # noqa: E402
 
 from tinyhat import secret_handoff, tools  # noqa: E402
+from tinyhat import context as tinyhat_context  # noqa: E402
 from tinyhat import secret_handoff_worker  # noqa: E402
 
 
@@ -38,6 +39,7 @@ class FakeHermesContext:
         self.tools: dict[str, dict] = {}
         self.commands: dict[str, dict] = {}
         self.skills: dict[str, Path] = {}
+        self.hooks: dict[str, list] = {}
 
     def register_tool(self, **kwargs) -> None:
         self.tools[kwargs["name"]] = kwargs
@@ -47,6 +49,9 @@ class FakeHermesContext:
 
     def register_skill(self, name: str, skill_md: Path) -> None:
         self.skills[name] = skill_md
+
+    def register_hook(self, name: str, handler) -> None:
+        self.hooks.setdefault(name, []).append(handler)
 
 
 class HermesAdapterTests(unittest.TestCase):
@@ -61,12 +66,15 @@ class HermesAdapterTests(unittest.TestCase):
         self.assertIn("tinyhat-plugin-version", ctx.commands)
         self.assertIn("tinyhat-joke", ctx.commands)
         self.assertIn("tinyhat-secret", ctx.commands)
+        self.assertIn("pre_llm_call", ctx.hooks)
         self.assertIn("tinyhat-plugin-version", ctx.skills)
         self.assertIn("tinyhat-tell-joke", ctx.skills)
         self.assertIn("tinyhat-private-secret", ctx.skills)
+        self.assertIn("tinyhat-platform", ctx.skills)
         self.assertTrue(ctx.skills["tinyhat-plugin-version"].is_file())
         self.assertTrue(ctx.skills["tinyhat-tell-joke"].is_file())
         self.assertTrue(ctx.skills["tinyhat-private-secret"].is_file())
+        self.assertTrue(ctx.skills["tinyhat-platform"].is_file())
 
     def test_registered_commands_match_telegram_dispatch_names(self) -> None:
         ctx = FakeHermesContext()
@@ -87,6 +95,39 @@ class HermesAdapterTests(unittest.TestCase):
         self.assertEqual(payload["schema"], "tinyhat_plugin_version_v1")
         self.assertEqual(payload["name"], "tinyhat")
         self.assertEqual(payload["version"], "0.20.4")
+
+    def test_context_hook_injects_for_secret_requests(self) -> None:
+        ctx = FakeHermesContext()
+        tinyhat.register(ctx)
+
+        injected = ctx.hooks["pre_llm_call"][0](
+            user_message="I want to add my Exa API key",
+            is_first_turn=False,
+        )
+
+        self.assertIsNotNone(injected)
+        assert injected is not None
+        self.assertIn("tinyhat_private_secret_handoff", injected["context"])
+        self.assertIn("Do not ask the user to paste secrets", injected["context"])
+        self.assertIn("/codex_auth", injected["context"])
+
+    def test_context_hook_skips_unrelated_later_turns(self) -> None:
+        self.assertIsNone(
+            tinyhat_context.inject_tinyhat_context(
+                user_message="Tell me a short poem about the moon",
+                is_first_turn=False,
+            )
+        )
+
+    def test_context_hook_injects_on_first_turn(self) -> None:
+        injected = tinyhat_context.inject_tinyhat_context(
+            user_message="hello",
+            is_first_turn=True,
+        )
+
+        self.assertIsNotNone(injected)
+        assert injected is not None
+        self.assertIn("Tinyhat-managed Computer", injected["context"])
 
     def test_tell_joke_returns_stable_json(self) -> None:
         payload = json.loads(tools.tell_joke({"topic": "Hermes"}))

--- a/test/test_hermes_adapter.py
+++ b/test/test_hermes_adapter.py
@@ -111,6 +111,22 @@ class HermesAdapterTests(unittest.TestCase):
         self.assertIn("Do not ask the user to paste secrets", injected["context"])
         self.assertIn("/codex_auth", injected["context"])
 
+    def test_context_hook_injects_for_env_style_secret_names(self) -> None:
+        for secret_name in (
+            "EXA_API_KEY",
+            "OPENROUTER_API_KEY",
+            "GITHUB_TOKEN",
+            "STRIPE_SECRET_KEY",
+            "TAVILY_API_KEY",
+            "FIRECRAWL_API_KEY",
+        ):
+            with self.subTest(secret_name=secret_name):
+                injected = tinyhat_context.inject_tinyhat_context(
+                    user_message=f"Please add {secret_name}",
+                    is_first_turn=False,
+                )
+                self.assertIsNotNone(injected)
+
     def test_context_hook_skips_unrelated_later_turns(self) -> None:
         self.assertIsNone(
             tinyhat_context.inject_tinyhat_context(

--- a/test/test_hermes_adapter.py
+++ b/test/test_hermes_adapter.py
@@ -118,6 +118,12 @@ class HermesAdapterTests(unittest.TestCase):
                 is_first_turn=False,
             )
         )
+        self.assertIsNone(
+            tinyhat_context.inject_tinyhat_context(
+                user_message="Write an author bio and estimate token count",
+                is_first_turn=False,
+            )
+        )
 
     def test_context_hook_injects_on_first_turn(self) -> None:
         injected = tinyhat_context.inject_tinyhat_context(
@@ -128,6 +134,15 @@ class HermesAdapterTests(unittest.TestCase):
         self.assertIsNotNone(injected)
         assert injected is not None
         self.assertIn("Tinyhat-managed Computer", injected["context"])
+
+    def test_tinyhat_secret_command_without_args_returns_usage(self) -> None:
+        ctx = FakeHermesContext()
+        tinyhat.register(ctx)
+
+        reply = ctx.commands["tinyhat-secret"]["handler"]("")
+
+        self.assertIn("/tinyhat_secret EXA_API_KEY", reply)
+        self.assertNotIn("TINYHAT_SECRET", reply)
 
     def test_tell_joke_returns_stable_json(self) -> None:
         payload = json.loads(tools.tell_joke({"topic": "Hermes"}))


### PR DESCRIPTION
## Summary

- add a small Hermes `pre_llm_call` context hook for Tinyhat-sensitive turns
- add `tinyhat-platform` skill so Hermes agents default to Tinyhat secrets and Codex auth flows
- sharpen private-secret guidance, schemas, docs, and tests so manual `.env` setup is not the default answer

## Research

- Added Drive memo: `Tinyhat Docs/divergent-research/2026-06-29-hermes-agent-tinyhat-platform-context/01-hermes-agent-tinyhat-platform-context.md`
- Updated the engineering playbook note in `capabilities-architecture.md` to state that platform-default agent behavior belongs in plugin context and skills.

## Verification

- `python3 scripts/validate_framework_package.py`
- `python3 -m unittest discover -s test -p "*.py"`
- `python3 -m compileall -q .`
- `git diff --check`
