### PR TITLE
fix(plugin): reload Hermes after saving secrets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ All notable changes to the Tinyhat plugin are documented here.
 - Route natural-language Codex subscription requests to the screenshot
   prerequisite helper by default, so the user sees the ChatGPT Settings >
   Security visual guide and `/codex_auth` without duplicate text replies.
+- Reload Hermes after private secrets are saved so new env values are
+  available to the next agent tool call without manual shell sourcing.
 - Teach the private secret skill and tool to use meaningful env-style names
   such as `EXA_API_KEY` instead of generic placeholders like
   `TINYHAT_SECRET`.

--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ For development or manual testing, use `channels/latest` or an exact tag:
 
 ```bash
 TINYHAT_PLUGIN_REF=channels/latest
-TINYHAT_PLUGIN_REF=v0.20.10
+TINYHAT_PLUGIN_REF=v0.20.11
 ```
 
 ## Channels

--- a/hermes.plugin.json
+++ b/hermes.plugin.json
@@ -1,6 +1,6 @@
 {
   "schema": "tinyhat.framework-adapter.v1",
-  "version": "0.20.10",
+  "version": "0.20.11",
   "framework": {
     "name": "hermes",
     "minimum": "0.0.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tinyhat",
-  "version": "0.20.10",
+  "version": "0.20.11",
   "description": "Hermes plugin that teaches agents how to use Tinyhat platform capabilities.",
   "private": true,
   "files": [

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -1,5 +1,5 @@
 name: tinyhat
-version: 0.20.10
+version: 0.20.11
 description: Framework-neutral Tinyhat platform skills and tools.
 kind: standalone
 author: Tinyloop

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "tinyhat"
-version = "0.20.10"
+version = "0.20.11"
 description = "Hermes plugin that teaches agents how to use Tinyhat platform capabilities."
 readme = "README.md"
 requires-python = ">=3.9"

--- a/secret_handoff.py
+++ b/secret_handoff.py
@@ -373,16 +373,17 @@ def _reload_hermes_gateway_after_secret() -> dict[str, Any]:
     recovery_start = None
     recovery_status = None
     if not healthy:
+        recovery_log_offset = _gateway_log_size(foreground_log) or foreground_log_offset
         recovery_start = _run_gateway_command([hermes, "gateway", "start"], timeout=60)
         recovery_status = _wait_for_healthy_gateway(
             hermes,
             timeout_seconds=12,
             log_path=foreground_log,
-            log_start_offset=foreground_log_offset,
+            log_start_offset=recovery_log_offset,
         )
         adapter_failure = _gateway_log_has_adapter_failure(
             foreground_log,
-            since_byte=foreground_log_offset,
+            since_byte=recovery_log_offset,
         )
         healthy = _gateway_status_is_healthy(recovery_status) and not adapter_failure
 
@@ -511,6 +512,15 @@ def _gateway_log_path() -> Path:
     return Path.home() / ".tinyhat" / GATEWAY_RELOAD_LOG_NAME
 
 
+def _gateway_log_size(path: Path | None) -> int:
+    if path is None:
+        return 0
+    try:
+        return path.stat().st_size
+    except OSError:
+        return 0
+
+
 def _gateway_log_has_adapter_failure(path: Path | None, *, since_byte: int = 0) -> bool:
     if path is None:
         return False
@@ -532,10 +542,7 @@ def _gateway_log_has_adapter_failure(path: Path | None, *, since_byte: int = 0) 
 def _start_gateway_foreground(hermes: str) -> dict[str, Any]:
     log_path = _gateway_log_path()
     log_path.parent.mkdir(parents=True, exist_ok=True)
-    try:
-        log_start_offset = log_path.stat().st_size
-    except OSError:
-        log_start_offset = 0
+    log_start_offset = _gateway_log_size(log_path)
     with log_path.open("ab") as log_file:
         process = subprocess.Popen(
             [

--- a/secret_handoff.py
+++ b/secret_handoff.py
@@ -333,20 +333,26 @@ def _reload_hermes_gateway_after_secret() -> dict[str, Any]:
         timeout=45,
     )
     start = _run_gateway_command([hermes, "gateway", "start"], timeout=180)
-    status_after_start = _run_gateway_command(
-        [hermes, "gateway", "status"],
-        timeout=45,
+    status_after_start = _wait_for_healthy_gateway(
+        hermes,
+        timeout_seconds=12,
     )
 
     foreground = None
-    if _gateway_status_is_healthy(status_after_stop) or _gateway_needs_foreground_run(
+    stop_left_gateway_running = _gateway_status_is_healthy(status_after_stop)
+    if stop_left_gateway_running or _gateway_needs_foreground_run(
         start=start,
         status=status_after_start,
     ):
+        # Local/Docker gateways may keep a foreground `gateway run` process
+        # alive even after `gateway stop`. In that case use Hermes' public
+        # replace mode so the new process gets a fresh env.
         foreground = _start_gateway_foreground(hermes)
-        status_after_start = _run_gateway_command(
-            [hermes, "gateway", "status"],
-            timeout=45,
+        status_after_start = _wait_for_healthy_gateway(
+            hermes,
+            timeout_seconds=15,
+            log_path=Path(str(foreground.get("log_path"))),
+            log_start_offset=int(foreground.get("log_start_offset") or 0),
         )
 
     foreground_log = (
@@ -354,8 +360,32 @@ def _reload_hermes_gateway_after_secret() -> dict[str, Any]:
         if isinstance(foreground, dict) and foreground.get("log_path")
         else None
     )
-    adapter_failure = _gateway_log_has_adapter_failure(foreground_log)
+    foreground_log_offset = (
+        int(foreground.get("log_start_offset") or 0)
+        if isinstance(foreground, dict)
+        else 0
+    )
+    adapter_failure = _gateway_log_has_adapter_failure(
+        foreground_log,
+        since_byte=foreground_log_offset,
+    )
     healthy = _gateway_status_is_healthy(status_after_start) and not adapter_failure
+    recovery_start = None
+    recovery_status = None
+    if not healthy:
+        recovery_start = _run_gateway_command([hermes, "gateway", "start"], timeout=60)
+        recovery_status = _wait_for_healthy_gateway(
+            hermes,
+            timeout_seconds=12,
+            log_path=foreground_log,
+            log_start_offset=foreground_log_offset,
+        )
+        adapter_failure = _gateway_log_has_adapter_failure(
+            foreground_log,
+            since_byte=foreground_log_offset,
+        )
+        healthy = _gateway_status_is_healthy(recovery_status) and not adapter_failure
+
     result = {
         "schema": "tinyhat_secret_hermes_reload_v1",
         "healthy": healthy,
@@ -366,6 +396,8 @@ def _reload_hermes_gateway_after_secret() -> dict[str, Any]:
         "start": _compact_gateway_process(start),
         "foreground": foreground,
         "status_after": _compact_gateway_process(status_after_start),
+        "recovery_start": _compact_gateway_process(recovery_start),
+        "recovery_status": _compact_gateway_process(recovery_status),
     }
     if not healthy:
         raise SecretHandoffError(
@@ -452,6 +484,26 @@ def _gateway_needs_foreground_run(
     return not _gateway_status_is_healthy(status)
 
 
+def _wait_for_healthy_gateway(
+    hermes: str,
+    *,
+    timeout_seconds: float,
+    log_path: Path | None = None,
+    log_start_offset: int = 0,
+) -> dict[str, Any]:
+    deadline = time.monotonic() + timeout_seconds
+    last_status = _run_gateway_command([hermes, "gateway", "status"], timeout=45)
+    while time.monotonic() < deadline:
+        if _gateway_status_is_healthy(last_status) and not _gateway_log_has_adapter_failure(
+            log_path,
+            since_byte=log_start_offset,
+        ):
+            return last_status
+        time.sleep(1)
+        last_status = _run_gateway_command([hermes, "gateway", "status"], timeout=45)
+    return last_status
+
+
 def _gateway_log_path() -> Path:
     state_dir = os.getenv("TINYHAT_RUNTIME_STATE_DIR")
     if state_dir:
@@ -459,11 +511,14 @@ def _gateway_log_path() -> Path:
     return Path.home() / ".tinyhat" / GATEWAY_RELOAD_LOG_NAME
 
 
-def _gateway_log_has_adapter_failure(path: Path | None) -> bool:
+def _gateway_log_has_adapter_failure(path: Path | None, *, since_byte: int = 0) -> bool:
     if path is None:
         return False
     try:
-        text = path.read_text(encoding="utf-8", errors="replace")[-8000:].lower()
+        with path.open("rb") as handle:
+            if since_byte > 0:
+                handle.seek(since_byte)
+            text = handle.read().decode("utf-8", errors="replace")[-8000:].lower()
     except OSError:
         return False
     needles = (
@@ -477,6 +532,10 @@ def _gateway_log_has_adapter_failure(path: Path | None) -> bool:
 def _start_gateway_foreground(hermes: str) -> dict[str, Any]:
     log_path = _gateway_log_path()
     log_path.parent.mkdir(parents=True, exist_ok=True)
+    try:
+        log_start_offset = log_path.stat().st_size
+    except OSError:
+        log_start_offset = 0
     with log_path.open("ab") as log_file:
         process = subprocess.Popen(
             [
@@ -500,6 +559,7 @@ def _start_gateway_foreground(hermes: str) -> dict[str, Any]:
         "started": returncode is None,
         "returncode": returncode,
         "log_path": str(log_path),
+        "log_start_offset": log_start_offset,
     }
 
 

--- a/secret_handoff.py
+++ b/secret_handoff.py
@@ -20,6 +20,7 @@ KEY_ALGORITHM = "RSA-OAEP-256"
 DEFAULT_EXPIRES_IN_SECONDS = 300
 SECRET_NAME_RE = re.compile(r"^[A-Z_][A-Z0-9_]{0,126}$")
 STATE_DIR = Path.home() / ".tinyhat" / "private-secret-handoffs"
+GATEWAY_RELOAD_LOG_NAME = "hermes-gateway.log"
 GENERIC_SECRET_NAMES = {
     "TINYHAT_SECRET",
     "SECRET",
@@ -212,6 +213,7 @@ def _install_submitted_secret(
         _set_hermes_secret(secret_name, plaintext)
     finally:
         plaintext = ""
+    _reload_hermes_gateway_after_secret()
     _claim_handoff(client, platform_auth, handoff_id, installed=True)
 
 
@@ -310,6 +312,195 @@ def _set_hermes_secret(secret_name: str, value: str) -> None:
             "Hermes config set failed.",
             public_message="Hermes could not save this secret.",
         )
+
+
+def _reload_hermes_gateway_after_secret() -> dict[str, Any]:
+    """Restart Hermes messaging so newly saved env values are live immediately."""
+    hermes = shutil.which("hermes")
+    if not hermes:
+        raise SecretHandoffError(
+            "Hermes CLI was not found while reloading the gateway.",
+            public_message=(
+                "Secret saved, but I could not reload Hermes. Send /restart "
+                "before using it."
+            ),
+        )
+
+    status_before = _run_gateway_command([hermes, "gateway", "status"], timeout=45)
+    stop = _run_gateway_command([hermes, "gateway", "stop"], timeout=60)
+    status_after_stop = _run_gateway_command(
+        [hermes, "gateway", "status"],
+        timeout=45,
+    )
+    start = _run_gateway_command([hermes, "gateway", "start"], timeout=180)
+    status_after_start = _run_gateway_command(
+        [hermes, "gateway", "status"],
+        timeout=45,
+    )
+
+    foreground = None
+    if _gateway_status_is_healthy(status_after_stop) or _gateway_needs_foreground_run(
+        start=start,
+        status=status_after_start,
+    ):
+        foreground = _start_gateway_foreground(hermes)
+        status_after_start = _run_gateway_command(
+            [hermes, "gateway", "status"],
+            timeout=45,
+        )
+
+    foreground_log = (
+        Path(str(foreground.get("log_path")))
+        if isinstance(foreground, dict) and foreground.get("log_path")
+        else None
+    )
+    adapter_failure = _gateway_log_has_adapter_failure(foreground_log)
+    healthy = _gateway_status_is_healthy(status_after_start) and not adapter_failure
+    result = {
+        "schema": "tinyhat_secret_hermes_reload_v1",
+        "healthy": healthy,
+        "adapter_ready": not adapter_failure,
+        "status_before": _compact_gateway_process(status_before),
+        "stop": _compact_gateway_process(stop),
+        "status_after_stop": _compact_gateway_process(status_after_stop),
+        "start": _compact_gateway_process(start),
+        "foreground": foreground,
+        "status_after": _compact_gateway_process(status_after_start),
+    }
+    if not healthy:
+        raise SecretHandoffError(
+            f"Hermes gateway reload failed: {result}",
+            public_message=(
+                "Secret saved, but I could not reload Hermes. Send /restart "
+                "before using it."
+            ),
+        )
+    return result
+
+
+def _run_gateway_command(command: list[str], *, timeout: int) -> dict[str, Any]:
+    started_at = time.monotonic()
+    try:
+        result = subprocess.run(
+            command,
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+            check=False,
+        )
+        duration_ms = int((time.monotonic() - started_at) * 1000)
+        return {
+            "ok": result.returncode == 0,
+            "returncode": result.returncode,
+            "timed_out": False,
+            "duration_ms": duration_ms,
+            "stdout": str(result.stdout or "")[:4000],
+            "stderr": str(result.stderr or "")[:4000],
+        }
+    except subprocess.TimeoutExpired as exc:
+        duration_ms = int((time.monotonic() - started_at) * 1000)
+        stdout = exc.stdout.decode("utf-8", "replace") if isinstance(exc.stdout, bytes) else exc.stdout
+        stderr = exc.stderr.decode("utf-8", "replace") if isinstance(exc.stderr, bytes) else exc.stderr
+        return {
+            "ok": False,
+            "returncode": None,
+            "timed_out": True,
+            "duration_ms": duration_ms,
+            "stdout": str(stdout or "")[:4000],
+            "stderr": str(stderr or "")[:4000],
+        }
+
+
+def _compact_gateway_process(result: dict[str, Any] | None) -> dict[str, Any] | None:
+    if not isinstance(result, dict):
+        return None
+    return {
+        "ok": bool(result.get("ok")),
+        "returncode": result.get("returncode"),
+        "timed_out": bool(result.get("timed_out")),
+        "duration_ms": result.get("duration_ms"),
+        "stdout": str(result.get("stdout") or "")[:1000],
+        "stderr": str(result.get("stderr") or "")[:1000],
+    }
+
+
+def _gateway_process_text(result: dict[str, Any] | None) -> str:
+    if not isinstance(result, dict):
+        return ""
+    return f"{result.get('stdout') or ''}\n{result.get('stderr') or ''}".lower()
+
+
+def _gateway_status_is_healthy(status: dict[str, Any] | None) -> bool:
+    if not isinstance(status, dict) or not status.get("ok"):
+        return False
+    text = _gateway_process_text(status)
+    if "not running" in text or "gateway is not running" in text:
+        return False
+    return True
+
+
+def _gateway_needs_foreground_run(
+    *,
+    start: dict[str, Any],
+    status: dict[str, Any],
+) -> bool:
+    text = f"{_gateway_process_text(start)}\n{_gateway_process_text(status)}"
+    if "not applicable inside a docker container" in text:
+        return True
+    if "run the gateway directly" in text:
+        return True
+    return not _gateway_status_is_healthy(status)
+
+
+def _gateway_log_path() -> Path:
+    state_dir = os.getenv("TINYHAT_RUNTIME_STATE_DIR")
+    if state_dir:
+        return Path(state_dir) / GATEWAY_RELOAD_LOG_NAME
+    return Path.home() / ".tinyhat" / GATEWAY_RELOAD_LOG_NAME
+
+
+def _gateway_log_has_adapter_failure(path: Path | None) -> bool:
+    if path is None:
+        return False
+    try:
+        text = path.read_text(encoding="utf-8", errors="replace")[-8000:].lower()
+    except OSError:
+        return False
+    needles = (
+        "platform 'telegram' requirements not met",
+        "adapter creation failed",
+        "no adapter available for telegram",
+    )
+    return any(needle in text for needle in needles)
+
+
+def _start_gateway_foreground(hermes: str) -> dict[str, Any]:
+    log_path = _gateway_log_path()
+    log_path.parent.mkdir(parents=True, exist_ok=True)
+    with log_path.open("ab") as log_file:
+        process = subprocess.Popen(
+            [
+                hermes,
+                "gateway",
+                "run",
+                "--replace",
+                "--force",
+                "--accept-hooks",
+            ],
+            stdin=subprocess.DEVNULL,
+            stdout=log_file,
+            stderr=log_file,
+            start_new_session=True,
+        )
+    time.sleep(2)
+    returncode = process.poll()
+    return {
+        "mode": "foreground_detached",
+        "pid": process.pid,
+        "started": returncode is None,
+        "returncode": returncode,
+        "log_path": str(log_path),
+    }
 
 
 def _run(command: list[str], *, text: bool = True) -> str | bytes:

--- a/test/test_hermes_adapter.py
+++ b/test/test_hermes_adapter.py
@@ -97,7 +97,7 @@ class HermesAdapterTests(unittest.TestCase):
 
         self.assertEqual(payload["schema"], "tinyhat_plugin_version_v1")
         self.assertEqual(payload["name"], "tinyhat")
-        self.assertEqual(payload["version"], "0.20.10")
+        self.assertEqual(payload["version"], "0.20.11")
 
     def test_context_hook_injects_for_secret_requests(self) -> None:
         ctx = FakeHermesContext()
@@ -525,6 +525,108 @@ class HermesAdapterTests(unittest.TestCase):
         self.assertEqual(
             fake_client.claim_payloads[-1]["message"],
             "Hermes could not save this secret.",
+        )
+        self.assertNotIn("super-secret-value", json.dumps(fake_client.claim_payloads))
+
+    def test_worker_reloads_hermes_before_claiming_secret_saved(self) -> None:
+        class FakeClient:
+            def __init__(self) -> None:
+                self.claim_payloads: list[dict] = []
+
+            def post_json(self, path: str, payload: dict) -> dict:
+                self.claim_payloads.append(payload)
+                return {"status": "claimed"}
+
+        calls: list[str] = []
+        original_decrypt = secret_handoff._decrypt_ciphertext
+        original_set = secret_handoff._set_hermes_secret
+        original_reload = secret_handoff._reload_hermes_gateway_after_secret
+        fake_client = FakeClient()
+        try:
+            secret_handoff._decrypt_ciphertext = lambda *_: "super-secret-value"
+            secret_handoff._set_hermes_secret = lambda *_: calls.append("set")
+            secret_handoff._reload_hermes_gateway_after_secret = lambda: calls.append(
+                "reload"
+            )
+
+            secret_handoff._install_submitted_secret(
+                client=fake_client,
+                platform_auth="local_dev",
+                handoff_id="sh_test",
+                private_key_pem="PRIVATE",
+                state={
+                    "secret_name": "EXA_API_KEY",
+                    "ciphertext_payload": {
+                        "algorithm": "RSA-OAEP-256",
+                        "ciphertext_b64": "ignored",
+                    },
+                },
+            )
+        finally:
+            secret_handoff._decrypt_ciphertext = original_decrypt
+            secret_handoff._set_hermes_secret = original_set
+            secret_handoff._reload_hermes_gateway_after_secret = original_reload
+
+        self.assertEqual(calls, ["set", "reload"])
+        self.assertEqual(fake_client.claim_payloads[-1]["installed"], True)
+
+    def test_worker_does_not_claim_success_when_reload_fails(self) -> None:
+        class FakeClient:
+            def __init__(self) -> None:
+                self.claim_payloads: list[dict] = []
+
+            def get_json(self, path: str) -> dict:
+                return {
+                    "status": "submitted",
+                    "secret_name": "EXA_API_KEY",
+                    "ciphertext_payload": {
+                        "algorithm": "RSA-OAEP-256",
+                        "ciphertext_b64": "ignored",
+                    },
+                }
+
+            def post_json(self, path: str, payload: dict) -> dict:
+                self.claim_payloads.append(payload)
+                return {"status": "failed"}
+
+        fake_client = FakeClient()
+        original_decrypt = secret_handoff._decrypt_ciphertext
+        original_set = secret_handoff._set_hermes_secret
+        original_reload = secret_handoff._reload_hermes_gateway_after_secret
+        try:
+            secret_handoff._decrypt_ciphertext = lambda *_: "super-secret-value"
+            secret_handoff._set_hermes_secret = lambda *_: None
+            secret_handoff._reload_hermes_gateway_after_secret = lambda: (
+                _ for _ in ()
+            ).throw(
+                secret_handoff.SecretHandoffError(
+                    "reload output mentioned super-secret-value",
+                    public_message=(
+                        "Secret saved, but I could not reload Hermes. Send /restart "
+                        "before using it."
+                    ),
+                )
+            )
+
+            secret_handoff._poll_and_install_secret(
+                client=fake_client,
+                platform_auth="local_dev",
+                handoff={
+                    "handoff_id": "sh_test",
+                    "expires_at": "2999-01-01T00:00:00Z",
+                    "poll_after_ms": 1,
+                },
+                private_key_pem="PRIVATE",
+            )
+        finally:
+            secret_handoff._decrypt_ciphertext = original_decrypt
+            secret_handoff._set_hermes_secret = original_set
+            secret_handoff._reload_hermes_gateway_after_secret = original_reload
+
+        self.assertEqual(fake_client.claim_payloads[-1]["installed"], False)
+        self.assertEqual(
+            fake_client.claim_payloads[-1]["message"],
+            "Secret saved, but I could not reload Hermes. Send /restart before using it.",
         )
         self.assertNotIn("super-secret-value", json.dumps(fake_client.claim_payloads))
 

--- a/test/test_hermes_adapter.py
+++ b/test/test_hermes_adapter.py
@@ -630,6 +630,34 @@ class HermesAdapterTests(unittest.TestCase):
         )
         self.assertNotIn("super-secret-value", json.dumps(fake_client.claim_payloads))
 
+    def test_gateway_log_failure_scan_ignores_old_failures(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="tinyhat-log-test-") as temp_dir:
+            log_path = Path(temp_dir) / "gateway.log"
+            log_path.write_text(
+                "old adapter creation failed\n",
+                encoding="utf-8",
+            )
+            offset = log_path.stat().st_size
+            with log_path.open("a", encoding="utf-8") as handle:
+                handle.write("new start is healthy\n")
+
+            self.assertFalse(
+                secret_handoff._gateway_log_has_adapter_failure(
+                    log_path,
+                    since_byte=offset,
+                )
+            )
+
+            with log_path.open("a", encoding="utf-8") as handle:
+                handle.write("platform 'telegram' requirements not met\n")
+
+            self.assertTrue(
+                secret_handoff._gateway_log_has_adapter_failure(
+                    log_path,
+                    since_byte=offset,
+                )
+            )
+
     def test_worker_script_bootstraps_from_non_package_checkout(self) -> None:
         result = subprocess.run(
             [


### PR DESCRIPTION
## Summary
- restart the Hermes gateway after private secret handoff writes a new env value
- treat reload failure as a safe handoff failure instead of claiming the secret is ready
- bump the plugin package to 0.20.11

## Verification
- python3 scripts/validate_framework_package.py
- python3 -m unittest discover -s test -p "*.py"
- python3 -m compileall -q .
- git diff --check

Stacked on #142 so the screenshot/default Codex auth change can land first.

— posted by Codex