### PR TITLE
fix(plugin): restart Hermes after private secret save

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ All notable changes to the Tinyhat plugin are documented here.
 - Teach the private secret skill and tool to use meaningful env-style names
   such as `EXA_API_KEY` instead of generic placeholders like
   `TINYHAT_SECRET`.
+- Restart the Hermes gateway after a private secret is saved, with a short
+  Telegram notice first, so Hermes reloads the saved env value before the next
+  message.
 - Add a repo-local Tinyhat plugin skill-authoring skill and expand the
   public skill standard for future plugin capabilities.
 - Bump the fresh Hermes plugin package to `0.20.3` so managed Computers can

--- a/README.md
+++ b/README.md
@@ -75,7 +75,10 @@ to save an API key, token, password, or credential, the agent calls
 pair, the user enters the value in a Telegram Mini App, the browser
 encrypts the value with the public key, and the Computer decrypts it with
 the temporary private key. Tinyhat stores only short-lived ciphertext for
-the handoff and wipes it after completion, expiration, or failure.
+the handoff and wipes it after completion, expiration, or failure. After
+the Computer saves the secret locally, the plugin sends a short Telegram
+notice and restarts the Hermes gateway so Hermes reloads the updated env value
+before the next message.
 
 `tinyhat-codex-auth` teaches the agent how to start the Tinyhat-managed
 OpenAI Codex / ChatGPT subscription sign-in flow. When the user says

--- a/secret_handoff.py
+++ b/secret_handoff.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import base64
+import json
 import os
 import re
 import shlex
@@ -213,6 +214,8 @@ def _install_submitted_secret(
         _set_hermes_secret(secret_name, plaintext)
     finally:
         plaintext = ""
+    _send_secret_available_notice(secret_name)
+    _restart_gateway_after_secret()
     _claim_handoff(client, platform_auth, handoff_id, installed=True)
 
 
@@ -312,6 +315,97 @@ def _set_hermes_secret(secret_name: str, value: str) -> None:
             "Hermes config could not save this secret.",
             public_message="Hermes could not save this secret.",
         ) from exc
+
+
+def _send_secret_available_notice(secret_name: str) -> dict[str, Any]:
+    try:
+        from .tools import _telegram_credentials, _telegram_send_message
+
+        token, chat_id = _telegram_credentials()
+        sent = _telegram_send_message(
+            token=token,
+            chat_id=chat_id,
+            text=(
+                f"`{secret_name}` is saved. I'm restarting my Telegram gateway "
+                "now so Hermes can load this secret before the next message."
+            ),
+        )
+        return {"sent": bool(sent.get("ok")), "ok": bool(sent.get("ok"))}
+    except Exception as exc:
+        return {"sent": False, "ok": False, "error": str(exc)[:200]}
+
+
+def _restart_gateway_after_secret() -> dict[str, Any]:
+    hermes = shutil.which("hermes")
+    if not hermes:
+        raise SecretHandoffError(
+            "Hermes CLI was not found.",
+            public_message=(
+                "Hermes saved the secret, but I could not restart the gateway "
+                "to make it available yet."
+            ),
+        )
+    runtime_prefix = os.getenv("TINYHAT_RUNTIME_PREFIX", "/opt/tinyhat-hermes-runtime")
+    env = os.environ.copy()
+    env["PYTHONPATH"] = (
+        f"{runtime_prefix}{os.pathsep}{env['PYTHONPATH']}"
+        if env.get("PYTHONPATH")
+        else runtime_prefix
+    )
+    script = (
+        "import asyncio, json, sys\n"
+        "from pathlib import Path\n"
+        "from hermes_runtime.commands.configure_telegram import _run_gateway\n"
+        "result = asyncio.run(_run_gateway(Path(sys.argv[1])))\n"
+        "print(json.dumps(result, sort_keys=True))\n"
+    )
+    try:
+        completed = subprocess.run(
+            [sys.executable, "-c", script, hermes],
+            capture_output=True,
+            text=True,
+            timeout=90,
+            check=False,
+            env=env,
+        )
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        raise SecretHandoffError(
+            "Hermes gateway restart failed after saving a secret.",
+            public_message=(
+                "Hermes saved the secret, but I could not restart the gateway "
+                "to make it available yet."
+            ),
+        ) from exc
+    if completed.returncode != 0:
+        error_text = (
+            completed.stderr or completed.stdout or "gateway restart failed"
+        ).strip()[:500]
+        raise SecretHandoffError(
+            error_text,
+            public_message=(
+                "Hermes saved the secret, but I could not restart the gateway "
+                "to make it available yet."
+            ),
+        )
+    try:
+        payload = json.loads(completed.stdout or "{}")
+    except json.JSONDecodeError as exc:
+        raise SecretHandoffError(
+            "Hermes gateway restart returned invalid JSON.",
+            public_message=(
+                "Hermes saved the secret, but I could not confirm the gateway "
+                "restart."
+            ),
+        ) from exc
+    if not isinstance(payload, dict) or not payload.get("healthy"):
+        raise SecretHandoffError(
+            "Hermes gateway did not report healthy after secret save.",
+            public_message=(
+                "Hermes saved the secret, but I could not confirm the gateway "
+                "restart."
+            ),
+        )
+    return payload
 
 
 def _can_save_with_hermes_config_set(secret_name: str) -> bool:

--- a/secret_handoff.py
+++ b/secret_handoff.py
@@ -215,8 +215,18 @@ def _install_submitted_secret(
     finally:
         plaintext = ""
     _send_secret_available_notice(secret_name)
-    _restart_gateway_after_secret()
-    _claim_handoff(client, platform_auth, handoff_id, installed=True)
+    restart_message = None
+    try:
+        _restart_gateway_after_secret()
+    except Exception as exc:
+        restart_message = _public_failure_message(exc)
+    _claim_handoff(
+        client,
+        platform_auth,
+        handoff_id,
+        installed=True,
+        message=restart_message,
+    )
 
 
 def _claim_handoff(
@@ -326,7 +336,7 @@ def _send_secret_available_notice(secret_name: str) -> dict[str, Any]:
             token=token,
             chat_id=chat_id,
             text=(
-                f"`{secret_name}` is saved. I'm restarting my Telegram gateway "
+                f"{secret_name} is saved. I'm restarting my Telegram gateway "
                 "now so Hermes can load this secret before the next message."
             ),
         )
@@ -352,6 +362,8 @@ def _restart_gateway_after_secret() -> dict[str, Any]:
         if env.get("PYTHONPATH")
         else runtime_prefix
     )
+    # This worker already runs inside the plugin interpreter; PYTHONPATH points it
+    # at the separately-installed runtime package that owns gateway lifecycle.
     script = (
         "import asyncio, json, sys\n"
         "from pathlib import Path\n"

--- a/test/test_hermes_adapter.py
+++ b/test/test_hermes_adapter.py
@@ -588,6 +588,167 @@ class HermesAdapterTests(unittest.TestCase):
         )
         self.assertNotIn("super-secret-value", json.dumps(fake_client.claim_payloads))
 
+    def test_private_secret_install_claims_installed_when_restart_fails(self) -> None:
+        class FakeClient:
+            def __init__(self) -> None:
+                self.claim_payloads: list[dict] = []
+
+            def post_json(self, path: str, payload: dict) -> dict:
+                self.claim_payloads.append(payload)
+                return {"status": "claimed"}
+
+        fake_client = FakeClient()
+        original_decrypt = secret_handoff._decrypt_ciphertext
+        original_set = secret_handoff._set_hermes_secret
+        original_notice = secret_handoff._send_secret_available_notice
+        original_restart = secret_handoff._restart_gateway_after_secret
+        try:
+            secret_handoff._decrypt_ciphertext = lambda *_: "super-secret-value"
+            secret_handoff._set_hermes_secret = lambda *_: None
+            secret_handoff._send_secret_available_notice = lambda *_: {
+                "sent": True,
+                "ok": True,
+            }
+            secret_handoff._restart_gateway_after_secret = lambda: (
+                (_ for _ in ()).throw(
+                    secret_handoff.SecretHandoffError(
+                        "raw failure super-secret-value",
+                        public_message=(
+                            "Hermes saved the secret, but I could not restart "
+                            "the gateway to make it available yet."
+                        ),
+                    )
+                )
+            )
+
+            secret_handoff._install_submitted_secret(
+                client=fake_client,
+                platform_auth="local_dev",
+                handoff_id="sh_test",
+                private_key_pem="PRIVATE",
+                state={
+                    "secret_name": "EXA_API_KEY",
+                    "ciphertext_payload": {"algorithm": "RSA-OAEP-256"},
+                },
+            )
+        finally:
+            secret_handoff._decrypt_ciphertext = original_decrypt
+            secret_handoff._set_hermes_secret = original_set
+            secret_handoff._send_secret_available_notice = original_notice
+            secret_handoff._restart_gateway_after_secret = original_restart
+
+        self.assertEqual(fake_client.claim_payloads[-1]["installed"], True)
+        self.assertEqual(
+            fake_client.claim_payloads[-1]["message"],
+            "Hermes saved the secret, but I could not restart "
+            "the gateway to make it available yet.",
+        )
+        self.assertNotIn("super-secret-value", json.dumps(fake_client.claim_payloads))
+
+    def test_private_secret_restart_gateway_subprocess_contract(self) -> None:
+        original_which = secret_handoff.shutil.which
+        original_run = secret_handoff.subprocess.run
+        calls: list[dict] = []
+
+        def fake_run(args, **kwargs):
+            calls.append({"args": args, **kwargs})
+            return subprocess.CompletedProcess(
+                args=args,
+                returncode=0,
+                stdout='{"healthy": true, "phase": "started"}',
+                stderr="",
+            )
+
+        try:
+            secret_handoff.shutil.which = lambda name: "/usr/bin/hermes"
+            secret_handoff.subprocess.run = fake_run
+
+            result = secret_handoff._restart_gateway_after_secret()
+        finally:
+            secret_handoff.shutil.which = original_which
+            secret_handoff.subprocess.run = original_run
+
+        self.assertEqual(result["phase"], "started")
+        self.assertEqual(calls[0]["args"][0], sys.executable)
+        self.assertIn(
+            "/opt/tinyhat-hermes-runtime",
+            calls[0]["env"].get("PYTHONPATH", ""),
+        )
+
+    def test_private_secret_restart_gateway_rejects_bad_subprocess_results(self) -> None:
+        original_which = secret_handoff.shutil.which
+        original_run = secret_handoff.subprocess.run
+
+        def assert_restart_error(completed: subprocess.CompletedProcess) -> None:
+            secret_handoff.subprocess.run = lambda *_, **__: completed
+            with self.assertRaises(secret_handoff.SecretHandoffError) as raised:
+                secret_handoff._restart_gateway_after_secret()
+            self.assertTrue(raised.exception.public_message)
+            self.assertIn("Hermes saved the secret", raised.exception.public_message)
+
+        try:
+            secret_handoff.shutil.which = lambda name: "/usr/bin/hermes"
+            assert_restart_error(
+                subprocess.CompletedProcess(
+                    args=["hermes"],
+                    returncode=1,
+                    stdout="",
+                    stderr="gateway failed",
+                )
+            )
+            assert_restart_error(
+                subprocess.CompletedProcess(
+                    args=["hermes"],
+                    returncode=0,
+                    stdout="not-json",
+                    stderr="",
+                )
+            )
+            assert_restart_error(
+                subprocess.CompletedProcess(
+                    args=["hermes"],
+                    returncode=0,
+                    stdout='{"healthy": false}',
+                    stderr="",
+                )
+            )
+        finally:
+            secret_handoff.shutil.which = original_which
+            secret_handoff.subprocess.run = original_run
+
+    def test_private_secret_notice_is_plain_text_and_best_effort(self) -> None:
+        original_credentials = tools._telegram_credentials
+        original_send = tools._telegram_send_message
+        sent_messages: list[str] = []
+
+        try:
+            tools._telegram_credentials = lambda: ("token", "chat")
+            tools._telegram_send_message = lambda **kwargs: sent_messages.append(
+                kwargs["text"]
+            ) or {"ok": True}
+
+            result = secret_handoff._send_secret_available_notice("EXA_API_KEY")
+        finally:
+            tools._telegram_credentials = original_credentials
+            tools._telegram_send_message = original_send
+
+        self.assertEqual(result, {"sent": True, "ok": True})
+        self.assertIn("EXA_API_KEY is saved.", sent_messages[-1])
+        self.assertNotIn("`", sent_messages[-1])
+
+        original_credentials = tools._telegram_credentials
+        try:
+            tools._telegram_credentials = lambda: (_ for _ in ()).throw(
+                RuntimeError("telegram unavailable")
+            )
+
+            failed = secret_handoff._send_secret_available_notice("EXA_API_KEY")
+        finally:
+            tools._telegram_credentials = original_credentials
+
+        self.assertEqual(failed["sent"], False)
+        self.assertEqual(failed["ok"], False)
+
     def test_worker_script_bootstraps_from_non_package_checkout(self) -> None:
         result = subprocess.run(
             [

--- a/test/test_hermes_adapter.py
+++ b/test/test_hermes_adapter.py
@@ -529,6 +529,65 @@ class HermesAdapterTests(unittest.TestCase):
         )
         self.assertNotIn("super-secret-value", json.dumps(fake_client.claim_payloads))
 
+    def test_private_secret_install_notifies_and_restarts_before_claim(self) -> None:
+        class FakeClient:
+            def __init__(self) -> None:
+                self.claim_payloads: list[dict] = []
+
+            def post_json(self, path: str, payload: dict) -> dict:
+                events.append(("claim", payload.get("installed")))
+                self.claim_payloads.append(payload)
+                return {"status": "claimed"}
+
+        events: list[tuple[str, object]] = []
+        fake_client = FakeClient()
+        original_decrypt = secret_handoff._decrypt_ciphertext
+        original_set = secret_handoff._set_hermes_secret
+        original_notice = secret_handoff._send_secret_available_notice
+        original_restart = secret_handoff._restart_gateway_after_secret
+        try:
+            secret_handoff._decrypt_ciphertext = lambda *_: "super-secret-value"
+            secret_handoff._set_hermes_secret = lambda name, value: events.append(
+                ("set", name)
+            )
+            secret_handoff._send_secret_available_notice = lambda name: events.append(
+                ("notice", name)
+            ) or {"sent": True, "ok": True}
+            secret_handoff._restart_gateway_after_secret = lambda: events.append(
+                ("restart", True)
+            ) or {"healthy": True}
+
+            secret_handoff._install_submitted_secret(
+                client=fake_client,
+                platform_auth="local_dev",
+                handoff_id="sh_test",
+                private_key_pem="PRIVATE",
+                state={
+                    "secret_name": "EXA_API_KEY",
+                    "ciphertext_payload": {"algorithm": "RSA-OAEP-256"},
+                },
+            )
+        finally:
+            secret_handoff._decrypt_ciphertext = original_decrypt
+            secret_handoff._set_hermes_secret = original_set
+            secret_handoff._send_secret_available_notice = original_notice
+            secret_handoff._restart_gateway_after_secret = original_restart
+
+        self.assertEqual(
+            events,
+            [
+                ("set", "EXA_API_KEY"),
+                ("notice", "EXA_API_KEY"),
+                ("restart", True),
+                ("claim", True),
+            ],
+        )
+        self.assertEqual(
+            fake_client.claim_payloads[-1],
+            {"installed": True, "message": None},
+        )
+        self.assertNotIn("super-secret-value", json.dumps(fake_client.claim_payloads))
+
     def test_worker_script_bootstraps_from_non_package_checkout(self) -> None:
         result = subprocess.run(
             [


### PR DESCRIPTION
## Summary

- send the owner a clear Telegram notice after a Mini App private-secret save and before restarting the Hermes gateway
- restart the gateway immediately after the encrypted value is written so Hermes reloads its env files before the next chat turn
- keep provider-style secrets out of generic shell/runtime passthrough; Hermes currently blocklists keys such as `EXA_API_KEY`, so the platform should rely on the Computer secrets inventory for names/status instead of exposing a masked runtime-command result

## Verification

- `python3 scripts/validate_framework_package.py`
- `python3 -m unittest discover -s test -p "*.py"`
- `python3 -m compileall -q .`
- `git diff --check`
- Live local E2E on Computer 5271 / agent 4442: saved `EXA_API_KEY` through the Telegram Mini App, observed the pre-restart chat notice, observed gateway shutdown/restart, and confirmed the Computer page shows the saved env name while the removed masked-secret runtime command is no longer present.

Screenshots from the local admin E2E:

![Computer-scoped Secrets section](https://gist.githubusercontent.com/tinyloop-farid-codex/48f4fb651489608b71150b14af2aba03/raw/8469bf9e6a470b693f36340f626c72b01486ca40/secret-section.png)

![Runtime command list without masked secrets command](https://gist.githubusercontent.com/tinyloop-farid-codex/48f4fb651489608b71150b14af2aba03/raw/c9971a4ea2b73ac83d7423dc516a82c64ceb8c3e/runtime-command-list.png)

Agent model / effort: GPT-5 / high
— posted by Codex