### PR TITLE
fix(plugin): add Hermes update and skill discovery tools

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,8 +23,10 @@ a fresh Hermes-only start.
 - `tools.py`, `schemas.py`, `platform.py`, and `secret_handoff.py`: tiny public tool surface.
 - `skills/tinyhat-tell-joke/SKILL.md`: deterministic joke proof.
 - `skills/tinyhat-plugin-version/SKILL.md`: live plugin version proof.
+- `skills/tinyhat-skill-catalog/SKILL.md`: plugin-qualified skill discovery.
 - `skills/tinyhat-private-secret/SKILL.md`: private Mini App secret handoff.
 - `skills/tinyhat-codex-auth/SKILL.md`: OpenAI Codex / ChatGPT subscription auth flow guidance.
+- `skills/tinyhat-plugin-update/SKILL.md`: installed plugin channel update guidance.
 - `skills/tinyhat-platform/SKILL.md`: Tinyhat-managed Hermes operating context.
 - `context.py`: small keyword-gated Hermes `pre_llm_call` context hook.
 - `.agents/skills/tinyhat-plugin-skill-authoring/SKILL.md`: maintainer

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ All notable changes to the Tinyhat plugin are documented here.
 
 ### Changed
 
+- Bump the fresh Hermes plugin package to `0.20.13`, add
+  `tinyhat_skill_catalog` for plugin-qualified skill discovery, and add
+  `tinyhat_plugin_update` so agents can check/apply stale installed plugin
+  channels through runtime commands instead of ad hoc shell snippets.
 - Bump the fresh Hermes plugin package to `0.20.12` after tightening the
   agent-facing tool schemas and self-correcting error payloads.
 - Register private-handoff secret names with the Tinyhat runtime's Hermes

--- a/README.md
+++ b/README.md
@@ -10,12 +10,12 @@ that explain how to use Tinyhat platform capabilities without exposing
 private platform URLs, machine credentials, bot tokens, or tenant data.
 
 For the first v0.20 version, this repo is deliberately small. It supports
-Hermes only, ships two proof skills, a small Tinyhat context hook, and
-now includes the first real Tinyhat platform capability: a private secret
-handoff that lets the user enter a secret in a Telegram Mini App without
-sending the plaintext to Tinyhat's servers. It also teaches the agent
-the Tinyhat-managed OpenAI Codex / ChatGPT subscription auth flow that
-is installed on each Hermes Computer.
+Hermes only, ships a compact set of packaged skills, a small Tinyhat
+context hook, and now includes the first real Tinyhat platform capability:
+a private secret handoff that lets the user enter a secret in a Telegram
+Mini App without sending the plaintext to Tinyhat's servers. It also
+teaches the agent the Tinyhat-managed OpenAI Codex / ChatGPT subscription
+auth flow that is installed on each Hermes Computer.
 
 ## What This Plugin Does
 
@@ -25,11 +25,13 @@ is installed on each Hermes Computer.
 | `__init__.py` | Hermes registration entrypoint. |
 | `hermes.plugin.json` | Tinyhat metadata for the Hermes adapter, skill, command, and release channels. |
 | `context.py` | Small Hermes `pre_llm_call` context hook for Tinyhat-sensitive turns. |
-| `tools.py` / `schemas.py` | Tinyhat tools: plugin version, joke proof, private secret handoff, and Codex auth setup/status helpers. |
+| `tools.py` / `schemas.py` | Tinyhat tools: plugin version, joke proof, skill catalog, private secret handoff, Codex auth setup/status helpers, and plugin update helper. |
 | `skills/tinyhat-tell-joke/SKILL.md` | Deterministic joke proof. |
 | `skills/tinyhat-plugin-version/SKILL.md` | Live plugin version proof. |
+| `skills/tinyhat-skill-catalog/SKILL.md` | Skill discovery guidance for plugin-qualified Tinyhat skill names. |
 | `skills/tinyhat-private-secret/SKILL.md` | Browser-encrypted secret handoff guidance. |
 | `skills/tinyhat-codex-auth/SKILL.md` | OpenAI Codex / ChatGPT subscription auth guidance. |
+| `skills/tinyhat-plugin-update/SKILL.md` | Channel update guidance for stale installed plugin checkouts. |
 | `skills/tinyhat-platform/SKILL.md` | Platform context for Tinyhat-managed Hermes agents. |
 | `docs/skill-authoring.md` | The standard for future Tinyhat skills. |
 | `.agents/skills/tinyhat-plugin-skill-authoring/SKILL.md` | Maintainer workflow for adding or changing plugin skills. |
@@ -69,6 +71,13 @@ Tinyhat plugin version is running, the agent can call
 `tinyhat_plugin_version`. The answer comes from the plugin code loaded by
 Hermes, not from admin metadata or a GitHub branch name.
 
+`tinyhat-skill-catalog` is the discovery repair path. When `skills_list`,
+`available_skills`, or an unqualified `skill_view(name="tinyhat-codex-auth")`
+does not show Tinyhat plugin skills clearly, the agent calls
+`tinyhat_skill_catalog`. The result lists `tinyhat:<skill-name>` qualified
+names, unqualified aliases, paths, and purposes so the agent can retry with
+the correct qualified skill name instead of guessing from a not-found error.
+
 `tinyhat-private-secret` is the first real capability. When the user asks
 to save an API key, token, password, or credential, the agent calls
 `tinyhat_private_secret_handoff`. The Computer creates a one-time key
@@ -97,12 +106,26 @@ duplicate text reply, call the prerequisite tool twice, ask the user to
 choose between unrelated interpretations, or give manual `hermes auth`
 instructions.
 
+`tinyhat-plugin-update` teaches the agent how to handle an installed plugin
+that is behind `channels/lts` or `channels/latest`. The agent starts with
+`tinyhat_plugin_update` `{"action": "status"}`. If the runtime reports
+`update_available=true` or `decision=target_ref_changed`, it applies the
+update only after the user/operator asks for it by calling
+`{"action": "update", "confirmed": true, "restart_gateway": true}`. The
+tool uses the installed runtime's `tinyhat_plugin_status`,
+`update_tinyhat_plugin`, `stop_hermes`, and `start_hermes` commands rather
+than ad hoc shell snippets.
+
 `tinyhat-platform` is the operating context. It tells the agent that
 Tinyhat secrets are the default way to add credentials to Hermes and that
 Tinyhat's installed Codex auth commands should be used for OpenAI Codex
-auth and limit checks. A small `pre_llm_call` hook injects only the short
-version of that context on first turn or when the user mentions secrets,
-credentials, Tinyhat, Codex auth, or usage limits.
+auth and limit checks. It also routes stale-plugin reports through
+`tinyhat_plugin_update`, skill discovery failures through
+`tinyhat_skill_catalog`, and Tinyhat QA reports through native reporting
+tools instead of arbitrary terminal commands. A small `pre_llm_call` hook
+injects only the short version of that context on first turn or when the
+user mentions secrets, credentials, Tinyhat, Codex auth, usage limits,
+skill lookup, plugin updates, or QA reports.
 
 ## Installing
 

--- a/__init__.py
+++ b/__init__.py
@@ -59,6 +59,12 @@ def register(ctx: Any) -> None:
         handler=tools.tell_joke,
     )
     ctx.register_tool(
+        name="tinyhat_skill_catalog",
+        toolset="tinyhat",
+        schema=schemas.TINYHAT_SKILL_CATALOG_SCHEMA,
+        handler=tools.skill_catalog,
+    )
+    ctx.register_tool(
         name="tinyhat_private_secret_handoff",
         toolset="tinyhat",
         schema=schemas.TINYHAT_PRIVATE_SECRET_HANDOFF_SCHEMA,
@@ -69,6 +75,12 @@ def register(ctx: Any) -> None:
         toolset="tinyhat",
         schema=schemas.TINYHAT_CODEX_AUTH_SCHEMA,
         handler=tools.codex_auth,
+    )
+    ctx.register_tool(
+        name="tinyhat_plugin_update",
+        toolset="tinyhat",
+        schema=schemas.TINYHAT_PLUGIN_UPDATE_SCHEMA,
+        handler=tools.plugin_update,
     )
     ctx.register_hook("pre_llm_call", context.inject_tinyhat_context)
     # Hermes registers plugin slash commands by their canonical names, then

--- a/context.py
+++ b/context.py
@@ -11,7 +11,10 @@ TINYHAT_CONTEXT = """Tinyhat context: this Hermes agent runs on a Tinyhat-manage
 - Choose meaningful env-style names such as EXA_API_KEY, OPENROUTER_API_KEY, GITHUB_TOKEN, or STRIPE_SECRET_KEY. Never use TINYHAT_SECRET for a known provider.
 - When the user asks to connect ChatGPT, OpenAI, Codex, ChatGPT Plus/Pro/Team, a paid ChatGPT account, their Codex subscription, or to stop using Tinyhat/platform credits, load tinyhat:tinyhat-codex-auth and call tinyhat_codex_auth once with action=prerequisite. That sends the ChatGPT Settings > Security screenshot and /codex_auth instruction on its own line. Do not send an extra text reply after that tool call. Do not ask a multiple-choice clarification unless they explicitly ask for ChatGPT history/data or an OpenAI API key.
 - For OpenAI Codex auth status, recent auth output, or usage limits, prefer tinyhat_codex_auth with action=status, action=log, or action=limits. The auth flow sends the Telegram button and copyable device code after the ChatGPT Security setting is confirmed; do not ask for auth.json, refresh tokens, passwords, or raw OAuth tokens.
-- Load tinyhat:tinyhat-platform, tinyhat:tinyhat-private-secret, tinyhat:tinyhat-codex-auth, or tinyhat:tinyhat-plugin-version when you need the longer Tinyhat playbook."""
+- If skill_view or skills_list omits Tinyhat plugin skills, call tinyhat_skill_catalog and retry with qualified names such as tinyhat:tinyhat-codex-auth.
+- If this Computer reports update_available=true or target_ref_changed for the Tinyhat plugin, load tinyhat:tinyhat-plugin-update and use tinyhat_plugin_update with action=status before applying updates. Only call action=update after the user/operator asks to update, and use restart_gateway=true when the live Telegram gateway should reload the new plugin commands.
+- For Tinyhat QA or Slack-style bug reports that mention words like restart, reload, update, or gateway, do not use terminal/curl just to post the text. Use a native Slack/reporting tool if available, or return the report in chat.
+- Load tinyhat:tinyhat-platform, tinyhat:tinyhat-private-secret, tinyhat:tinyhat-codex-auth, tinyhat:tinyhat-plugin-update, tinyhat:tinyhat-skill-catalog, or tinyhat:tinyhat-plugin-version when you need the longer Tinyhat playbook."""
 
 _CONTEXT_PHRASES = (
     "api key",
@@ -37,6 +40,12 @@ _CONTEXT_PHRASES = (
     "usage limits",
     "sign in",
     "device code authorization",
+    "bug report",
+    "plugin update",
+    "qa report",
+    "skills_list",
+    "skill_view",
+    "slack report",
     "start codex sign-in",
     "start codex sign in",
     "secure sign in",
@@ -64,7 +73,9 @@ _CONTEXT_TERMS = (
     "auth",
     "login",
     "settings",
+    "gateway",
     "tinyhat",
+    "update",
 )
 
 

--- a/docs/capabilities.md
+++ b/docs/capabilities.md
@@ -6,8 +6,10 @@ The current capability list is intentionally small.
 | --- | --- | --- |
 | `tinyhat_plugin_version` | Available now | Proves which Tinyhat plugin version Hermes has loaded for the live agent. |
 | `tinyhat_tell_joke` | Available now | Proves Hermes loaded the Tinyhat plugin and can call a plugin tool. |
+| `tinyhat_skill_catalog` | Available now | Lists Tinyhat plugin skills with `tinyhat:<skill>` qualified names and unqualified aliases. |
 | `tinyhat_private_secret_handoff` | Available now | Lets a user enter a secret in a Telegram Mini App while Tinyhat stores only short-lived ciphertext. |
 | `tinyhat-codex-auth` skill | Available now | Teaches the agent to start and inspect the Tinyhat-installed OpenAI Codex / ChatGPT subscription auth flow. |
+| `tinyhat_plugin_update` | Available now | Checks and applies the configured plugin channel through installed runtime commands. |
 | `pre_llm_call` context | Available now | Gives Hermes a short Tinyhat operating reminder on first turn and Tinyhat-sensitive requests. |
 
 Each capability should be visible in this document, represented by a small
@@ -27,10 +29,13 @@ Tinyhat stores only ciphertext during the short handoff window.
 ## Tinyhat Platform Context
 
 The plugin injects a short context note when the user asks about secrets,
-credentials, Tinyhat, Codex auth, usage limits, or on the first turn of a
-session. The context tells the agent to prefer Tinyhat private secret
-entry for credentials and Tinyhat's installed Codex commands for OpenAI
-Codex auth. The longer playbook lives in `skills/tinyhat-platform/SKILL.md`.
+credentials, Tinyhat, Codex auth, usage limits, plugin updates, skill
+lookup, QA reports, or on the first turn of a session. The context tells
+the agent to prefer Tinyhat private secret entry for credentials,
+Tinyhat's installed Codex commands for OpenAI Codex auth, the plugin
+catalog for missing skill lookup, and runtime channel commands for stale
+installed plugins. The longer playbook lives in
+`skills/tinyhat-platform/SKILL.md`.
 
 ## Codex / ChatGPT Subscription Auth
 
@@ -54,6 +59,26 @@ ask for `auth.json`, refresh tokens, passwords, or OpenAI API keys for
 this subscription-auth path. For follow-up inspection, the same tool
 accepts `{"action": "status"}`, `{"action": "log"}`, or
 `{"action": "limits"}` and returns bounded runtime output.
+
+## Plugin Update And Skill Discovery
+
+These capabilities are used when the live Computer is behind its configured
+plugin channel or when Hermes cannot find Tinyhat plugin skills by their
+unqualified names.
+
+For skill lookup failures, the agent calls `tinyhat_skill_catalog` and
+uses the returned `qualified_name` values, for example
+`tinyhat:tinyhat-codex-auth`. This keeps Tinyhat plugin skills
+discoverable even when a generic `skills_list` output omits
+plugin-qualified entries.
+
+For stale installed plugin reports, the agent calls
+`tinyhat_plugin_update` with `{"action": "status"}` first. When the
+runtime reports `update_available=true` or `decision=target_ref_changed`,
+the agent applies the update only after the user/operator asks for it:
+`{"action": "update", "confirmed": true, "restart_gateway": true}`. The
+tool delegates to the installed runtime commands rather than composing
+arbitrary shell commands in chat.
 
 ## Capability Rules
 

--- a/docs/skill-authoring.md
+++ b/docs/skill-authoring.md
@@ -89,6 +89,11 @@ installed before we add real Tinyhat platform capabilities.
 running. Use it for update tests so we do not confuse admin metadata with
 the live plugin code loaded in an agent session.
 
+`tinyhat-skill-catalog` lists the plugin-qualified skill names for Tinyhat
+skills. Use it when `skills_list`, `available_skills`, or unqualified
+`skill_view` cannot find a Tinyhat plugin skill. It should steer the agent
+to retry with names like `tinyhat:tinyhat-codex-auth`.
+
 `tinyhat-private-secret` is the default way to add credentials to Hermes.
 It should be triggered before generic `.env` advice whenever a user asks
 to add or save an API key, token, password, or credential.
@@ -103,6 +108,12 @@ skill should not send an extra text reply, duplicate links, or start the
 helper twice. It may use `{"action": "status"}`, `{"action": "log"}`, or
 `{"action": "limits"}` for follow-up inspection.
 
+`tinyhat-plugin-update` checks and applies the configured plugin channel
+through installed runtime commands. It should start with
+`{"action": "status"}` and require explicit user/operator confirmation
+before `{"action": "update", "confirmed": true, "restart_gateway": true}`.
+
 `tinyhat-platform` is the compact operating map for Tinyhat-managed
 Hermes agents. It explains secrets, Codex auth commands, usage limit
-commands, and the runtime/plugin/platform boundary.
+commands, skill discovery, plugin updates, reporting guidance, and the
+runtime/plugin/platform boundary.

--- a/hermes.plugin.json
+++ b/hermes.plugin.json
@@ -1,6 +1,6 @@
 {
   "schema": "tinyhat.framework-adapter.v1",
-  "version": "0.20.12",
+  "version": "0.20.13",
   "framework": {
     "name": "hermes",
     "minimum": "0.0.0"
@@ -13,26 +13,50 @@
   "skills": [
     {
       "name": "tinyhat-plugin-version",
+      "qualified_name": "tinyhat:tinyhat-plugin-version",
+      "aliases": ["tinyhat-plugin-version"],
       "path": "skills/tinyhat-plugin-version/SKILL.md",
       "purpose": "Reports the Tinyhat plugin version currently loaded by Hermes."
     },
     {
       "name": "tinyhat-tell-joke",
+      "qualified_name": "tinyhat:tinyhat-tell-joke",
+      "aliases": ["tinyhat-tell-joke"],
       "path": "skills/tinyhat-tell-joke/SKILL.md",
       "purpose": "Simple wiring proof that a Hermes agent can discover Tinyhat plugin skills."
     },
     {
+      "name": "tinyhat-skill-catalog",
+      "qualified_name": "tinyhat:tinyhat-skill-catalog",
+      "aliases": ["tinyhat-skill-catalog"],
+      "path": "skills/tinyhat-skill-catalog/SKILL.md",
+      "purpose": "Lists Tinyhat plugin skills with qualified names and unqualified aliases."
+    },
+    {
       "name": "tinyhat-private-secret",
+      "qualified_name": "tinyhat:tinyhat-private-secret",
+      "aliases": ["tinyhat-private-secret"],
       "path": "skills/tinyhat-private-secret/SKILL.md",
       "purpose": "Starts a private browser-encrypted secret handoff to the assigned Computer."
     },
     {
       "name": "tinyhat-codex-auth",
+      "qualified_name": "tinyhat:tinyhat-codex-auth",
+      "aliases": ["tinyhat-codex-auth"],
       "path": "skills/tinyhat-codex-auth/SKILL.md",
       "purpose": "Starts Tinyhat's OpenAI Codex / ChatGPT subscription auth flow."
     },
     {
+      "name": "tinyhat-plugin-update",
+      "qualified_name": "tinyhat:tinyhat-plugin-update",
+      "aliases": ["tinyhat-plugin-update"],
+      "path": "skills/tinyhat-plugin-update/SKILL.md",
+      "purpose": "Checks and applies Tinyhat plugin channel updates through the runtime."
+    },
+    {
       "name": "tinyhat-platform",
+      "qualified_name": "tinyhat:tinyhat-platform",
+      "aliases": ["tinyhat-platform"],
       "path": "skills/tinyhat-platform/SKILL.md",
       "purpose": "Explains Tinyhat-managed Hermes defaults for secrets, Codex auth, and platform boundaries."
     }
@@ -49,6 +73,11 @@
       "skill": "tinyhat-tell-joke"
     },
     {
+      "name": "tinyhat_skill_catalog",
+      "handler": "tools.skill_catalog",
+      "skill": "tinyhat-skill-catalog"
+    },
+    {
       "name": "tinyhat_private_secret_handoff",
       "handler": "tools.private_secret_handoff",
       "skill": "tinyhat-private-secret"
@@ -57,6 +86,11 @@
       "name": "tinyhat_codex_auth",
       "handler": "tools.codex_auth",
       "skill": "tinyhat-codex-auth"
+    },
+    {
+      "name": "tinyhat_plugin_update",
+      "handler": "tools.plugin_update",
+      "skill": "tinyhat-plugin-update"
     }
   ],
   "commands": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tinyhat",
-  "version": "0.20.12",
+  "version": "0.20.13",
   "description": "Hermes plugin that teaches agents how to use Tinyhat platform capabilities.",
   "private": true,
   "files": [

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -1,12 +1,14 @@
 name: tinyhat
-version: 0.20.12
+version: 0.20.13
 description: Framework-neutral Tinyhat platform skills and tools.
 kind: standalone
 author: Tinyloop
 provides_tools:
   - tinyhat_plugin_version
   - tinyhat_tell_joke
+  - tinyhat_skill_catalog
   - tinyhat_private_secret_handoff
   - tinyhat_codex_auth
+  - tinyhat_plugin_update
 provides_hooks:
   - pre_llm_call

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "tinyhat"
-version = "0.20.12"
+version = "0.20.13"
 description = "Hermes plugin that teaches agents how to use Tinyhat platform capabilities."
 readme = "README.md"
 requires-python = ">=3.9"

--- a/schemas.py
+++ b/schemas.py
@@ -14,6 +14,18 @@ TINYHAT_TELL_JOKE_SCHEMA = {
     "additionalProperties": False,
 }
 
+TINYHAT_SKILL_CATALOG_SCHEMA = {
+    "type": "object",
+    "description": (
+        "Lists Tinyhat plugin skills with their plugin-qualified names and "
+        "unqualified aliases. Use this when Hermes skill lookup/listing does "
+        "not show Tinyhat plugin skills clearly."
+    ),
+    "properties": {},
+    "required": [],
+    "additionalProperties": False,
+}
+
 TINYHAT_PRIVATE_SECRET_HANDOFF_SCHEMA = {
     "type": "object",
     "description": (
@@ -69,6 +81,43 @@ TINYHAT_CODEX_AUTH_SCHEMA = {
             "description": (
                 "Set true with action=start only after the user confirms the "
                 "ChatGPT Security toggle is on."
+            ),
+        },
+    },
+    "required": ["action"],
+    "additionalProperties": False,
+}
+
+TINYHAT_PLUGIN_UPDATE_SCHEMA = {
+    "type": "object",
+    "description": (
+        "Checks or applies the installed Tinyhat plugin update from the "
+        "configured channel, usually channels/lts. Use status first when the "
+        "agent may be running older plugin schemas."
+    ),
+    "properties": {
+        "action": {
+            "type": "string",
+            "enum": ["status", "update"],
+            "description": (
+                "Use status to compare the installed plugin with the target "
+                "channel. Use update only after the user/operator asks to "
+                "apply the plugin update."
+            ),
+        },
+        "confirmed": {
+            "type": "boolean",
+            "description": (
+                "Set true with action=update only after the user/operator "
+                "has asked to update the Tinyhat plugin on this Computer."
+            ),
+        },
+        "restart_gateway": {
+            "type": "boolean",
+            "description": (
+                "With action=update, set true when the Hermes Telegram "
+                "gateway should be stopped and started after a plugin change "
+                "so long-running commands/tools reload."
             ),
         },
     },

--- a/scripts/validate_framework_package.py
+++ b/scripts/validate_framework_package.py
@@ -13,8 +13,10 @@ VERSION_SHAPE = re.compile(r"^\d+\.\d+\.\d+$")
 REQUIRED_TOOLS = [
     "tinyhat_plugin_version",
     "tinyhat_tell_joke",
+    "tinyhat_skill_catalog",
     "tinyhat_private_secret_handoff",
     "tinyhat_codex_auth",
+    "tinyhat_plugin_update",
 ]
 REQUIRED_COMMANDS = [
     "tinyhat-joke",
@@ -24,8 +26,10 @@ REQUIRED_COMMANDS = [
 REQUIRED_SKILLS = [
     "tinyhat-plugin-version",
     "tinyhat-tell-joke",
+    "tinyhat-skill-catalog",
     "tinyhat-private-secret",
     "tinyhat-codex-auth",
+    "tinyhat-plugin-update",
     "tinyhat-platform",
 ]
 FORBIDDEN_PATHS = (
@@ -165,8 +169,10 @@ def validate_hermes_adapter(root: Path) -> None:
     expected_skill_paths = {
         "tinyhat-plugin-version": "skills/tinyhat-plugin-version/SKILL.md",
         "tinyhat-tell-joke": "skills/tinyhat-tell-joke/SKILL.md",
+        "tinyhat-skill-catalog": "skills/tinyhat-skill-catalog/SKILL.md",
         "tinyhat-private-secret": "skills/tinyhat-private-secret/SKILL.md",
         "tinyhat-codex-auth": "skills/tinyhat-codex-auth/SKILL.md",
+        "tinyhat-plugin-update": "skills/tinyhat-plugin-update/SKILL.md",
         "tinyhat-platform": "skills/tinyhat-platform/SKILL.md",
     }
     for skill in skills:
@@ -180,6 +186,13 @@ def validate_hermes_adapter(root: Path) -> None:
             (root / str(skill.get("path"))).is_file(),
             f"{name} proof skill missing",
         )
+        require(
+            skill.get("qualified_name") == f"tinyhat:{name}",
+            f"{name} qualified_name drift",
+        )
+        aliases = skill.get("aliases")
+        require(isinstance(aliases, list), f"{name} aliases must be a list")
+        require(name in aliases, f"{name} aliases must include the unqualified name")
 
     tools = hermes.get("tools")
     require(isinstance(tools, list), "hermes.plugin.json tools must be a list")
@@ -241,8 +254,10 @@ def validate_docs(root: Path) -> None:
             "Hermes only",
             "tinyhat-tell-joke",
             "tinyhat-plugin-version",
+            "tinyhat-skill-catalog",
             "tinyhat-private-secret",
             "tinyhat-codex-auth",
+            "tinyhat-plugin-update",
             "tinyhat-platform",
             "pre_llm_call",
             "channels/lts",
@@ -254,6 +269,18 @@ def validate_docs(root: Path) -> None:
             "Secret Naming Standard",
             "Tinyhat Platform Context",
             "tinyhat-codex-auth",
+            "tinyhat-skill-catalog",
+            "tinyhat-plugin-update",
+        ),
+        "skills/tinyhat-platform/SKILL.md": (
+            "tinyhat_skill_catalog",
+            "tinyhat_plugin_update",
+            "Reporting Tinyhat Bugs",
+        ),
+        "docs/capabilities.md": (
+            "tinyhat_skill_catalog",
+            "tinyhat_plugin_update",
+            "Plugin Update And Skill Discovery",
         ),
         "skills/tinyhat-codex-auth/SKILL.md": (
             "For common natural-language requests, call `tinyhat_codex_auth` once",

--- a/skills/tinyhat-platform/SKILL.md
+++ b/skills/tinyhat-platform/SKILL.md
@@ -16,6 +16,9 @@ Use this as the default routing map:
 | Add or save an API key, token, password, webhook secret, or credential | Call `tinyhat_private_secret_handoff` once. |
 | Ask which Tinyhat plugin is running | Call `tinyhat_plugin_version`. |
 | Check that the Tinyhat plugin exists | Call `tinyhat_tell_joke` or `tinyhat_plugin_version`. |
+| Find a Tinyhat plugin skill after `skills_list`, `available_skills`, or unqualified `skill_view` fails | Call `tinyhat_skill_catalog`; retry with the returned `tinyhat:<skill-name>` qualified name. |
+| Check whether this Computer is behind `channels/lts` or `channels/latest` | Call `tinyhat_plugin_update` with `{"action": "status"}`. |
+| Apply a plugin channel update the user/operator asked for | Call `tinyhat_plugin_update` with `{"action": "update", "confirmed": true, "restart_gateway": true}`. |
 | Connect ChatGPT / OpenAI Codex auth or use the user's OpenAI paid access | Load `tinyhat:tinyhat-codex-auth`; call `tinyhat_codex_auth` once with `{"action": "prerequisite"}` so it sends the screenshot and `/codex_auth`. Do not send an extra text reply. |
 | Check Codex auth | Call `tinyhat_codex_auth` with `{"action": "status"}`. |
 | Inspect recent Codex auth output | Call `tinyhat_codex_auth` with `{"action": "log"}`. |
@@ -70,6 +73,38 @@ recent auth output, and `{"action": "limits"}` if they ask about
 remaining limits. Only fall back to `/codex_auth_status`,
 `/codex_auth_log`, or `/codex_limits` when the tool is unavailable or
 reports that the runtime command could not be delivered.
+
+## Plugin Updates And Skill Discovery
+
+If the live plugin appears older than `channels/lts` or `channels/latest`,
+or a runtime status report says `update_available=true` or
+`decision=target_ref_changed`, start with:
+
+```json
+{"action": "status"}
+```
+
+for `tinyhat_plugin_update`. Apply the update only after the user or
+operator asks for it:
+
+```json
+{"action": "update", "confirmed": true, "restart_gateway": true}
+```
+
+This route uses the installed runtime's plugin status, update, stop, and
+start commands. Do not invent a shell command for plugin updates.
+
+If a Tinyhat skill lookup fails with an unqualified name, call
+`tinyhat_skill_catalog` and retry with the returned qualified name, for
+example `tinyhat:tinyhat-codex-auth`.
+
+## Reporting Tinyhat Bugs
+
+When asked to write or post a Tinyhat QA report that mentions words like
+restart, reload, gateway, or update, do not use an arbitrary terminal or
+curl command just to carry that text. Return the report in chat or use a
+native Slack/reporting tool when one is available. Terminal command guards
+can confuse report text with shell intent.
 
 ## Boundary
 

--- a/skills/tinyhat-plugin-update/SKILL.md
+++ b/skills/tinyhat-plugin-update/SKILL.md
@@ -1,0 +1,36 @@
+---
+name: tinyhat-plugin-update
+description: Check or apply Tinyhat plugin channel updates. Use when the live Tinyhat plugin is behind channels/lts or channels/latest, update_available is true, target_ref_changed is reported, or current tools/skills look stale.
+---
+
+# Tinyhat Plugin Update
+
+Use this when the current Hermes agent may be running an older Tinyhat
+plugin than the configured channel.
+
+Start with a read-only check:
+
+```json
+{"action": "status"}
+```
+
+This compares the installed Tinyhat plugin with the configured target
+channel, usually `channels/lts`. If `update_available` is true or the
+decision is `target_ref_changed`, the Computer is still running an older
+plugin checkout.
+
+Only apply the update when the user or operator asks you to update this
+Computer's plugin. Then call:
+
+```json
+{"action": "update", "confirmed": true, "restart_gateway": true}
+```
+
+The update path uses the installed Tinyhat runtime command
+`update_tinyhat_plugin`. With `restart_gateway=true`, it then uses the
+installed `stop_hermes` and `start_hermes` commands so the long-running
+Telegram gateway reloads plugin tools and commands.
+
+Do not use arbitrary shell commands to clone, edit, or install plugin
+files manually. Use the Tinyhat runtime update path so the installed
+source metadata and channel commit remain auditable.

--- a/skills/tinyhat-skill-catalog/SKILL.md
+++ b/skills/tinyhat-skill-catalog/SKILL.md
@@ -1,0 +1,21 @@
+---
+name: tinyhat-skill-catalog
+description: List Tinyhat plugin skills with qualified names. Use when skill lookup, skill_view, skills_list, or available_skills does not show Tinyhat plugin skills clearly.
+---
+
+# Tinyhat Skill Catalog
+
+Use this when Hermes skill discovery is confusing or incomplete.
+
+Call `tinyhat_skill_catalog`. The result lists each Tinyhat skill with:
+
+- `qualified_name`, for example `tinyhat:tinyhat-codex-auth`
+- unqualified `aliases`, for example `tinyhat-codex-auth`
+- the skill path and purpose
+
+Prefer the qualified name when loading a Tinyhat skill. If
+`skill_view(name="tinyhat-codex-auth")` fails, retry with
+`skill_view(name="tinyhat:tinyhat-codex-auth")`.
+
+Do not guess at hidden skill names from an error message. Use the catalog
+tool, then load the matching qualified skill.

--- a/test/test_hermes_adapter.py
+++ b/test/test_hermes_adapter.py
@@ -63,21 +63,27 @@ class HermesAdapterTests(unittest.TestCase):
 
         self.assertIn("tinyhat_plugin_version", ctx.tools)
         self.assertIn("tinyhat_tell_joke", ctx.tools)
+        self.assertIn("tinyhat_skill_catalog", ctx.tools)
         self.assertIn("tinyhat_private_secret_handoff", ctx.tools)
         self.assertIn("tinyhat_codex_auth", ctx.tools)
+        self.assertIn("tinyhat_plugin_update", ctx.tools)
         self.assertIn("tinyhat-plugin-version", ctx.commands)
         self.assertIn("tinyhat-joke", ctx.commands)
         self.assertIn("tinyhat-secret", ctx.commands)
         self.assertIn("pre_llm_call", ctx.hooks)
         self.assertIn("tinyhat-plugin-version", ctx.skills)
         self.assertIn("tinyhat-tell-joke", ctx.skills)
+        self.assertIn("tinyhat-skill-catalog", ctx.skills)
         self.assertIn("tinyhat-private-secret", ctx.skills)
         self.assertIn("tinyhat-codex-auth", ctx.skills)
+        self.assertIn("tinyhat-plugin-update", ctx.skills)
         self.assertIn("tinyhat-platform", ctx.skills)
         self.assertTrue(ctx.skills["tinyhat-plugin-version"].is_file())
         self.assertTrue(ctx.skills["tinyhat-tell-joke"].is_file())
+        self.assertTrue(ctx.skills["tinyhat-skill-catalog"].is_file())
         self.assertTrue(ctx.skills["tinyhat-private-secret"].is_file())
         self.assertTrue(ctx.skills["tinyhat-codex-auth"].is_file())
+        self.assertTrue(ctx.skills["tinyhat-plugin-update"].is_file())
         self.assertTrue(ctx.skills["tinyhat-platform"].is_file())
 
     def test_registered_commands_match_telegram_dispatch_names(self) -> None:
@@ -98,6 +104,8 @@ class HermesAdapterTests(unittest.TestCase):
         self.assertEqual(schemas.TINYHAT_PLUGIN_VERSION_SCHEMA["required"], [])
         self.assertEqual(schemas.TINYHAT_TELL_JOKE_SCHEMA["properties"], {})
         self.assertEqual(schemas.TINYHAT_TELL_JOKE_SCHEMA["required"], [])
+        self.assertEqual(schemas.TINYHAT_SKILL_CATALOG_SCHEMA["properties"], {})
+        self.assertEqual(schemas.TINYHAT_SKILL_CATALOG_SCHEMA["required"], [])
 
         secret_schema = schemas.TINYHAT_PRIVATE_SECRET_HANDOFF_SCHEMA
         self.assertEqual(secret_schema["required"], ["name", "description"])
@@ -120,12 +128,37 @@ class HermesAdapterTests(unittest.TestCase):
         self.assertNotIn("env_var", secret_schema["properties"])
         self.assertNotIn("key_name", secret_schema["properties"])
 
+        update_schema = schemas.TINYHAT_PLUGIN_UPDATE_SCHEMA
+        self.assertEqual(update_schema["required"], ["action"])
+        self.assertFalse(update_schema["additionalProperties"])
+        self.assertEqual(update_schema["properties"]["action"]["enum"], ["status", "update"])
+        self.assertIn("confirmed", update_schema["properties"])
+        self.assertIn("restart_gateway", update_schema["properties"])
+
     def test_plugin_version_returns_live_manifest_version(self) -> None:
         payload = json.loads(tools.plugin_version())
 
         self.assertEqual(payload["schema"], "tinyhat_plugin_version_v1")
         self.assertEqual(payload["name"], "tinyhat")
-        self.assertEqual(payload["version"], "0.20.12")
+        self.assertEqual(payload["version"], "0.20.13")
+
+    def test_skill_catalog_lists_qualified_names_and_aliases(self) -> None:
+        payload = json.loads(tools.skill_catalog())
+
+        self.assertEqual(payload["schema"], "tinyhat_skill_catalog_v1")
+        self.assertEqual(payload["plugin"]["name"], "tinyhat")
+        self.assertEqual(payload["plugin"]["version"], "0.20.13")
+        by_name = {skill["name"]: skill for skill in payload["skills"]}
+        self.assertEqual(
+            by_name["tinyhat-codex-auth"]["qualified_name"],
+            "tinyhat:tinyhat-codex-auth",
+        )
+        self.assertIn("tinyhat-codex-auth", by_name["tinyhat-codex-auth"]["aliases"])
+        self.assertEqual(
+            by_name["tinyhat-plugin-update"]["qualified_name"],
+            "tinyhat:tinyhat-plugin-update",
+        )
+        self.assertIn("qualified names", payload["lookup_rule"])
 
     def test_context_hook_injects_for_secret_requests(self) -> None:
         ctx = FakeHermesContext()
@@ -175,6 +208,39 @@ class HermesAdapterTests(unittest.TestCase):
         assert injected is not None
         self.assertIn("tinyhat_codex_auth", injected["context"])
         self.assertIn("/codex_auth", injected["context"])
+
+    def test_context_hook_injects_for_plugin_update_requests(self) -> None:
+        injected = tinyhat_context.inject_tinyhat_context(
+            user_message="Plugin update check says target_ref_changed",
+            is_first_turn=False,
+        )
+
+        self.assertIsNotNone(injected)
+        assert injected is not None
+        self.assertIn("tinyhat_plugin_update", injected["context"])
+        self.assertIn("action=status", injected["context"])
+        self.assertIn("restart_gateway=true", injected["context"])
+
+    def test_context_hook_injects_for_skill_lookup_failures(self) -> None:
+        injected = tinyhat_context.inject_tinyhat_context(
+            user_message='skill_view(name="tinyhat-codex-auth") failed',
+            is_first_turn=False,
+        )
+
+        self.assertIsNotNone(injected)
+        assert injected is not None
+        self.assertIn("tinyhat_skill_catalog", injected["context"])
+        self.assertIn("tinyhat:tinyhat-codex-auth", injected["context"])
+
+    def test_context_hook_injects_for_tinyhat_qa_reports(self) -> None:
+        injected = tinyhat_context.inject_tinyhat_context(
+            user_message="Post this Slack report about a gateway restart bug",
+            is_first_turn=False,
+        )
+
+        self.assertIsNotNone(injected)
+        assert injected is not None
+        self.assertIn("do not use terminal/curl just to post the text", injected["context"])
 
     def test_codex_auth_skill_packages_prerequisite_screenshot(self) -> None:
         skill_md = REPO_ROOT / "skills" / "tinyhat-codex-auth" / "SKILL.md"
@@ -349,6 +415,118 @@ class HermesAdapterTests(unittest.TestCase):
         self.assertIn("telegram_codex_auth status", calls[0])
         self.assertIn("telegram_codex_auth log", calls[1])
         self.assertIn("codex_limits telegram", calls[2])
+
+    def test_plugin_update_missing_action_error_is_actionable(self) -> None:
+        payload = json.loads(tools.plugin_update({}))
+
+        self.assertEqual(payload["schema"], "tinyhat_tool_error_v1")
+        self.assertEqual(payload["tool"], "tinyhat_plugin_update")
+        self.assertEqual(payload["status"], "error")
+        self.assertEqual(payload["error"], "missing_required_parameter")
+        self.assertEqual(payload["missing"], ["action"])
+        self.assertEqual(payload["example_call"], {"action": "status"})
+
+    def test_plugin_update_status_uses_runtime_status_command(self) -> None:
+        original_run = tools._run_runtime_json_command
+        calls: list[str] = []
+        try:
+            tools._run_runtime_json_command = lambda kind, **_: calls.append(kind) or {
+                "ok": True,
+                "command": kind,
+                "result": {"update_available": True, "decision": "target_ref_changed"},
+                "process": {"ok": True},
+                "parse_error": None,
+            }
+
+            payload = json.loads(tools.plugin_update({"action": "status"}))
+        finally:
+            tools._run_runtime_json_command = original_run
+
+        self.assertEqual(calls, ["tinyhat_plugin_status"])
+        self.assertEqual(payload["schema"], "tinyhat_plugin_update_action_v1")
+        self.assertEqual(payload["action"], "status")
+        self.assertEqual(payload["status"], "ok")
+        self.assertIn("update_available", payload["result"]["result"])
+        self.assertIn("action=update", payload["next_action"])
+
+    def test_plugin_update_requires_confirmation_before_apply(self) -> None:
+        original_run = tools._run_runtime_json_command
+        calls: list[str] = []
+        try:
+            tools._run_runtime_json_command = lambda kind, **_: calls.append(kind) or {
+                "ok": True,
+                "command": kind,
+                "result": {},
+                "process": {"ok": True},
+                "parse_error": None,
+            }
+
+            payload = json.loads(tools.plugin_update({"action": "update"}))
+        finally:
+            tools._run_runtime_json_command = original_run
+
+        self.assertEqual(payload["schema"], "tinyhat_tool_error_v1")
+        self.assertEqual(payload["error"], "confirmation_required")
+        self.assertEqual(calls, [])
+
+    def test_plugin_update_can_apply_and_restart_gateway(self) -> None:
+        original_run = tools._run_runtime_json_command
+        calls: list[str] = []
+        try:
+            tools._run_runtime_json_command = lambda kind, **_: calls.append(kind) or {
+                "ok": True,
+                "command": kind,
+                "result": {"kind": kind, "healthy": True},
+                "process": {"ok": True},
+                "parse_error": None,
+            }
+
+            payload = json.loads(
+                tools.plugin_update(
+                    {
+                        "action": "update",
+                        "confirmed": True,
+                        "restart_gateway": True,
+                    }
+                )
+            )
+        finally:
+            tools._run_runtime_json_command = original_run
+
+        self.assertEqual(calls, ["update_tinyhat_plugin", "stop_hermes", "start_hermes"])
+        self.assertEqual(payload["schema"], "tinyhat_plugin_update_action_v1")
+        self.assertEqual(payload["status"], "ok")
+        self.assertTrue(payload["restart_gateway"]["requested"])
+
+    def test_plugin_update_fails_if_gateway_stop_fails(self) -> None:
+        original_run = tools._run_runtime_json_command
+        results = {
+            "update_tinyhat_plugin": {"ok": True},
+            "stop_hermes": {"ok": False},
+            "start_hermes": {"ok": True},
+        }
+        try:
+            tools._run_runtime_json_command = lambda kind, **_: {
+                "ok": results[kind]["ok"],
+                "command": kind,
+                "result": {},
+                "process": {"ok": results[kind]["ok"]},
+                "parse_error": None,
+            }
+
+            payload = json.loads(
+                tools.plugin_update(
+                    {
+                        "action": "update",
+                        "confirmed": True,
+                        "restart_gateway": True,
+                    }
+                )
+            )
+        finally:
+            tools._run_runtime_json_command = original_run
+
+        self.assertEqual(payload["status"], "failed")
 
     def test_context_hook_injects_for_env_style_secret_names(self) -> None:
         for secret_name in (

--- a/tools.py
+++ b/tools.py
@@ -31,13 +31,19 @@ TELEGRAM_ENV_CANDIDATES = (
     Path("/usr/local/lib/hermes-agent/.env"),
 )
 CODEX_AUTH_ACTIONS = ("prerequisite", "start", "status", "log", "limits")
+PLUGIN_UPDATE_ACTIONS = ("status", "update")
 RUNTIME_OUTPUT_LIMIT = 1200
+RUNTIME_JSON_OUTPUT_LIMIT = 12000
+
+
+def _plugin_manifest() -> dict[str, Any]:
+    manifest_path = Path(__file__).resolve().parent / "hermes.plugin.json"
+    return json.loads(manifest_path.read_text(encoding="utf-8"))
 
 
 def plugin_version_payload() -> dict[str, str]:
     """Return the version of the Tinyhat plugin code currently loaded."""
-    manifest_path = Path(__file__).resolve().parent / "hermes.plugin.json"
-    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    manifest = _plugin_manifest()
     version = str(manifest.get("version") or "unknown").strip() or "unknown"
     return {
         "schema": "tinyhat_plugin_version_v1",
@@ -50,6 +56,51 @@ def plugin_version(args: dict[str, Any] | None = None, **_: Any) -> str:
     """Hermes tool handler for reporting the loaded Tinyhat plugin version."""
     _ = args
     return json.dumps(plugin_version_payload(), sort_keys=True)
+
+
+def skill_catalog_payload() -> dict[str, Any]:
+    """Return Tinyhat plugin skill names in qualified and alias forms."""
+    manifest = _plugin_manifest()
+    version = str(manifest.get("version") or "unknown").strip() or "unknown"
+    skills: list[dict[str, Any]] = []
+    for entry in manifest.get("skills") or []:
+        if not isinstance(entry, dict):
+            continue
+        raw_name = str(entry.get("name") or "").strip()
+        if not raw_name:
+            continue
+        qualified_name = str(entry.get("qualified_name") or f"tinyhat:{raw_name}")
+        aliases = entry.get("aliases")
+        if not isinstance(aliases, list):
+            aliases = [raw_name]
+        alias_names = [str(alias).strip() for alias in aliases if str(alias).strip()]
+        if raw_name not in alias_names:
+            alias_names.insert(0, raw_name)
+        skills.append(
+            {
+                "name": raw_name,
+                "qualified_name": qualified_name,
+                "aliases": alias_names,
+                "path": entry.get("path"),
+                "purpose": entry.get("purpose"),
+            }
+        )
+    return {
+        "schema": "tinyhat_skill_catalog_v1",
+        "plugin": {"name": "tinyhat", "version": version},
+        "skills": skills,
+        "lookup_rule": (
+            "Prefer qualified names like tinyhat:tinyhat-codex-auth. If an "
+            "unqualified skill_view lookup fails, retry the matching "
+            "qualified_name from this catalog."
+        ),
+    }
+
+
+def skill_catalog(args: dict[str, Any] | None = None, **_: Any) -> str:
+    """Hermes tool handler for reporting Tinyhat skill discovery metadata."""
+    _ = args
+    return json.dumps(skill_catalog_payload(), sort_keys=True)
 
 
 def joke_text(topic: str | None = None) -> str:
@@ -162,6 +213,97 @@ def codex_auth(args: dict[str, Any] | None = None, **_: Any) -> str:
         sort_keys=True,
     )
 
+
+def plugin_update(args: dict[str, Any] | None = None, **_: Any) -> str:
+    """Check or apply the Tinyhat plugin update through runtime commands."""
+    payload = args if isinstance(args, dict) else {}
+    raw_action = payload.get("action")
+    if not isinstance(raw_action, str) or not raw_action.strip():
+        return tool_error_json(
+            tool="tinyhat_plugin_update",
+            error_name="missing_required_parameter",
+            message="Call tinyhat_plugin_update with action='status' or action='update'.",
+            missing=["action"],
+            example_call={"action": "status"},
+        )
+
+    action = raw_action.strip().lower()
+    if action not in PLUGIN_UPDATE_ACTIONS:
+        return tool_error_json(
+            tool="tinyhat_plugin_update",
+            error_name="invalid_parameter",
+            message=(
+                "Unsupported tinyhat_plugin_update action. Use one of: "
+                + ", ".join(PLUGIN_UPDATE_ACTIONS)
+                + "."
+            ),
+            expected={"action": list(PLUGIN_UPDATE_ACTIONS)},
+            example_call={"action": "status"},
+        )
+
+    if action == "status":
+        result = _run_runtime_json_command("tinyhat_plugin_status")
+        return json.dumps(
+            {
+                "schema": "tinyhat_plugin_update_action_v1",
+                "action": "status",
+                "status": "ok" if result["ok"] else "failed",
+                "result": result,
+                "next_action": (
+                    "If update_available is true and the user/operator wants "
+                    "the current channel applied, call tinyhat_plugin_update "
+                    "with action=update, confirmed=true, and restart_gateway=true."
+                ),
+            },
+            sort_keys=True,
+        )
+
+    if payload.get("confirmed") is not True:
+        return tool_error_json(
+            tool="tinyhat_plugin_update",
+            error_name="confirmation_required",
+            message=(
+                "Do not update the Tinyhat plugin yet. Ask the user/operator "
+                "to confirm applying the configured plugin channel to this Computer."
+            ),
+            example_call={
+                "action": "update",
+                "confirmed": True,
+                "restart_gateway": True,
+            },
+        )
+
+    update = _run_runtime_json_command("update_tinyhat_plugin", timeout_seconds=360)
+    restart: dict[str, Any] = {"requested": False}
+    if payload.get("restart_gateway") is True:
+        restart = {
+            "requested": True,
+            "stop": _run_runtime_json_command("stop_hermes", timeout_seconds=120),
+            "start": _run_runtime_json_command("start_hermes", timeout_seconds=240),
+        }
+    return json.dumps(
+        {
+            "schema": "tinyhat_plugin_update_action_v1",
+            "action": "update",
+            "status": "ok"
+            if update["ok"]
+            and (
+                not restart["requested"]
+                or (restart["stop"]["ok"] and restart["start"]["ok"])
+            )
+            else "failed",
+            "update": update,
+            "restart_gateway": restart,
+            "message": (
+                "Tinyhat plugin update path ran through the installed runtime. "
+                "If restart_gateway was true, the Hermes gateway stop/start "
+                "path was used so long-running agent commands can reload."
+            ),
+        },
+        sort_keys=True,
+    )
+
+
 def _send_codex_prerequisite() -> dict[str, Any]:
     """Deliver the prerequisite image through Telegram when possible."""
     try:
@@ -234,7 +376,52 @@ def _codex_auth_runtime_action(action: str) -> str:
     )
 
 
-def _run_runtime_command(script: str, *, timeout_seconds: int = 15) -> dict[str, Any]:
+def _run_runtime_json_command(kind: str, *, timeout_seconds: int = 60) -> dict[str, Any]:
+    command_json = json.dumps({"kind": kind, "spec": {}})
+    script = (
+        'PYTHONPATH="${TINYHAT_RUNTIME_PREFIX:-/opt/tinyhat-hermes-runtime}:'
+        '${PYTHONPATH:-}" python3 - <<\'PY\'\n'
+        "import asyncio\n"
+        "import json\n"
+        "from types import SimpleNamespace\n"
+        "from hermes_runtime.commands import run_command\n\n"
+        "async def main():\n"
+        f"    command = json.loads({command_json!r})\n"
+        "    result = await run_command(SimpleNamespace(), command)\n"
+        "    print(json.dumps(result, sort_keys=True))\n\n"
+        "asyncio.run(main())\n"
+        "PY"
+    )
+    process = _run_runtime_command(
+        script,
+        timeout_seconds=timeout_seconds,
+        output_limit=RUNTIME_JSON_OUTPUT_LIMIT,
+    )
+    parsed: Any = None
+    parse_error: str | None = None
+    if process["ok"]:
+        try:
+            parsed = json.loads(process.get("stdout") or "{}")
+        except json.JSONDecodeError as exc:
+            parse_error = str(exc)
+    compact_process = dict(process)
+    if parsed is not None:
+        compact_process["stdout"] = ""
+    return {
+        "ok": bool(process["ok"] and parsed is not None),
+        "command": kind,
+        "result": parsed,
+        "process": compact_process,
+        "parse_error": parse_error,
+    }
+
+
+def _run_runtime_command(
+    script: str,
+    *,
+    timeout_seconds: int = 15,
+    output_limit: int = RUNTIME_OUTPUT_LIMIT,
+) -> dict[str, Any]:
     try:
         completed = subprocess.run(
             ["bash", "-lc", script],
@@ -250,8 +437,8 @@ def _run_runtime_command(script: str, *, timeout_seconds: int = 15) -> dict[str,
     return {
         "ok": completed.returncode == 0,
         "returncode": completed.returncode,
-        "stdout": stdout[-RUNTIME_OUTPUT_LIMIT:],
-        "stderr": stderr[-RUNTIME_OUTPUT_LIMIT:],
+        "stdout": stdout[-output_limit:],
+        "stderr": stderr[-output_limit:],
     }
 
 


### PR DESCRIPTION
## TL;DR for the reviewer

This bumps the Hermes Tinyhat plugin to `0.20.13` and adds two agent repair paths: `tinyhat_skill_catalog` for plugin-qualified skill discovery, and `tinyhat_plugin_update` for checking/applying stale installed plugin channels through the runtime.

## Reviewer context

A live QA report found three agent-facing gaps after the plugin channel moved:

- A Computer could keep running an older installed plugin checkout even after `channels/lts` advanced, leaving stale tool schemas active.
- Hermes skill lookup could fail for unqualified Tinyhat skill names unless the agent already knew to use `tinyhat:<skill-name>`.
- Bug-report text containing words like restart/reload/gateway could trip command guards when the agent tried to post the report through a generic terminal command.

## Scope

- Adds `tinyhat_skill_catalog`, including manifest metadata for qualified skill names and aliases.
- Adds `tinyhat_plugin_update`, with read-only `status` first and confirmation-gated `update` that can restart the Hermes gateway through installed runtime commands.
- Updates `tinyhat-platform` context so agents route stale-plugin, skill-lookup, and QA-report cases to the intended tool/reporting paths.
- Bumps plugin package manifests to `0.20.13` and updates README/capabilities/authoring docs.
- Expands package validation and unit coverage for the new tools, schemas, context triggers, and manifest shape.

## Non-scope

- Does not move `channels/lts` or `channels/latest`; those should advance only after this PR merges.
- Does not change the host runtime implementations of `tinyhat_plugin_status`, `update_tinyhat_plugin`, `stop_hermes`, or `start_hermes`; the plugin delegates to the installed runtime command runner.
- Does not change the terminal command guard itself. This PR gives the agent a safer routing rule for QA/report text.
- Does not target `main`; base is `codex/v0.20-hermes-plugin`.

## How to test

```bash
python3 scripts/validate_framework_package.py
python3 -m unittest discover -s test -p "*.py"
python3 -m compileall -q .
git diff --check
```

Before this PR, agents had no plugin-provided catalog for qualified Tinyhat skill names and no schema-backed plugin update tool. After this PR, `tinyhat_skill_catalog` returns `tinyhat:<skill>` names and aliases, while `tinyhat_plugin_update` exposes `status` and confirmation-gated `update` actions.

## Verification

```text
$ python3 scripts/validate_framework_package.py
framework-package: ok (version 0.20.13)

$ python3 -m unittest discover -s test -p "*.py"
.................................................
----------------------------------------------------------------------
Ran 49 tests in 0.562s

OK

$ python3 -m compileall -q .
# passed

$ git diff --check
# passed
```

Public runtime/plugin critical-path verification:

- Local Hermes Computer `5333` was assigned to the Forecaster test agent (`@tinyhatdevtest_4_bot`) and tested against this PR head, `b7ac1523f97e15321bd368313d538b10f45bacd5`.
- The agent used `tinyhat_plugin_version`, `tinyhat_plugin_update`, `tinyhat_skill_catalog`, and `tinyhat_private_secret_handoff` successfully.
- Runtime plugin status settled with installed/target version `0.20.13`, installed/target commit `b7ac1523f97e15321bd368313d538b10f45bacd5`, `update_available=false`, and `decision=installed_matches_target`.
- A disposable private secret handoff was submitted and claimed; only the secret name was verified in runtime env, not the value.
- The companion platform rollout-path PR tinyloophub/tinyloop#941 verifies that admin/plugin status commands can carry this plugin repo/ref from the Computer manifest into the runtime command spec.

## Data model changes

No schema changes.

## Implementation summary

- `tools.py` now reads manifest skill metadata for catalog output and shells through the installed runtime command runner for JSON command execution.
- `schemas.py`, `plugin.yaml`, and `hermes.plugin.json` expose the new tool contracts and plugin-qualified skill metadata.
- `context.py` and `skills/tinyhat-platform/SKILL.md` steer agents toward the catalog/update/reporting paths when the live environment looks stale or incomplete.
