### PR TITLE
fix(plugin): bump Hermes schema version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to the Tinyhat plugin are documented here.
 
 ### Changed
 
+- Bump the fresh Hermes plugin package to `0.20.12` after tightening the
+  agent-facing tool schemas and self-correcting error payloads.
 - Register private-handoff secret names with the Tinyhat runtime's Hermes
   terminal env helper after saving. The runtime records the saved name and
   maintains Hermes local-terminal aliases so the secret is available to

--- a/hermes.plugin.json
+++ b/hermes.plugin.json
@@ -1,6 +1,6 @@
 {
   "schema": "tinyhat.framework-adapter.v1",
-  "version": "0.20.11",
+  "version": "0.20.12",
   "framework": {
     "name": "hermes",
     "minimum": "0.0.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tinyhat",
-  "version": "0.20.11",
+  "version": "0.20.12",
   "description": "Hermes plugin that teaches agents how to use Tinyhat platform capabilities.",
   "private": true,
   "files": [
@@ -8,9 +8,11 @@
     "hermes.plugin.json",
     "__init__.py",
     "platform.py",
+    "context.py",
     "secret_handoff.py",
     "secret_handoff_worker.py",
     "schemas.py",
+    "tool_errors.py",
     "tools.py",
     "skills",
     "docs",

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -1,5 +1,5 @@
 name: tinyhat
-version: 0.20.11
+version: 0.20.12
 description: Framework-neutral Tinyhat platform skills and tools.
 kind: standalone
 author: Tinyloop

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "tinyhat"
-version = "0.20.11"
+version = "0.20.12"
 description = "Hermes plugin that teaches agents how to use Tinyhat platform capabilities."
 readme = "README.md"
 requires-python = ">=3.9"

--- a/test/test_hermes_adapter.py
+++ b/test/test_hermes_adapter.py
@@ -125,7 +125,7 @@ class HermesAdapterTests(unittest.TestCase):
 
         self.assertEqual(payload["schema"], "tinyhat_plugin_version_v1")
         self.assertEqual(payload["name"], "tinyhat")
-        self.assertEqual(payload["version"], "0.20.11")
+        self.assertEqual(payload["version"], "0.20.12")
 
     def test_context_hook_injects_for_secret_requests(self) -> None:
         ctx = FakeHermesContext()


### PR DESCRIPTION
## TL;DR for the reviewer

Bumps the Tinyhat Hermes plugin metadata from `0.20.11` to `0.20.12` so the promoted `channels/lts` and `channels/latest` branches report the schema-tightening release correctly.

## Scope

- Version metadata: updates `hermes.plugin.json`, `plugin.yaml`, `pyproject.toml`, and `package.json` to `0.20.12`.
- Tests: updates the live plugin-version assertion to expect `0.20.12`.
- Packaging metadata: adds the newly imported `context.py` and `tool_errors.py` files to the package allowlist for future-proofing.
- Changelog: records the version bump for the Hermes tool-schema tightening work.

## Non-scope

- No runtime behavior changes beyond reported metadata.
- No change to `main`; this PR targets `codex/v0.20-hermes-plugin` only.

## How to test

- Run `python3 scripts/validate_framework_package.py`. Before this PR, the package validator reports `0.20.11`; after this PR, it reports `framework-package: ok (version 0.20.12)`. This proves the four version surfaces agree.
- Run `python3 -m unittest discover -s test -p "*.py"`. Before this PR, the plugin-version test expects `0.20.11`; after this PR, all tests pass with the `0.20.12` expectation.
- Inspect `hermes.plugin.json` on `channels/lts` or `channels/latest`; after the channel ref correction, it reports `"version": "0.20.12"`.

## Verified

```text
python3 scripts/validate_framework_package.py
framework-package: ok (version 0.20.12)

python3 -m unittest discover -s test -p "*.py"
Ran 40 tests in 0.603s
OK

python3 -m compileall -q .
git diff --check
```

Channel refs have already been corrected to this commit (`78e6383a4665dfd5d81f4c11d438dcf679b82ed9`) so `channels/lts` and `channels/latest` expose `0.20.12`; this PR folds the same correction back into the v0.20 integration branch through the required PR path.

Agent model / effort: GPT-5 / high
— posted by Codex