### PR TITLE
fix(plugin): reload private secrets into Hermes env

### DIFF
--- a/secret_handoff.py
+++ b/secret_handoff.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import base64
 import os
 import re
+import shlex
 import shutil
 import subprocess
 import sys
@@ -297,31 +298,114 @@ def _decrypt_one_chunk(private_key_pem: str, ciphertext_b64: str) -> bytes:
 def _set_hermes_secret(secret_name: str, value: str) -> None:
     hermes = shutil.which("hermes")
     if not hermes:
-        raise SecretHandoffError("Hermes CLI was not found.")
-    result = subprocess.run(
-        [hermes, "config", "set", secret_name, value],
-        capture_output=True,
-        text=True,
-        timeout=45,
-        check=False,
-    )
-    if result.returncode != 0:
         raise SecretHandoffError(
-            "Hermes config set failed.",
+            "Hermes CLI was not found.",
             public_message="Hermes could not save this secret.",
         )
+    try:
+        if _can_save_with_hermes_config_set(secret_name):
+            _run([hermes, "config", "set", secret_name, value], redactions=(value,))
+            return
+        _save_hermes_env_value(hermes, secret_name, value)
+    except SecretHandoffError as exc:
+        raise SecretHandoffError(
+            "Hermes config could not save this secret.",
+            public_message="Hermes could not save this secret.",
+        ) from exc
 
 
-def _run(command: list[str], *, text: bool = True) -> str | bytes:
+def _can_save_with_hermes_config_set(secret_name: str) -> bool:
+    return (
+        secret_name.endswith(("_API_KEY", "_TOKEN"))
+        or secret_name.startswith("TERMINAL_SSH")
+        or secret_name
+        in {
+            "FAL_KEY",
+            "SUDO_PASSWORD",
+        }
+    )
+
+
+def _save_hermes_env_value(hermes: str, secret_name: str, value: str) -> None:
+    python = _hermes_python_executable(hermes)
+    if not python:
+        raise SecretHandoffError("Could not find Hermes' Python runtime.")
+    script = (
+        "import sys\n"
+        "from hermes_cli.config import save_env_value\n"
+        "save_env_value(sys.argv[1], sys.stdin.read())\n"
+    )
+    _run([python, "-c", script, secret_name], input_text=value, redactions=(value,))
+
+
+def _hermes_python_executable(hermes: str) -> str | None:
+    for candidate in _hermes_script_candidates(Path(hermes)):
+        for name in ("python", "python3"):
+            python = candidate.parent / name
+            if python.exists():
+                return str(python)
+        shebang = _read_first_line(candidate)
+        if not shebang.startswith("#!"):
+            continue
+        try:
+            parts = shlex.split(shebang[2:].strip())
+        except ValueError:
+            continue
+        if not parts:
+            continue
+        executable = Path(parts[0])
+        if executable.name.startswith("python") and executable.exists():
+            return str(executable)
+        if executable.name == "env" and len(parts) > 1 and parts[1].startswith("python"):
+            python = shutil.which(parts[1])
+            if python:
+                return python
+    return None
+
+
+def _hermes_script_candidates(hermes: Path) -> list[Path]:
+    candidates: list[Path] = []
+    try:
+        text = hermes.read_text(encoding="utf-8", errors="ignore")[:8192]
+    except OSError:
+        return [hermes]
+    for match in re.finditer(r"""["']([^"']*/hermes(?:\.exe)?)["']""", text):
+        candidate = Path(match.group(1))
+        if candidate.exists() and candidate not in candidates:
+            candidates.append(candidate)
+    if hermes not in candidates:
+        candidates.append(hermes)
+    return candidates
+
+
+def _read_first_line(path: Path) -> str:
+    try:
+        with path.open("r", encoding="utf-8", errors="ignore") as handle:
+            return handle.readline().strip()
+    except OSError:
+        return ""
+
+
+def _run(
+    command: list[str],
+    *,
+    text: bool = True,
+    input_text: str | None = None,
+    redactions: tuple[str, ...] = (),
+) -> str | bytes:
     result = subprocess.run(
         command,
         capture_output=True,
         text=text,
+        input=input_text,
         timeout=45,
         check=False,
     )
     if result.returncode != 0:
         stderr = result.stderr if text else result.stderr.decode("utf-8", "replace")
+        for value in redactions:
+            if value:
+                stderr = stderr.replace(value, "[redacted]")
         raise SecretHandoffError((stderr or "command failed").strip()[:500])
     return result.stdout if text else result.stdout
 

--- a/test/test_hermes_adapter.py
+++ b/test/test_hermes_adapter.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import importlib.util
+import os
 import subprocess
 import sys
 import tempfile
@@ -596,6 +597,236 @@ class HermesAdapterTests(unittest.TestCase):
             "Hermes could not save this secret.",
         )
         self.assertNotIn("super-secret-value", json.dumps(fake_client.claim_payloads))
+
+    def test_private_secret_save_uses_hermes_config_for_next_process_reload(self) -> None:
+        original_secret = os.environ.get("EXA_API_KEY")
+        try:
+            os.environ.pop("EXA_API_KEY", None)
+            with tempfile.TemporaryDirectory() as temp_dir:
+                temp_root = Path(temp_dir)
+                env_file = temp_root / "hermes.env"
+                package_link = temp_root / "tinyhat"
+                package_link.symlink_to(REPO_ROOT, target_is_directory=True)
+                bin_dir = temp_root / "bin"
+                bin_dir.mkdir()
+                fake_hermes = bin_dir / "hermes"
+                fake_hermes.write_text(
+                    """#!/usr/bin/env python3
+import os
+import sys
+from pathlib import Path
+
+if sys.argv[1:3] != ["config", "set"] or len(sys.argv) != 5:
+    sys.exit(2)
+
+key = sys.argv[3]
+value = sys.argv[4]
+path = Path(os.environ["HERMES_ENV_FILE"])
+path.parent.mkdir(parents=True, exist_ok=True)
+lines = path.read_text(encoding="utf-8").splitlines() if path.exists() else []
+escaped = value.replace("\\\\", "\\\\\\\\").replace('"', '\\\\"')
+entry = f'{key}="{escaped}"'
+updated = False
+next_lines = []
+for line in lines:
+    clean_key, sep, _raw = line.partition("=")
+    if sep and clean_key.strip() == key:
+        next_lines.append(entry)
+        updated = True
+    else:
+        next_lines.append(line)
+if not updated:
+    next_lines.append(entry)
+path.write_text("\\n".join(next_lines).rstrip() + "\\n", encoding="utf-8")
+path.chmod(0o600)
+""",
+                    encoding="utf-8",
+                )
+                fake_hermes.chmod(0o700)
+
+                worker_env = dict(os.environ)
+                worker_env.update(
+                    {
+                        "HERMES_ENV_FILE": str(env_file),
+                        "PATH": f"{bin_dir}{os.pathsep}{worker_env.get('PATH', '')}",
+                        "PYTHONPATH": str(temp_root),
+                    }
+                )
+                worker = subprocess.run(
+                    [
+                        sys.executable,
+                        "-c",
+                        (
+                            "from tinyhat.secret_handoff import _set_hermes_secret; "
+                            "_set_hermes_secret('EXA_API_KEY', 'test-secret-value')"
+                        ),
+                    ],
+                    cwd="/tmp",
+                    env=worker_env,
+                    capture_output=True,
+                    text=True,
+                    timeout=10,
+                    check=False,
+                )
+
+                self.assertEqual(worker.returncode, 0, worker.stderr)
+                self.assertNotIn("test-secret-value", worker.stdout + worker.stderr)
+                self.assertNotEqual(os.environ.get("EXA_API_KEY"), "test-secret-value")
+                self.assertIn('EXA_API_KEY="test-secret-value"', env_file.read_text())
+
+                reloader = subprocess.run(
+                    [
+                        sys.executable,
+                        "-c",
+                        """
+import os
+from pathlib import Path
+
+path = Path(os.environ["HERMES_ENV_FILE"])
+for line in path.read_text(encoding="utf-8").splitlines():
+    clean = line.strip()
+    if not clean or clean.startswith("#") or "=" not in clean:
+        continue
+    key, raw = clean.split("=", 1)
+    value = raw.strip()
+    if len(value) >= 2 and value[0] == value[-1] and value.startswith(("'", '"')):
+        value = value[1:-1]
+    os.environ[key.strip()] = value.replace('\\\\"', '"').replace("\\\\\\\\", "\\\\")
+print("set" if os.environ.get("EXA_API_KEY") == "test-secret-value" else "missing")
+""",
+                    ],
+                    cwd="/tmp",
+                    env={
+                        "HERMES_ENV_FILE": str(env_file),
+                    },
+                    capture_output=True,
+                    text=True,
+                    timeout=10,
+                    check=False,
+                )
+                self.assertEqual(reloader.returncode, 0, reloader.stderr)
+                self.assertEqual(reloader.stdout.strip(), "set")
+        finally:
+            if original_secret is None:
+                os.environ.pop("EXA_API_KEY", None)
+            else:
+                os.environ["EXA_API_KEY"] = original_secret
+
+    def test_private_secret_save_uses_hermes_env_writer_for_secret_key_names(self) -> None:
+        original_secret = os.environ.get("STRIPE_SECRET_KEY")
+        try:
+            os.environ.pop("STRIPE_SECRET_KEY", None)
+            with tempfile.TemporaryDirectory() as temp_dir:
+                temp_root = Path(temp_dir)
+                env_file = temp_root / "hermes.env"
+                package_link = temp_root / "tinyhat"
+                package_link.symlink_to(REPO_ROOT, target_is_directory=True)
+                bin_dir = temp_root / "bin"
+                venv_bin = temp_root / "hermes-agent" / "venv" / "bin"
+                bin_dir.mkdir()
+                venv_bin.mkdir(parents=True)
+
+                fake_python = venv_bin / "python"
+                fake_python.write_text(
+                    f"""#!{sys.executable}
+import os
+import sys
+from pathlib import Path
+
+key = sys.argv[-1]
+value = sys.stdin.read()
+path = Path(os.environ["HERMES_ENV_FILE"])
+path.parent.mkdir(parents=True, exist_ok=True)
+escaped = value.replace("\\\\", "\\\\\\\\").replace('"', '\\\\"')
+path.write_text(f'{{key}}="{{escaped}}"\\n', encoding="utf-8")
+path.chmod(0o600)
+""",
+                    encoding="utf-8",
+                )
+                fake_python.chmod(0o700)
+                fake_console = venv_bin / "hermes"
+                fake_console.write_text(f"#!{fake_python}\n", encoding="utf-8")
+                fake_console.chmod(0o700)
+                fake_wrapper = bin_dir / "hermes"
+                fake_wrapper.write_text(
+                    f'#!/bin/sh\nexec "{fake_console}" "$@"\n',
+                    encoding="utf-8",
+                )
+                fake_wrapper.chmod(0o700)
+
+                worker_env = dict(os.environ)
+                worker_env.update(
+                    {
+                        "HERMES_ENV_FILE": str(env_file),
+                        "PATH": f"{bin_dir}{os.pathsep}{worker_env.get('PATH', '')}",
+                        "PYTHONPATH": str(temp_root),
+                    }
+                )
+                worker = subprocess.run(
+                    [
+                        sys.executable,
+                        "-c",
+                        (
+                            "from tinyhat.secret_handoff import _set_hermes_secret; "
+                            "_set_hermes_secret('STRIPE_SECRET_KEY', 'test-secret-value')"
+                        ),
+                    ],
+                    cwd="/tmp",
+                    env=worker_env,
+                    capture_output=True,
+                    text=True,
+                    timeout=10,
+                    check=False,
+                )
+
+                self.assertEqual(worker.returncode, 0, worker.stderr)
+                self.assertNotIn("test-secret-value", worker.stdout + worker.stderr)
+                self.assertNotEqual(
+                    os.environ.get("STRIPE_SECRET_KEY"),
+                    "test-secret-value",
+                )
+                self.assertIn(
+                    'STRIPE_SECRET_KEY="test-secret-value"',
+                    env_file.read_text(encoding="utf-8"),
+                )
+
+                reloader = subprocess.run(
+                    [
+                        sys.executable,
+                        "-c",
+                        """
+import os
+from pathlib import Path
+
+path = Path(os.environ["HERMES_ENV_FILE"])
+for line in path.read_text(encoding="utf-8").splitlines():
+    clean = line.strip()
+    if not clean or clean.startswith("#") or "=" not in clean:
+        continue
+    key, raw = clean.split("=", 1)
+    value = raw.strip()
+    if len(value) >= 2 and value[0] == value[-1] and value.startswith(("'", '"')):
+        value = value[1:-1]
+    os.environ[key.strip()] = value.replace('\\\\"', '"').replace("\\\\\\\\", "\\\\")
+print("set" if os.environ.get("STRIPE_SECRET_KEY") == "test-secret-value" else "missing")
+""",
+                    ],
+                    cwd="/tmp",
+                    env={
+                        "HERMES_ENV_FILE": str(env_file),
+                    },
+                    capture_output=True,
+                    text=True,
+                    timeout=10,
+                    check=False,
+                )
+                self.assertEqual(reloader.returncode, 0, reloader.stderr)
+                self.assertEqual(reloader.stdout.strip(), "set")
+        finally:
+            if original_secret is None:
+                os.environ.pop("STRIPE_SECRET_KEY", None)
+            else:
+                os.environ["STRIPE_SECRET_KEY"] = original_secret
 
     def test_tell_joke_ignores_hermes_runtime_metadata(self) -> None:
         payload = json.loads(


### PR DESCRIPTION
## Summary
- add the Hermes private-secret handoff tool and skill for encrypted Mini App secret entry
- store submitted secrets directly in Hermes env files and update the live plugin process env before claiming success
- avoid gateway restart for added/updated secrets; the next shell/tool child process inherits the new env var immediately

## Verification
- `python3 scripts/validate_framework_package.py`
- `python3 -m unittest discover -s test -p '*.py'`
- `python3 -m compileall -q .`

## Notes
- Secret values remain local to the Computer. The platform receives only handoff metadata/ciphertext and claim state.
